### PR TITLE
Re-sync with internal repository

### DIFF
--- a/antlir/bzl/oss_shim_impl.bzl
+++ b/antlir/bzl/oss_shim_impl.bzl
@@ -1,61 +1,30 @@
-#
-# IMPORTANT: You **MUST** wrap with `_wrap_internal()` any rules / macros
-# exported from this file (any functions that define new targets).  Per the
-# D23464472 description, consistently using `_wrap_internal()` creates a
-# rule ecosystem where we are forced to consistently label targets as
-# "internal" vs "external".  Read that diff for the full context.
-#
-# Please **ALSO** call `_assert_package()` from any function that a
-# non-Antlir developer might accidentally call if their editor auto-imports
-# `oss_shim.bzl`.
-#
-# If you came here to understand the `antlir_rule` kwarg, please read the
-# docblocks for `_wrap_internal` and `_assert_package`.
-#
-load("@fbcode_macros//build_defs:config.bzl", "config")
-load("@fbcode_macros//build_defs:cpp_unittest.bzl", "cpp_unittest")
-load("@fbcode_macros//build_defs:custom_rule.bzl", "get_project_root_from_gen_dir")
-load("@fbcode_macros//build_defs:export_files.bzl", "export_file")
-load("@fbcode_macros//build_defs:native_rules.bzl", "buck_command_alias", "buck_filegroup", "buck_genrule", "buck_sh_binary", "buck_sh_test")
-load("@fbcode_macros//build_defs:platform_utils.bzl", "platform_utils")
-load("@fbcode_macros//build_defs:python_binary.bzl", "python_binary")
-load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
-load("@fbcode_macros//build_defs:python_unittest.bzl", "python_unittest")
-load("@fbcode_macros//build_defs/lib:target_utils.bzl", "target_utils")
-load("@fbcode_macros//build_defs/lib:third_party.bzl", "third_party")
-load("@fbcode_macros//build_defs/lib:visibility.bzl", "get_visibility")
+load("@bazel_skylib//lib:types.bzl", "types")
+load("//third-party/fedora31/kernel:kernels.bzl", "kernels")
 
-# We have tens of thousands of `empty_rpm` targets, so eliminating the
-# indirection of `buck_export_file` seems worthwhile.
-#
-# @lint-ignore-every BUCKFBCODENATIVE
-load("@fbsource//tools/build_defs:fb_native_wrapper.bzl", "fb_native")
-load("//kernel/kernels:kernels.bzl", "kernels")
-
-# IMPORTANT: These _RULE constants are cloned to `oss_shim_impl.bzl.oss`
 _RULE_TYPE_KWARG = "antlir_rule"
+
 _RULE_PRIVATE = "antlir-private"
+
 _RULE_USER_FACING = "user-facing"
+
 _RULE_USER_INTERNAL = "user-internal"
-_ALLOWED_RULES = [_RULE_PRIVATE, _RULE_USER_FACING, _RULE_USER_INTERNAL]
 
-# CRUCIAL: Do NOT change this constant.  It is used inside the sitevar
-# `SV_SANDCASTLE_RDEPS_COST_ADJUSTMENT` to ensure that fbcode TD triggers
-# enough tests for source changes that affect image tests & artifacts.
-# See also: https://fburl.com/antlir_rule_usage
-_INTERNAL_RULE_LABEL = "antlir__internal"  # maps to "user-internal" above
+_ALLOWED_RULES = [
+    _RULE_PRIVATE,
+    _RULE_USER_FACING,
+    _RULE_USER_INTERNAL,
+]
 
-_default_vm_layer = "//tupperware/image/vmtest:base"
-_default_vm_package = "//tupperware/image/vmtest:base.btrfs"
+# The default native platform to use for shared libraries and static binary
+# dependencies.  Right now this tooling only supports one platform and so
+# this is not a method, but in the future as we support other native platforms
+# (like Debian, Arch Linux, etc..) this should be expanded to allow for those.
+_DEFAULT_NATIVE_PLATFORM = "fedora31"
 
