### PR TITLE
antlir oss: set rpm_installer_default = dnf

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -24,3 +24,6 @@
   # option.
   # ie:  `buck test //antlir/rpm:test-yum-dnf-from-snapshot --always-exclude`
   excluded_labels = exclude_test_if_transitive_dep
+
+[antlir]
+  build_appliance_default = //appliance:host_build_appliance

--- a/.buckconfig
+++ b/.buckconfig
@@ -27,3 +27,4 @@
 
 [antlir]
   build_appliance_default = //appliance:host_build_appliance
+  rpm_installer_default = dnf

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ## What is `antlir`?
 As it's primary purpose, `antlir` is a set of
-[Starlark](https://github.com/bazelbuild/starlark) macros suitable for use 
+[Starlark](https://github.com/bazelbuild/starlark) macros suitable for use
 by the [Buck](https://buck.build) build system to build OS images for containers
 and hosts, as well as other filesystem images.
 
-### License                                                                                             
-                                                                                                         
-`antlir` is licensed under the MIT License.  See [here](LICENSE).  
+### License
+
+`antlir` is licensed under the MIT License.  See [here](LICENSE).

--- a/antlir/bzl/oss_shim_impl.bzl
+++ b/antlir/bzl/oss_shim_impl.bzl
@@ -203,6 +203,7 @@ def _wrap_internal(fn, args, kwargs):
             "Bad value {}, must be one of {}".format(rule_type, _ALLOWED_RULES),
             _RULE_TYPE_KWARG,
         )
+    kwargs["visibility"] = _normalize_visibility(kwargs.get("visibility", None))
     fn(*args, **kwargs)
 
 def _command_alias(*args, **kwargs):
@@ -220,11 +221,10 @@ def _sh_binary(*args, **kwargs):
 def _sh_test(*args, **kwargs):
     _wrap_internal(native.sh_test, args, kwargs)
 
-def _impl_cpp_unittest(name, tags = [], visibility = None, **kwargs):
+def _impl_cpp_unittest(name, tags = [], **kwargs):
     native.cxx_test(
         name = name,
         labels = tags,
-        visibility = _normalize_visibility(visibility),
         **kwargs
     )
 
@@ -244,7 +244,7 @@ def _impl_python_binary(
     _impl_python_library(
         name = name + "-library",
         resources = resources,
-        visibility = _normalize_visibility(visibility, name),
+        visibility = visibility,
         **kwargs
     )
 
@@ -252,7 +252,7 @@ def _impl_python_binary(
         name = name,
         main_module = main_module,
         package_style = _normalize_pkg_style(par_style),
-        visibility = _normalize_visibility(visibility, name),
+        visibility = visibility,
         deps = [":" + name + "-library"],
     )
 
@@ -262,7 +262,6 @@ def _python_binary(*args, **kwargs):
 def _impl_python_library(
         name,
         deps = None,
-        visibility = None,
         resources = None,
         srcs = None,
         **kwargs):
@@ -271,7 +270,6 @@ def _impl_python_library(
         deps = _normalize_deps(deps),
         resources = _normalize_resources(resources),
         srcs = _invert_dict(srcs),
-        visibility = _normalize_visibility(visibility, name),
         **kwargs
     )
 

--- a/antlir/bzl/oss_shim_impl.bzl
+++ b/antlir/bzl/oss_shim_impl.bzl
@@ -241,10 +241,10 @@ def _impl_python_binary(
         resources = None,
         visibility = None,
         **kwargs):
-    _python_library(
+    _impl_python_library(
         name = name + "-library",
         resources = resources,
-        visibility = visibility,
+        visibility = _normalize_visibility(visibility, name),
         **kwargs
     )
 

--- a/antlir/compiler/defs.bzl
+++ b/antlir/compiler/defs.bzl
@@ -1,4 +1,4 @@
-load("//antlir/bzl:constants.bzl", "REPO_CFG", "VERSION_SET_ALLOW_ALL_VERSIONS"),
+load("//antlir/bzl:constants.bzl", "REPO_CFG", "VERSION_SET_ALLOW_ALL_VERSIONS")
 load("//antlir/bzl:oss_shim.bzl", "python_unittest")
 load("//antlir/bzl/image_actions:feature.bzl", "PRIVATE_DO_NOT_USE_feature_target_name")
 

--- a/antlir/nspawn_in_subvol/BUCK
+++ b/antlir/nspawn_in_subvol/BUCK
@@ -158,7 +158,7 @@ python_unittest(
         layer_resource(
             TEST_IMAGE_PREFIX + "hello_world_base",
         ): "tests/test-hello-world-base",
-        layer_resource("//tupperware/image/base:base"): "tests/bootable-systemd-os",
+        layer_resource("//appliance:host_build_appliance"): "tests/bootable-systemd-os",
         layer_resource(":host-hello-xar"): "tests/host-hello-xar",
     },
     deps = [":testlib_base"],

--- a/appliance/BUCK
+++ b/appliance/BUCK
@@ -1,0 +1,29 @@
+load("//antlir/bzl:constants.bzl", "DO_NOT_USE_BUILD_APPLIANCE")
+load("//antlir/bzl:image.bzl", "image")
+load("//antlir/bzl:rpm_repo_snapshot.bzl", "RPM_SNAPSHOT_BASE_DIR")
+
+image.layer(
+    name = "host_build_appliance",
+    features = [
+        image.mkdir("/", "var"),
+        image.mkdir("/var", "tmp"),
+        image.mkdir("/var", "log"),
+        image.mkdir("/var", "cache"),
+        image.mkdir("/var/cache", "dnf"),
+        image.mkdir("/var", "lib/rpm"),
+        image.mkdir("/var/lib", "dnf"),
+        image.mkdir("/", RPM_SNAPSHOT_BASE_DIR),
+    ] + [
+        image.host_dir_mount(source)
+        for source in [
+            "/bin",
+            "/etc",
+            "/lib",
+            "/sbin",
+            "/usr",
+        ]
+    ],
+    build_opts = image.opts(
+        build_appliance = DO_NOT_USE_BUILD_APPLIANCE,
+    ),
+)

--- a/third-party/fedora31/qemu/BUCK
+++ b/third-party/fedora31/qemu/BUCK
@@ -1,0 +1,8 @@
+# Emit a qemu "binary" that just invokes the system-installed qemu
+# This is a stopgap until antlir can vendor (probably a statically compiled)
+# qemu in some sane way
+sh_binary(
+    name = "qemu",
+    main = "system-qemu.sh",
+    visibility = ["PUBLIC"],
+)

--- a/third-party/fedora31/qemu/system-qemu.sh
+++ b/third-party/fedora31/qemu/system-qemu.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec qemu-system-x86_64 "${@}"


### PR DESCRIPTION
Summary:
Yet another config option that was required but not set.

The comments in `oss_shim_impl.bzl` say that open source usage is expected to use the `[antlir]` section in `.buckconfig` -
I am not sure if we want to revisit that for providing defaults, it depends on how buck cells work which I am still a little hazy on

Differential Revision: D23906132

