### PR TITLE
Re-sync with internal repository

### DIFF
--- a/fs_image/bzl/oss_shim.bzl
+++ b/fs_image/bzl/oss_shim.bzl
@@ -97,3 +97,4 @@ get_visibility = shim.get_visibility
 kernel_artifact = shim.kernel_artifact
 target_utils = shim.target_utils
 third_party = shim.third_party
+rpm_vset = shim.rpm_vset

--- a/fs_image/bzl/oss_shim_impl.bzl
+++ b/fs_image/bzl/oss_shim_impl.bzl
@@ -243,7 +243,7 @@ def rpm_vset(name, src = "empty=rpm=vset"):
         mode = "reference",
         # `image.layer`s all over the repo will depend on these
         visibility = ["PUBLIC"],
-   )
+     )
 
 shim = struct(
     buck_command_alias = command_alias,


### PR DESCRIPTION
The internal and external repositories are out of sync. This attempts to brings them back in sync by patching the GitHub repository. Please carefully review this patch. You must disable ShipIt for your project in order to merge this pull request. DO NOT IMPORT this pull request. Instead, merge it directly on GitHub using the MERGE BUTTON. Re-enable ShipIt after merging.