### PR TITLE
add .envrc for dotenv usage

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+# Useful tricks for direnv 
+
+# 'alias' buck to the local wrapper when in antlir/
+PATH_add tools

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ buck-image-out
 
 # vim stuff
 **/*.swp
+
+.vscode/


### PR DESCRIPTION
dotenv makes our buck wrapper much easier to use, by adding `tools/` to
$PATH when a user has direnv on their system.