### PR TITLE
antlir oss [easy]: fix submodule setup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,3 @@
   path = third-party/bazel-skylib
   url = https://github.com/bazelbuild/bazel-skylib.git
   ignore = untracked
-[submodule "third-party/cxx/googletest"]
-	path = third-party/cxx/googletest
-	url = https://github.com/google/googletest.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
   path = third-party/bazel-skylib
   url = https://github.com/bazelbuild/bazel-skylib.git
   ignore = untracked
+[submodule "third-party/cxx/googletest"]
+  path = third-party/cxx/googletest
+  url = https://github.com/google/googletest.git
+  ignore = untracked

--- a/third-party/cxx/googletest
+++ b/third-party/cxx/googletest
@@ -1,1 +1,0 @@
-Subproject commit 703bd9caab50b139428cea1aaff9974ebee5742e


### PR DESCRIPTION
Summary:
ShipIt does weird things with submodules. This mirrors the bazel_skylib setup,
so I think it should be correct.

Differential Revision: D24053320