-# The primary purpose of this assertion is to ensure that Antlir devs
-# annotate all targets that need to be hidden from fbcode target
-# determinator's distance-4 heuristic, see `_wrap_internal()` below.
-#
-# An important side effect is that this prevents the usage of `oss_shim.bzl`
-# from outside of the Antlir project.  This became necessary because some
-# automation (VSCode?) kept inserting bad `load` statements.  Context:
-# https://fb.prod.workplace.com/groups/btrmeup/permalink/3304265952986381/
+# Serves two important purposes:
+#  - Ensures that all user-instanted rules are annotated with
+#    `antlir_rule = "user-{facing,internal}", which is important for FB CI.
+#  - Discourages users from loading rules or functions from `oss_shim.bzl`.
 def _assert_package():
     package = native.package_name()
     if package == "antlir/compiler/test_images":
@@ -66,80 +35,144 @@ def _assert_package():
             "build file -- instead add and use a shim inside of " +
             "`antlir/compiler/test_images/defs.bzl`. You may also get this " +
             "error if you are adding a new user-instantiatable rule to the " +
-            "Antlir API. If so, read https://fburl.com/antlir_rule_usage. ",
+            "Antlir API. If so, read the `antlir_rule` section in " +
+            "`website/docs/coding-conventions/bzl-and-targets.md`",
         )
     if package != "antlir" and not package.startswith("antlir/"):
         fail(
-            "Package `" + package + "` must not " +
-            '`load("//antlir/bzl:oss_shim.bzl")` -- did you mean to `load(' +
-            '"@fbcode_macros//build_defs:RULE_NAME.bzl")` instead? Did ' +
-            "your editor insert this for you? If you are using VSCode, " +
-            "report the issue here: https://fburl.com/no_oss_shim_load " +
-            "FOR ANTLIR DEVS ONLY: Please read D23464472 or " +
-            "https://fburl.com/antlir_rule_usage.",
+            'Package `" + package + "` must not `load("//antlir/bzl:' +
+            'oss_shim.bzl")`. Antlir devs: read about `antlir_rule` in ' +
+            "`website/docs/coding-conventions/bzl-and-targets.md`.",
         )
 
-def _kernel_artifact_version(version):
-    """
-    Internally, we have a collection of kernel versions built at
-    //kernel/kernels:kernels.bzl. We allow users to specify either
-    the short form (used in `official`) or the full uname (used in `kernels`).
+def _invert_dict(d):
+    """ In OSS Buck some of the dicts used by targets (`srcs` and `resources`
+    specifically) are inverted, where internally this:
 
-    Internally, a `kernel_artifact`is a struct containing the following members:
+        resources = { "//target:name": "label_of_resource" }
+
+    In OSS Buck this is:
+
+        resources = { "label_of_resource": "//target:name" }
+    """
+    if d and types.is_dict(d):
+        result = {value: key for key, value in d.items()}
+
+        if len(result) != len(d):
+            fail("_invert_dict fail! len(result): " + len(result) + " != len(d): " + len(d))
+
+        return result
+    else:
+        return d
+
+def _kernel_artifact_version(version):
+    """ Resolve a kernel version to its corresponding kernel artifact.
+    Currently, the only `kernel_artifact` available is in
+    //third-party/fedora31/kernel:kernels.bzl.
+
+    a `kernel_artifact`is a struct containing the following members:
     - uname
     - vmlinuz: compressed vmlinux
-    - vmlinux: Linux kernel in an statically linked executable file format
     - modules: kernel modules
-    - initrd:  used to boot this kernel in a virtual machine and setup the root
-               disk as a btrfs seed device with the second disk for writes to go to.
     - headers: Includes the C header files that specify the interface between the
                Linux kernel and user-space libraries and programs.
     - devel:   Contains the kernel headers and makefiles sufficient to build modules
                against the kernel package.
