### PR TITLE
antlir oss: more flexible systemd-nspawn version check

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -31,3 +31,4 @@
 [antlir]
   build_appliance_default = //appliance:host_build_appliance
   rpm_installer_default = dnf
+  host_mounts_allowed_in_targets = //appliance:host_build_appliance

--- a/.buckconfig
+++ b/.buckconfig
@@ -16,6 +16,10 @@
   interpreter = /usr/bin/python3
   package_style = inplace
 
+[cxx]
+  gtest_dep = //third-party/cxx:gtest
+  should_remap_host_platform = true
+
 [test]
   # This is needed to ensure that the test runner only executes the
   # 'in image' unittest targets, and not the `IGNORE-ME*` wrapper tests

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
   path = third-party/bazel-skylib
   url = https://github.com/bazelbuild/bazel-skylib.git
   ignore = untracked
+[submodule "third-party/cxx/googletest"]
+	path = third-party/cxx/googletest
+	url = https://github.com/google/googletest.git

--- a/antlir/bzl/shape.bzl
+++ b/antlir/bzl/shape.bzl
@@ -415,7 +415,7 @@ def _loader_src(shape, classname):
 def _loader(name, shape, classname = None, **kwargs):
     python_src = _loader_src(shape, classname or name)
     buck_genrule(
-        name = "{}={}.py".format(name, name),
+        name = "{}.py".format(name),
         out = "unused.py",
         cmd = "echo {} > $OUT".format(shell.quote(python_src)),
         # Antlir users should not directly use `shape`, but we do use it
@@ -424,7 +424,7 @@ def _loader(name, shape, classname = None, **kwargs):
     )
     python_library(
         name = name,
-        srcs = [":{}={}.py".format(name, name)],
+        srcs = {":{}.py".format(name): "{}.py".format(name)},
         deps = ["//antlir:shape"],
         # Antlir users should not directly use `shape`, but we do use it
         # as an implementation detail of "builder" / "publisher" targets.
@@ -469,10 +469,9 @@ def _python_data(name, shape, module = None, **python_library_kwargs):
     if not module:
         module = name
 
-    src_name = "{}={}.py".format(name, module)
     buck_genrule(
-        name = src_name,
-        out = src_name,
+        name = "{}.py".format(name),
+        out = "unused.py",
         cmd = "echo {} >> $OUT".format(shell.quote(python_src)),
         # Antlir users should not directly use `shape`, but we do use it
         # as an implementation detail of "builder" / "publisher" targets.
@@ -480,7 +479,7 @@ def _python_data(name, shape, module = None, **python_library_kwargs):
     )
     python_library(
         name = name,
-        srcs = [":{}".format(src_name)],
+        srcs = {":{}.py".format(name): "{}.py".format(name)},
         deps = [
             "//antlir:shape",
             third_party.library("pydantic", platform = "python"),

--- a/antlir/nspawn_in_subvol/common.py
+++ b/antlir/nspawn_in_subvol/common.py
@@ -53,5 +53,5 @@ def nspawn_version() -> NSpawnVersion:
     parts = subprocess.check_output(
         ["systemd-nspawn", "--version"], text=True
     ).split()
-    assert parts[2].startswith("(v") and parts[2].endswith(")"), parts
-    return NSpawnVersion(major=int(parts[1]), full=parts[2][2:-1])
+    assert parts[2].startswith("(") and parts[2].endswith(")"), parts
+    return NSpawnVersion(major=int(parts[1]), full=parts[2][1:-1])

--- a/antlir/nspawn_in_subvol/non_booted.py
+++ b/antlir/nspawn_in_subvol/non_booted.py
@@ -80,7 +80,7 @@ def _post_setup_popen_booted_nspawn(
     cmd.extend(["--setenv=" + se for se in setup.cmd_env])
     # FIXME: Remove this `no cover` once CI gets a newer `systemd` -- we'll
     # know when the CI coverage test starts failing.
-    if version.major > 247 or version.full == "246.1-1.fb3":  # pragma: no cover
+    if version.major > 247 or version.full == "v246.1-1.fb3":  # pragma: no cover
         # This gives better interactive behavior than the `--console=pipe`
         # setting below.  The security caveats still apply, but are harder
         # to trigger.  This is not a perfect fix for the issues, but it's

--- a/antlir/nspawn_in_subvol/tests/test_common.py
+++ b/antlir/nspawn_in_subvol/tests/test_common.py
@@ -17,7 +17,7 @@ class CommonTestCase(unittest.TestCase):
                 "systemd 602214076 (v602214076-2.fb1)\n+AVOGADROS SYSTEMD\n"
             )
             self.assertEqual(
-                NSpawnVersion(major=602214076, full="602214076-2.fb1"),
+                NSpawnVersion(major=602214076, full="v602214076-2.fb1"),
                 nspawn_version(),
             )
 
@@ -27,3 +27,19 @@ class CommonTestCase(unittest.TestCase):
         # guessing here.
         self.assertTrue(nspawn_version().major > 239)
         self.assertTrue(nspawn_version().major < 1000)
+
+    def test_arch_version(self):
+        # the above version check unit test is biased towards an fb environment
+        # systemd in other distributions can have different version formats
+        with mock.patch("subprocess.check_output") as version:
+            version.return_value = (
+                "systemd 246 (246.4-1-arch)\n"
+                "+PAM +AUDIT -SELINUX -IMA -APPARMOR +SMACK -SYSVINIT "
+                "+UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 "
+                "+ZSTD +SECCOMP +BLKID +ELFUTILS +KMOD +IDN2 -IDN "
+                "+PCRE2 default-hierarchy=hybrid"
+            )
+            self.assertEqual(
+                NSpawnVersion(major=246, full="246.4-1-arch"),
+                nspawn_version(),
+            )

--- a/third-party/cxx/BUCK
+++ b/third-party/cxx/BUCK
@@ -1,0 +1,37 @@
+load(":native_cxx.bzl", "cxx_library", "subdir_glob", "prebuilt_cxx_library")
+
+prebuilt_cxx_library(
+    name = "pthread",
+    header_only = True,
+    supported_platforms_regex = "linux.*",
+    exported_linker_flags = ["-lpthread"],
+    visibility = [
+        "PUBLIC",
+    ],
+)
+
+# mostly copied from
+# https://buck.build/files-and-dirs/buckconfig.html#cxx.gtest_dep
+cxx_library(
+    name = "gtest",
+    srcs = [
+        "googletest/googletest/src/gtest-all.cc",
+        "googletest/googlemock/src/gmock-all.cc",
+        "googletest/googlemock/src/gmock_main.cc",
+    ],
+    header_namespace = "",
+    exported_headers = subdir_glob([
+        ("googletest/googletest/include", "**/*.h"),
+        ("googletest/googlemock/include", "**/*.h"),
+    ]),
+    headers = subdir_glob([
+        ("googletest/googletest", "src/*.cc"),
+        ("googletest/googletest", "src/*.h"),
+        ("googletest/googlemock", "src/*.cc"),
+        ("googletest/googlemock", "src/*.h"),
+    ]),
+    visibility = [
+        "PUBLIC",
+    ],
+    deps = [":pthread"],
+)

--- a/third-party/cxx/googletest
+++ b/third-party/cxx/googletest
@@ -1,0 +1,1 @@
+Subproject commit 703bd9caab50b139428cea1aaff9974ebee5742e

--- a/third-party/cxx/native_cxx.bzl
+++ b/third-party/cxx/native_cxx.bzl
@@ -1,0 +1,21 @@
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+# we disable implicit native rules by default for antlir things, but for
+# third-party cxx rules it is easier to just use the buck native ruleset
+cxx_library = native.cxx_library
+prebuilt_cxx_library = native.prebuilt_cxx_library
+
+def subdir_glob(glob_specs):
+    # Simple re-implementation of the Buck Python DSL subdir_glob
+    # (https://buck.build/function/subdir_glob.html) which does not exist in
+    # the Starlark DSL, but is essential for third party cxx deps. This is a
+    # fairly naive implementation (for example, it does not ensure that there
+    # are no conflicting files), but is good enough for the existing use case
+    # of gtest (and likely only it will only ever be used for that)
+    srcs = {}
+    for subdir, pattern in glob_specs:
+        files = native.glob([paths.join(subdir, pattern)])
+        for f in files:
+            srcs[paths.relativize(f, subdir)] = f
+
+    return srcs

--- a/third-party/python/pypi.bzl
+++ b/third-party/python/pypi.bzl
@@ -3,7 +3,8 @@ load("//antlir/bzl:oss_shim.bzl", "http_file")
 def pypi_package(
     name,
     url,
-    sha256):
+    sha256,
+    deps=None):
     http_file(
         name = "{}-download".format(name),
         sha256 = sha256,
@@ -15,4 +16,5 @@ def pypi_package(
         name = name,
         binary_src = ":{}-download".format(name),
         visibility = ["PUBLIC"],
+        deps = deps or [],
     )

--- a/third-party/python/requests/BUCK
+++ b/third-party/python/requests/BUCK
@@ -4,4 +4,10 @@ pypi_package(
     name = "requests",
     sha256 = "43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
     url = "https://files.pythonhosted.org/packages/1a/70/1935c770cb3be6e3a8b78ced23d7e0f3b187f5cbfab4749523ed65d7c9b1/requests-2.23.0-py2.py3-none-any.whl",
+    deps = [
+        "//third-party/python/certifi:certifi",
+        "//third-party/python/chardet:chardet",
+        "//third-party/python/idna:idna",
+        "//third-party/python/urllib3:urllib3",
+    ],
 )


### PR DESCRIPTION
Summary:
Some distros (btw, I run Arch) have different systemd version outputs.

There appears to be only one place where a specific full version was
being used, so I updated it to include the `v` prefix, to match that
`nspawn_version` now returns an unmodified full version string (minus
the parens)

Differential Revision: D24031625

