### PR TITLE
antlir oss: publish docs to gh-pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,27 @@
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install docs tools
+        run: yarn
+        working-directory: website
+
+      - name: Build docs
+        run: yarn build
+        working-directory: website
+
+      - name: Deploy to gh-pages
+        uses: JamesIves/github-pages-deploy-action@3.6.2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: website/build
+          CLEAN: true

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -19,7 +19,7 @@ module.exports = {
     'internal': 'https://www.internalfb.com/intern/staticdocs/antlir',
     'external': 'https://www.github.com/facebookincubator/antlir',
   }),
-  baseUrl: '/',
+  baseUrl: '/antlir/',
   favicon: 'img/favicon.ico',
   organizationName: 'facebookincubator', // Usually your GitHub org/user name.
   projectName: 'antlir', // Usually your repo name.


### PR DESCRIPTION
Summary:
Setup a GitHub Actions workflow to build and publish the documentation
site on every push to `main`

Bonus points: it works for forks too

Test Plan:
https://vmagro.github.io/antlir/