### PR TITLE
Re-sync with internal repository

### DIFF
--- a/antlir/bzl/README.facebook
+++ b/antlir/bzl/README.facebook
@@ -1,8 +1,0 @@
-The above directory contains open source specific implementations of some
-core antlir functionality.
-
-Mainly, this exists to play nicely with fbcode Buck macros inside FB, and
-public Buck macros on GitHub.
-
-All the files in the above directory will be remapped into `antlir/bzl`,
-overwriting any files of the same name.


### PR DESCRIPTION
The internal and external repositories are out of sync. This attempts to brings them back in sync by patching the GitHub repository. Please carefully review this patch. You must disable ShipIt for your project in order to merge this pull request. DO NOT IMPORT this pull request. Instead, merge it directly on GitHub using the MERGE BUTTON. Re-enable ShipIt after merging.