### PR TITLE
antlir vm: move kernel layer artifacts macro into antlir/vm

### DIFF
--- a/antlir/bzl/foreign/rpmbuild/rpmbuild.bzl
+++ b/antlir/bzl/foreign/rpmbuild/rpmbuild.bzl
@@ -94,7 +94,7 @@ def image_rpmbuild(
     # <name>-rpmbuild-install-deps layer.
     build_opts = image_layer_kwargs.get("build_opts")
     build_opts_dict = structs.to_dict(build_opts) if build_opts else {}
-    installer = build_opts_dict.get("rpm_installer", "yum")
+    installer = build_opts_dict.get("rpm_installer", REPO_CFG.rpm_installer_default)
 
     install_deps_layer = name + "-rpmbuild-install-deps"
     image_foreign_layer(

--- a/antlir/bzl/foreign/rpmbuild/tests/BUCK
+++ b/antlir/bzl/foreign/rpmbuild/tests/BUCK
@@ -9,6 +9,13 @@ export_file(name = "toy_srcs")
 
 export_file(name = "toy.spec")
 
+# this needs to be re-exported in this BUCK file for
+# $BUCK_DEFAULT_RUNTIME_RESOURCES to work, because reasons
+export_file(
+    name = "gpg-test-signing-key",
+    src = "//antlir/rpm:gpg-test-signing-key",
+)
+
 # An example of an RPM signer that can sign an RPM with a test key.
 #
 # When signing with an existing key in a gpg agent or keyring, you can omit the
@@ -28,8 +35,8 @@ buck_sh_binary(
     name = "rpm_sign_with_test_key.sh",
     main = "rpm_sign_with_test_key.sh",
     resources = [
+        ":gpg-test-signing-key",
         ":rpm_sign_test_functions.sh",
-        "//antlir/rpm:gpg-test-signing-key",
     ],
     visibility = ["//antlir/bzl/foreign/rpmbuild/tests/..."],
 )

--- a/antlir/bzl/foreign/rpmbuild/tests/rpm_sign_test_functions.sh
+++ b/antlir/bzl/foreign/rpmbuild/tests/rpm_sign_test_functions.sh
@@ -20,7 +20,7 @@ function sign_with_test_key {
 
     trap 'rm -rf "$GNUPGHOME"' RETURN
 
-    signing_key="$BUCK_PROJECT_ROOT/antlir/rpm/tests/gpg_test_keypair/private.key"
+    signing_key="$BUCK_DEFAULT_RUNTIME_RESOURCES/gpg-test-signing-key"
     gpg -q --import "$signing_key"
     rpmsign --addsign --define='_gpg_name Test Key' --define='_gpg_digest_algo sha256' "$1"
 }

--- a/antlir/bzl/foreign/rpmbuild/tests/rpm_sign_with_test_key.sh
+++ b/antlir/bzl/foreign/rpmbuild/tests/rpm_sign_with_test_key.sh
@@ -6,10 +6,10 @@
 
 set -o pipefail
 
-# $BUCK_PROJECT_ROOT is a mirror of the source and artifact trees containing the
-# `resources` specified in the target for this buck_sh_binary.  Since it's
+# $BUCK_DEFAULT_RUNTIME_RESOURCES is populated with symlinks to (or copies of)
+# the `resources` specified in the target for this buck_sh_binary. Since it's
 # determined at runtime it cannot be shellcheck-ed.
 # shellcheck source=/dev/null
-source "$BUCK_PROJECT_ROOT/antlir/bzl/foreign/rpmbuild/tests/rpm_sign_test_functions.sh"
+source "$BUCK_DEFAULT_RUNTIME_RESOURCES/rpm_sign_test_functions.sh"
 
 sign_with_test_key "$1"

--- a/antlir/compiler/test_images/BUCK
+++ b/antlir/compiler/test_images/BUCK
@@ -790,11 +790,11 @@ image.package(
 
 add_rpm_repo_snapshots_layer(
     name = "build_appliance_testing",
-    dnf_snapshot = "//antlir/rpm:repo-snapshot-for-tests",
+    dnf_snapshot = "//antlir/rpm:repo-snapshot-for-tests" if "dnf" in REPO_CFG.rpm_installers_supported else None,
     make_caches_for_other_snapshot_installers = [
-        ("//antlir/rpm:non-default-repo-snapshot-for-tests", "dnf"),
-        ("//antlir/rpm:non-default-repo-snapshot-for-tests", "yum"),
+        ("//antlir/rpm:non-default-repo-snapshot-for-tests", installer)
+        for installer in REPO_CFG.rpm_installers_supported
     ],
     parent_layer = REPO_CFG.build_appliance_default,
-    yum_snapshot = "//antlir/rpm:repo-snapshot-for-tests",
+    yum_snapshot = "//antlir/rpm:repo-snapshot-for-tests" if "yum" in REPO_CFG.rpm_installers_supported else None,
 )

--- a/antlir/vm/kernel/defs.bzl
+++ b/antlir/vm/kernel/defs.bzl
@@ -1,5 +1,7 @@
+load("//antlir/bzl:constants.bzl", "REPO_CFG")
+load("//antlir/bzl:image.bzl", "image")
 load("//antlir/bzl:layer_resource.bzl", "layer_resource")
-load("//antlir/bzl:oss_shim.bzl", "default_vm_image", "python_binary", "python_library", "third_party")
+load("//antlir/bzl:oss_shim.bzl", "buck_genrule", "default_vm_image", "python_binary", "python_library", "third_party")
 
 def create_kernel_vm_targets(kernel):
     """
@@ -12,13 +14,13 @@ def create_kernel_vm_targets(kernel):
     # Future: replace with a kernel_t shape.
     python_library(
         name = "{}-vm".format(kernel.uname),
+        antlir_rule = "user-internal",
         base_module = "antlir.vm",
         resources = {
             "//antlir/vm/initrd:{}-initrd".format(kernel.uname): "initrd",
             kernel.vmlinuz: "vmlinuz",
             layer_resource(kernel.modules): "modules",
         },
-        antlir_rule = "user-internal",
     )
 
     python_binary(
@@ -28,12 +30,127 @@ def create_kernel_vm_targets(kernel):
         base_module = "antlir.vm",
         main_module = "antlir.vm.run",
         par_style = "xar",
+        resources = {
+            default_vm_image.package: "image",
+        },
         deps = [
             ":{}-vm".format(kernel.uname),
             "//antlir/vm:run",
             third_party.library("click", platform = "python"),
         ],
-        resources = {
-            default_vm_image.package: "image",
-        },
+    )
+
+def kernel_artifact_layers(uname, devel_rpm, rpm_exploded, extra_modules = None):
+    # Install the devel rpm into a layer.  The reasons for this instead of using the same
+    # pattern as the `rpm-exploded` targets are:
+    #  - The devel rpm contains some internally consistent symlinks that
+    #    we'd like to preserve when creating the image layer.  Currently
+    #    the only way to do that is via the `image.clone` operation, which
+    #    requires the source of the clone to be a layer.
+    #  - The destination of the contents need to be installed at the root
+    #    of the image layer (./).  This is currently not possible with the
+    #    implementation of `image.source` since `./` ends up conflicting
+    #    with the always provided /.
+    image.layer(
+        name = "{uname}--devel-installed".format(uname = uname),
+        # This is used because we need the gpg keys that this rpm is signed
+        # by and the build appliance should have it.
+        parent_layer = REPO_CFG.build_appliance_default,
+        features = [
+            image.rpms_install([devel_rpm]),
+        ],
+        visibility = [],
+    )
+    image.layer(
+        name = "{}-devel".format(uname),
+        features = [
+            image.clone(
+                ":{}--devel-installed".format(uname),
+                "usr/src/kernels/{}/".format(uname),
+                "./",
+            ),
+        ],
+    )
+
+    # This will extract all of the modules from the `{uname}-rpm-exploded` target as
+    # well as any additional modules that aren't part of the kernel rpm (for older
+    # kernels that weren't built with certain modules originally).
+    # Then it will run depmod to generate the module dependency information
+    # required.
+    buck_genrule(
+        name = "{uname}--precursor-of-modules".format(uname = uname),
+        out = ".",
+        cmd = """
+            mkdir -p "$OUT/lib/modules/{uname}"
+            cd "$OUT"
+
+            cp --reflink=auto -R "$(location {rpm_exploded})/lib/modules/{uname}"/* "lib/modules/{uname}/"
+
+            {cp_extra_modules}
+
+            # run depmod here so that we can include the results in the layer we build
+            # from this.
+            depmod --basedir="$OUT" {uname}
+
+            # if vmlinux is just 'vmlinux', copy it to be uniquely identified by its uname
+            if [ -f $(location {rpm_exploded})/lib/modules/{uname}/vmlinux ]; then
+                cp $(location {rpm_exploded})/lib/modules/{uname}/vmlinux "lib/modules/{uname}/vmlinux-{uname}"
+            fi
+        """.format(
+            uname = uname,
+            rpm_exploded = rpm_exploded,
+            # some older kernels were never built with the 9p fs module, so copy in
+            # any modules that are checked in to fbcode that might be missing from
+            # the rpm but are necessary for vmtest
+            cp_extra_modules = """
+                extra_mod_dir="$(location {extra_modules})/modules/{uname}"
+                if [[ -d  "$extra_mod_dir" ]]; then
+                    cp -R "$extra_mod_dir"/* "lib/modules/{uname}/kernel/"
+                fi
+            """.format(extra_modules) if extra_modules else "",
+        ),
+        visibility = [],
+        antlir_rule = "user-internal",
+    )
+
+    # The modules are inserted into the layer at the root
+    # of the layer with the expectation that the layer
+    # will be mounted for use at `/lib/modules/{uname}'.
+    image.layer(
+        name = "{}-modules".format(uname),
+        features = [
+            image.install(
+                image.source(
+                    ":{}--precursor-of-modules".format(uname),
+                    path = "lib/modules/{uname}/{part}".format(
+                        uname = uname,
+                        part = part,
+                    ),
+                ),
+                part,
+            )
+            for part in [
+                "kernel",  # The entire directory of modules
+                # All the supporting metadata that modprobe and other
+                # userspace tools need in order to deal with modules
+                "modules.alias",
+                "modules.alias.bin",
+                "modules.builtin",
+                "modules.builtin.bin",
+                "modules.dep",
+                "modules.dep.bin",
+                "modules.devname",
+                "modules.order",
+                "modules.symbols",
+                "modules.symbols.bin",
+                # Include the uncompressed kernel binary along with the modules so
+                # that some bpf tools can use it.
+                "vmlinux-{}".format(uname),
+            ]
+        ] + [
+            # If the devel headers/source are needed they will be
+            # bind mounted into place on this directory. This is here
+            # to support that.
+            image.mkdir("/", "build"),
+        ],
     )

--- a/third-party/fedora31/kernel/BUCK
+++ b/third-party/fedora31/kernel/BUCK
@@ -1,4 +1,5 @@
 load("//antlir/bzl:oss_shim.bzl", "buck_genrule", "http_file")
+load("//antlir/vm/kernel:defs.bzl", "kernel_artifact_layers")
 
 http_file(
     name = "5.3.7-301.fc31.x86_64-core.rpm",
@@ -42,14 +43,8 @@ buck_genrule(
     cmd = "cp --reflink=auto $(location :5.3.7-301.fc31.x86_64-rpm-exploded)/lib/modules/5.3.7-301.fc31.x86_64/vmlinuz $OUT",
 )
 
-# this is all the modules that the kernel could possibly need. they are
-# copied into the initrd so that they don't have to be installed in the
-# root disk
-buck_genrule(
-    name = "5.3.7-301.fc31.x86_64-modules",
-    out = ".",
-    cmd = """
-        mkdir -p $OUT
-        cp -R "$(location :5.3.7-301.fc31.x86_64-rpm-exploded)/lib/modules/5.3.7-301.fc31.x86_64/kernel" "$OUT"
-    """,
+kernel_artifact_layers(
+    devel_rpm = "5.3.7-301.fc31.x86_64-devel.rpm",
+    rpm_exploded = "5.3.7-301.fc31.x86_64-rpm-exploded",
+    uname = "5.3.7-301.fc31.x86_64",
 )


### PR DESCRIPTION
Summary:
This needs to exist in OSS, so move it into a location where it can be used
both internally and on github.

Differential Revision: D24663710

