### PR TITLE
[WIP] Open Source QEMU 

### DIFF
--- a/third-party/fedora31/kernel/BUCK
+++ b/third-party/fedora31/kernel/BUCK
@@ -1,3 +1,7 @@
+load("//fs_image/vm:vm.bzl", "kernel_vm")
+load("//fs_image/vm:initrd.bzl", "initrd")
+load(":kernels.bzl", "kernels")
+
 remote_file(
     name = "5.3.7-301.fc31.x86_64-core.rpm",
     url = "http://mirrors.kernel.org/fedora/releases/31/Everything/x86_64/os/Packages/k/kernel-core-5.3.7-301.fc31.x86_64.rpm",
@@ -46,4 +50,14 @@ genrule(
         mkdir -p $OUT
         cp -R "$(location :5.3.7-301.fc31.x86_64-rpm-exploded)/lib/modules/5.3.7-301.fc31.x86_64/kernel" "$OUT"
     """
+)
+
+kernel_vm(
+    name = "5.3.7-301.fc31.x86_64-vm",
+    kernel = kernels["5.3.7-301.fc31.x86_64"],
+)
+
+initrd(
+    name = "5.3.7-301.fc31.x86_64-initrd",
+    modules = ":5.3.7-301.fc31.x86_64-modules",
 )

--- a/third-party/fedora31/kernel/kernels.bzl
+++ b/third-party/fedora31/kernel/kernels.bzl
@@ -5,5 +5,7 @@ kernels = {
         modules = "//third-party/fedora31/kernel:5.3.7-301.fc31.x86_64-modules",
         headers = "//third-party/fedora31/kernel:5.3.6-300.fc31.x86_64-headers.rpm",
         devel = "//third-party/fedora31/kernel:5.3.7-301.fc31.x86_64-devel.rpm",
+	initrd = "//third-party/fedora31/kernel:5.3.7-301.fc31.x86_64-initrd",
+	vm = "//third-party/fedora31/kernel:5.3.7-301.fc31.x86_64-vm",
     ),
 }

--- a/third-party/fedora31/qemu/BUCK
+++ b/third-party/fedora31/qemu/BUCK
@@ -1,0 +1,11 @@
+# fs_image uses qemu system emulation in order to run vm tests
+# users are expected to have `qemu-system-x86_64` installed and on `PATH` 
+sh_binary(
+    name = "qemu-binary",
+    main = "qemu-binary.sh",
+)
+
+export_file(
+    name = "qemu",
+    src = ":qemu-binary",
+)

--- a/third-party/fedora31/qemu/qemu-binary.sh
+++ b/third-party/fedora31/qemu/qemu-binary.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+$(which qemu-system-x86_64)


### PR DESCRIPTION
### Goal
Internally, Facebook has a version of qemu at `//third-party-buck/platform007/build/qemu` which is the target we use for QEMU in our vmtest system. We want the equivalent of this in OSS. 

Unfortunately, simply downloading the [qemu rpm](https://fedora.pkgs.org/31/fedora-x86_64/qemu-system-x86-core-4.1.0-2.fc31.x86_64.rpm.html) and extracting it seems to only work, out of the box, on `fedora31` systems. In order to make it easier for ourselves, we will just have `qemu-system-x86_64` as a required binary (i.e. users should have it on their systems already and on their PATH).

### Changes
- Added targets for the `initrd` and `vm` module into `third-party/fedora31/kernel/BUCK`
- Added targets for `qemu` to `third-party/fedora31/qemu/BUCK`. It is essentially a `sh` script that runs the `qemu-system_x86_64` on PATH.

### What Needs to Be Done
- Add visibilities to all `export_file` targets. I realized that by default, the visibility of these `export_file` rules is `[]` and we need to make them visible so that our vmtest components can use them.
- Test whether or not the `qemu` target in `third-party/fedora31/qemu/BUCK` works. I'm not entirely convinced this works yet and I have not yet tested it. The contents of the shell script might just be 
```
#!/bin/sh
which qemu-system-x86_64
```