-    - vm:      a python_library containing all the artifacts required to run a kernel VM
     """
-    return kernels.kernel(version)
+    if version in kernels:
+        return kernels[version]
+    else:
+        fail("Unknown kernel version: {}".format(version))
 
-# Use = in the default filename to avoid clashing with RPM names.
-# The constant must match `update_allowed_versions.py`.
-def _rpm_vset(name, src = "empty=rpm=vset"):
-    # _assert_package() omitted for perf reasons, we have 60k callsites, and
-    # it's unlikely that a non-Antlir eng will use this by accident.
-    fb_native.export_file(
-        name = name,
-        src = src,
-        mode = "reference",
-        # `image.layer`s all over the repo will depend on these
-        visibility = ["PUBLIC"],
-        labels = [_INTERNAL_RULE_LABEL],
-    )
+def _normalize_deps(deps, more_deps = None):
+    """  Create a single list of deps from one or 2 provided lists of deps.
+    Additionally exclude any deps that have `/facebook` in the path as these
+    are internal and require internal FB infra.
+    """
+
+    _deps = deps or []
+    _more_deps = more_deps or []
+    _deps = _deps + _more_deps
+
+    derps = []
+    for dep in _deps:
+        if dep.find("facebook") < 0:
+            derps.append(dep)
+
+    return derps
+
+def _normalize_resources(resources):
+    """ Exclude any resources that have `/facebook` in the path as these
+    are internal and require internal FB infra. Only applies to resources
+    specified in the `dict` format
+
+    Will also go ahead an invert the dictionary using `_invert_dict`
+    """
+    if resources and types.is_dict(resources):
+        _normalized_dict_keys = _normalize_deps(resources.keys())
+        _normalized_resources = {key: resources[key] for key in _normalized_dict_keys}
+
+        return _invert_dict(_normalized_resources)
+    else:
+        return resources
+
+def _normalize_coverage(coverages):
+    """ Exclude any coverage requirements that have `facebook` in the path as
+    these are internal.
+    """
+    return [
+        (percent, dep)
+        for percent, dep in coverages
+        if "facebook" not in dep
+    ] if coverages else None
+
+def _normalize_visibility(vis, name = None):
+    """ OSS Buck has a slightly different handling of visibility.
+    The default is to be not visible.
+    For more info see: https://buck.build/concept/visibility.html
+    """
+    if vis == None:
+        return ["PUBLIC"]
+    else:
+        return vis
+
+def _normalize_pkg_style(style):
+    """
+    Internally, zip and fastzip internally behave similar to how an
+    `inplace` python binary behaves in OSS Buck.
+    """
+    if style and style in ("zip", "fastzip"):
+        return "inplace"
+    else:
+        return "standalone"
 
 def _third_party_library(project, rule = None, platform = None):
     """
-    In FB land we want to find the correct build for a third-party target
-    based on the current platform.
+    Generate a target for a third-party library.  This will return a target
+    that is normalized into the form (see the README in `//third-party/...`
+    more info on these targets):
 
-    If the platform is a python libary, use the pyfi infrastructure so
-    there is no need for `external_deps` in python targets.
+        //third-party/<platform>/<project>:<rule>
+
+    Thee are currently only 2 platforms supported in OSS:
+        - python
+        - fedora31
+
+    If `platform` is not provided it is assumed to be `fedora31`.
+
+    If `rule` is not provided it is assumed to be the same as `project`.
     """
+    _assert_package()  # Antlir-private: only use with `oss_shim.bzl` macros.
 
-    # _assert_package(): This is mostly just called from `antlir` TARGETS
-    # files, but we also have a callsite in `vm/initrd.bzl`, which can be
-    # invoked from customer TARGETS files.  I could work around this with an
-    # extra boolean flag, but it should be unlikely that people start using
-    # this helper by accident (so far, it happened once).
     if not rule:
         rule = project
 
     if not platform:
-        platform = platform_utils.get_platform_for_current_buildfile()
+        platform = _DEFAULT_NATIVE_PLATFORM
 
-    if platform == "python":
-        return "//python/wheel/" + project + ":" + rule
-    else:
-        return third_party.third_party_target(platform, project, rule)
+    return "//third-party/" + platform + "/" + project + ":" + rule
 
-def _wrap_internal(fn, args, kwargs, is_titled_labels = False):
+def _wrap_internal(fn, args, kwargs):
     """
     Wrap a build target rule with support for the `antlir_rule` kwarg.
 
@@ -148,145 +181,224 @@ def _wrap_internal(fn, args, kwargs, is_titled_labels = False):
       - "antlir-private" (default): Such rules MAY NOT be defined in user
         packages (outside of the Antlir codebase) -- see `_assert_package()`.
 
