### PR TITLE
antlir oss: run black on github actions

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,11 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: psf/black@stable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,9 @@ We actively welcome your pull requests.
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
 4. Ensure the test suite passes.
-5. Make sure your code follows our coding conventions described in the docs.
-6. If you haven't already, complete the Contributor License Agreement ("CLA").
+5. Make sure your code lints.
+6. Make sure your code follows our coding conventions described in the docs.
+7. If you haven't already, complete the Contributor License Agreement ("CLA").
 
 ## Contributor License Agreement ("CLA")
 In order to accept your pull request, we need you to submit a CLA. You only need

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,11 +5,11 @@ possible.
 ## Pull Requests
 We actively welcome your pull requests.
 
-1. Fork the repo and create your branch from `master`.
+1. Fork the repo and create your branch from `main`.
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
 4. Ensure the test suite passes.
-5. Make sure your code lints.
+5. Make sure your code follows our coding conventions described in the docs.
 6. If you haven't already, complete the Contributor License Agreement ("CLA").
 
 ## Contributor License Agreement ("CLA")


### PR DESCRIPTION
Summary:
Follow up to D24999006
For now this is only black since they provide a prebuilt github action, but it
will need to be expanded to run isort and flake8, as well as pyre etc

Differential Revision: D25002380