-      - "user-internal": May be defined by user packages, and excluded from
-        the fbcode TD-4 dependency distance calculation.  Specificially,
-        _INTERNAL_RULE_LABEL` will be added to labels/tags of the wrapped
-        rule.  That tells fbcode target determinator to skip the tagged rule
-        when calculating the build/test nodes affected by a diff -- nodes
-        farther than (currently) 4 dependency hops from their source will
-        not be validated on-diff. Wiki: https://fburl.com/antlir_td4
+      - "user-internal": May be defined by user packages, but does not
+        produce a build artifact that the user can use **directly**, e.g.
+        "SUFFIX-<name>" intermediate rules, or `image.{feature,layer}`.
 
-        Labeling rules "user-internal" is critical for CI to work as
-        expected, since the image building toolchain creates many
-        intermediary targets that artificially inflate the distance between
-        legitimate dependencies.
-
-      - "user-facing": Allowed in user packages, and counted towards the
-        TD-4 heuristic calculation.
+      - "user-facing": Allowed in user packages, and builds artifacts that
+        the end user can use directly, e.g. `image.package`.
 
     Rules are private by default to force Antlir devs to explicitly annotate
-    "user-internal" and "user-facing" rules.  We really only just want the
-    "internal" annotations to be correct so that fbcode TD works well, but
-    we cannot force the annotation of one without the other.  Since the
-    number of "user-facing" targets is very small, this is a good tradeoff.
+    "user-internal" and "user-facing" rules.
+
+    See also `website/docs/coding-conventions/bzl-and-targets.md`.
     """
     rule_type = kwargs.pop(_RULE_TYPE_KWARG, _RULE_PRIVATE)
     if rule_type == _RULE_PRIVATE:
         # Private rules should only be defined within `antlir/`.
         _assert_package()
-    elif rule_type == _RULE_USER_INTERNAL:
-        # This target is generated from a customer's package, but is a
-        # detail of Antlir's plumbing, and as such should not count towards
-        # the inter-rule dependency distance for fbcode TD4 purposes.
-        label_arg = "labels" if is_titled_labels else "tags"
-        kwargs.setdefault(label_arg, []).append(_INTERNAL_RULE_LABEL)
-    elif rule_type != _RULE_USER_FACING:
+    elif rule_type not in _ALLOWED_RULES:
         fail(
             "Bad value {}, must be one of {}".format(rule_type, _ALLOWED_RULES),
             _RULE_TYPE_KWARG,
         )
     fn(*args, **kwargs)
 
-def _buck_command_alias(*args, **kwargs):
-    _wrap_internal(buck_command_alias, args, kwargs, is_titled_labels = True)
+def _command_alias(*args, **kwargs):
+    _wrap_internal(command_alias, args, kwargs)
 
-def _buck_filegroup(*args, **kwargs):
-    _wrap_internal(buck_filegroup, args, kwargs, is_titled_labels = True)
+def _filegroup(*args, **kwargs):
+    _wrap_internal(filegroup, args, kwargs)
 
-def _buck_genrule(*args, **kwargs):
-    _wrap_internal(buck_genrule, args, kwargs, is_titled_labels = True)
+def _genrule(*args, **kwargs):
+    _wrap_internal(genrule, args, kwargs)
 
-def _buck_sh_binary(*args, **kwargs):
-    _wrap_internal(buck_sh_binary, args, kwargs, is_titled_labels = True)
+def _sh_binary(*args, **kwargs):
+    _wrap_internal(sh_binary, args, kwargs)
 
-def _buck_sh_test(*args, **kwargs):
-    _wrap_internal(buck_sh_test, args, kwargs, is_titled_labels = True)
+def _sh_test(*args, **kwargs):
+    _wrap_internal(sh_test, args, kwargs)
 
-def _export_file(*args, **kwargs):
-    _wrap_internal(export_file, args, kwargs, is_titled_labels = True)
+def _impl_cpp_unittest(name, tags = [], visibility = None, **kwargs):
+    cxx_test(
+        name = name,
+        labels = tags,
+        visibility = _normalize_visibility(visibility),
+        **kwargs
+    )
 
 def _cpp_unittest(*args, **kwargs):
-    _wrap_internal(cpp_unittest, args, kwargs)
+    _wrap_internal(_impl_cpp_unittest, args, kwargs)
+
+def _export_file(*args, **kwargs):
+    _wrap_internal(export_file, args, kwargs)
+
+def _impl_python_binary(
+        name,
+        main_module,
+        par_style = None,
+        resources = None,
+        visibility = None,
+        **kwargs):
+    _python_library(
+        name = name + "-library",
+        resources = resources,
+        visibility = visibility,
+        **kwargs
+    )
+
+    python_binary(
+        name = name,
+        main_module = main_module,
+        package_style = _normalize_pkg_style(par_style),
+        visibility = _normalize_visibility(visibility, name),
+        deps = [":" + name + "-library"],
+    )
 
 def _python_binary(*args, **kwargs):
-    _wrap_internal(python_binary, args, kwargs)
+    _wrap_internal(_impl_python_binary, args, kwargs)
+
+def _impl_python_library(
+        name,
+        deps = None,
+        visibility = None,
+        resources = None,
+        srcs = None,
+        **kwargs):
+    python_library(
+        name = name,
+        deps = _normalize_deps(deps),
+        resources = _normalize_resources(resources),
+        srcs = _invert_dict(srcs),
+        visibility = _normalize_visibility(visibility, name),
+        **kwargs
+    )
 
 def _python_library(*args, **kwargs):
-    _wrap_internal(python_library, args, kwargs)
+    _wrap_internal(_impl_python_library, args, kwargs)
+
+def _impl_python_unittest(
+        cpp_deps = "ignored",
+        deps = None,
+        needed_coverage = None,
+        par_style = None,
+        tags = None,
+        resources = None,
+        **kwargs):
+    python_test(
+        deps = _normalize_deps(deps),
+        labels = tags if tags else [],
+        needed_coverage = _normalize_coverage(needed_coverage),
+        package_style = _normalize_pkg_style(par_style),
+        resources = _normalize_resources(resources),
+        **kwargs
+    )
 
 def _python_unittest(*args, **kwargs):
-    _wrap_internal(python_unittest, args, kwargs)
+    _wrap_internal(_impl_python_binary, args, kwargs)
+
+# Use = in the default filename to avoid clashing with RPM names.
+# The constant must match `update_allowed_versions.py`.
+# Omits `_wrap_internal` due to perf paranoia -- we have a callsite per RPM.
+def _rpm_vset(name, src = "empty=rpm=vset"):
+    export_file(
+        name = name,
+        src = src,
+        mode = "reference",
+        # `image.layer`s all over the repo will depend on these
+        visibility = ["PUBLIC"],
+    )
+
+### BEGIN COPY-PASTA (@fbcode_macros//build_defs/lib:rule_target_types.bzl)
+# @lint-ignore BUILDIFIERLINT
+_RuleTargetProvider = provider(fields = [
+    "name",  # The name of the rule
+    "base_path",  # The base package within the repository
+    "repo",  # Either the cell or None (for the root cell)
+])
+
+def _RuleTarget(repo, base_path, name):
+    return _RuleTargetProvider(name = name, base_path = base_path, repo = repo)
+
+### END COPY-PASTA
+
+### BEGIN COPY-PASTA (@fbcode_macros//build_defs/lib:target_utils.bzl)
+def _parse_target(target, default_repo = None, default_base_path = None):
+    if target.count(":") != 1:
+        fail('rule name must contain exactly one ":": "{}"'.format(target))
+
+    repo_and_base_path, name = target.split(":")
+
+    # Parse relative target.
+    if not repo_and_base_path:
+        return _RuleTarget(default_repo, default_base_path, name)
+
+    # Parse absolute targets.
+    if repo_and_base_path.count("//") != 1:
+        fail('absolute rule name must contain one "//" before ":": "{}"'.format(target))
+    repo, base_path = repo_and_base_path.split("//", 1)
+    repo = repo or default_repo
+
+    return _RuleTarget(repo, base_path, name)
+
+def _to_label(repo, path, name):
+    return "{}//{}:{}".format(repo, path, name)
+
+### END COPY-PASTA
+
+def _get_project_root_from_gen_dir():
+    # NB: This will break if "buck-out" is set to something containing 1 or
+    # more slashes (e.g.  `/my/buck/out`).  A fix would be to copy-pasta
+    # `_get_buck_out_path`, but it seems like an unnecessary complication.
+    return "../.."
 
 # Please keep each section lexicographically sorted.
 shim = struct(
     #
     # Rules -- IMPORTANT -- wrap **ALL** rules with `_wrap_internal`
     #
-    buck_command_alias = _buck_command_alias,
-    buck_filegroup = _buck_filegroup,
-    buck_genrule = _buck_genrule,
-    buck_sh_binary = _buck_sh_binary,
-    buck_sh_test = _buck_sh_test,
-    cpp_unittest = _cpp_unittest,
-    export_file = _export_file,
-    python_binary = _python_binary,
-    python_library = _python_library,
-    python_unittest = _python_unittest,
-    rpm_vset = _rpm_vset,  # Not wrapped due to perf paranoia, we have 60k calls
+    buck_command_alias = _command_alias,
+    buck_filegroup = _filegroup,
+    buck_genrule = _genrule,
+    buck_sh_binary = _sh_binary,
+    buck_sh_test = _sh_test,
     #
     # Utility functions -- use `_assert_package()`, if at all possible.
     #
     config = struct(
-        get_current_repo_name = config.get_current_repo_name,
-        get_project_root_from_gen_dir = get_project_root_from_gen_dir,
+        # @lint-ignore BUCKFBCODENATIVE
+        get_current_repo_name = native.repository_name,
+        get_project_root_from_gen_dir = _get_project_root_from_gen_dir,
     ),
-    get_visibility = get_visibility,
-    target_utils = struct(
-        parse_target = target_utils.parse_target,
-        to_label = target_utils.to_label,
-    ),
-    third_party = struct(
-        library = _third_party_library,
-    ),
+    cpp_unittest = _cpp_unittest,
     #
     # Constants
     #
     default_vm_image = struct(
-        layer = _default_vm_layer,
-        package = _default_vm_package,
+        layer = None,
+        package = None,
     ),
-    # Access these via `constants.bzl`, do not use this dict directly.
-    #
-    # IMPORTANT: Before changing a config, please review the corresponding
-    # docblock in `constants.bzl`, many of these are sensitive.
-    #
-    # Keep in mind that this should be a `Dict[str, Optional[str]]` to allow
-    # overrides via Buck's `-c` CLI option.
-    #
-    # These `fbcode`-specific configs are not in `.buckconfig` because of
-    # https://fb.prod.workplace.com/groups/fbcode/permalink/3264530036917146/
-    do_not_use_repo_cfg = {
-        "build_appliance_default": "//tupperware/image/build_appliance:fb_build_appliance",
-        "host_mounts_allowed_in_targets": " ".join([
-            "//tupperware/image/features:fb_infra_support",
-        ]),
-        "host_mounts_for_repo_artifacts": " ".join([
-            "/mnt/gvfs",
-        ]),
-        "rpm_installer_default": "yum",
-        # Replace with "tw_jobs" once this is ready for prod:
-        # https://fb.quip.com/vsM7AIvScYrA
-        "version_set_default": None,
-        # DO NOT ADD to this list without reading the doc in `constants.bzl`.
-        "version_set_to_path": " ".join([
-            (k + " " + v)
-            for k, v in {
-                "tw_jobs": "//bot_generated/antlir/version_sets/tw_jobs",
-            }.items()
-        ]),
-    },
+    # Future: We could conceivably add OSS support for a `.bzl`-based
+    # deployment-specific customizations, but for now we expect non-FB
+    # customers to use the `[antlir]` section in `.buckconfig`.
+    # Look at `bzl/constants.bzl` for the available options.
+    do_not_use_repo_cfg = {},
+    export_file = _export_file,
+    get_visibility = _normalize_visibility,
     kernel_artifact = struct(
-        default_kernel = _kernel_artifact_version("5.2"),
+        default_kernel = _kernel_artifact_version("5.3.7-301.fc31.x86_64"),
         version = _kernel_artifact_version,
+    ),
+    platform_utils = None,
+    python_binary = _python_binary,
+    python_library = _python_library,
+    python_unittest = _python_unittest,
+    rpm_vset = _rpm_vset,  # Not wrapped due to perf paranoia.
+    target_utils = struct(
+        parse_target = _parse_target,
+        to_label = _to_label,
+    ),
+    third_party = struct(
+        library = _third_party_library,
     ),
 )

--- a/antlir/bzl/oss_shim_vm_impl.bzl
+++ b/antlir/bzl/oss_shim_vm_impl.bzl
@@ -1,4 +1,2 @@
-load("//antlir/bzl/facebook:image_vm_unittest.bzl", _image_vm_cpp_unittest = "image_vm_cpp_unittest", _image_vm_python_unittest = "image_vm_python_unittest")
-
-image_vm_cpp_unittest = _image_vm_cpp_unittest
-image_vm_python_unittest = _image_vm_python_unittest
+image_vm_cpp_unittest = None
+image_vm_python_unittest = None


### PR DESCRIPTION
The internal and external repositories are out of sync. This attempts to brings them back in sync by patching the GitHub repository. Please carefully review this patch. You must disable ShipIt for your project in order to merge this pull request. DO NOT IMPORT this pull request. Instead, merge it directly on GitHub using the MERGE BUTTON. Re-enable ShipIt after merging.