### PR TITLE
antlir oss: use RDS for snapshot database instead of sqlite

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -14,7 +14,7 @@
 # inplace python binaries in local dev mode, but it will always be python3.
 [python]
   interpreter = /usr/bin/python3
-  package_style = standalone
+  package_style = inplace
 
 [cxx]
   gtest_dep = //third-party/cxx:gtest

--- a/antlir/rpm/BUCK
+++ b/antlir/rpm/BUCK
@@ -70,6 +70,14 @@ python_library(
     deps = [
         ":pluggable",
         ":repo_db",
+        third_party.library(
+            "boto3",
+            platform = "python",
+        ),
+        third_party.library(
+            "mysql-connector-python",
+            platform = "python",
+        ),
     ],
 )
 

--- a/antlir/rpm/repo_db.py
+++ b/antlir/rpm/repo_db.py
@@ -438,13 +438,15 @@ class RepoDBContext(AbstractContextManager):
                     # don't want to import MySQLdb here, since it is an
                     # optional dependency for this specific module.
                     if (
-                        type(ex).__qualname__ != "OperationalError"
+                        type(ex).__qualname__
+                        not in ("OperationalError", "ProgrammingError")
                         or type(ex).__module__
                         not in [
                             "sqlite3",
                             # MySQLdb versions vary the module path.
                             "_mysql_exceptions",
                             "MySQLdb._exceptions",
+                            "mysql.connector.errors",
                         ]
                         or "already exists" not in str(ex.args)
                     ):

--- a/antlir/rpm/storage/BUCK
+++ b/antlir/rpm/storage/BUCK
@@ -27,7 +27,6 @@ python_library(
         "//antlir/rpm:open_url",
         third_party.library(
             "boto3",
-            "boto3",
             platform = "python",
         ),
     ],

--- a/snapshot/BUCK
+++ b/snapshot/BUCK
@@ -1,6 +1,19 @@
 load("//antlir/bzl:oss_shim.bzl", "buck_command_alias", "export_file")
 load("//antlir/bzl:rpm_repo_snapshot.bzl", "rpm_repo_snapshot")
 
+# The snapshot described in this file can only be updated by an AWS machine
+# that is in the correct VPC and has the necessary IAM role to write to the
+# Antlir database and S3 bucket. The configuration parameters can be altered to
+# run on a custom database for other organizations hosting their own snapshots.
+db_config = {
+    "dbname": "snapshots",
+    "endpoint": "rpm-snapshots.cic1w82jlt6n.us-east-2.rds.amazonaws.com",
+    "kind": "rds_mysql",
+    "port": 3306,
+    "region": "us-east-2",
+    "user": "snapshot_writer",
+}
+
 fedora_storage_config = {
     "bucket": "antlir",
     "key": "s3",
@@ -14,14 +27,14 @@ export_file(
 )
 
 # Command to snapshot all the specified Fedora repos.
-# Currently just snapshot the Fedora32 Everything 'os' repository, but this will be
+# Currently just snapshot the Fedmra32 Everything 'os' repository, but this will be
 # expanded to support more Fedora versions and repos.
 buck_command_alias(
     name = "snapshot-fedora",
     args = [
         "--snapshot-dir=snapshot/fedora",
         "--gpg-key-allowlist-dir=snapshot/fedora/repos/everything-os/gpg_keys",
-        '--db={"kind": "sqlite", "db_path": "snapshot/snapshots.sql3"}',
+        "--db={}".format(repr(db_config)),
         "--threads=16",
         "--storage={}".format(repr(fedora_storage_config)),
         "--one-universe-for-all-repos=fedora",

--- a/third-party/fedora33/kernel/kernels.bzl
+++ b/third-party/fedora33/kernel/kernels.bzl
@@ -12,6 +12,6 @@ kernels = {
             variant = 301,
             rc = None,
             flavor = "",
-        )
+        ),
     ),
 }

--- a/third-party/python/BUCK
+++ b/third-party/python/BUCK
@@ -99,3 +99,9 @@ pypi_package(
         ":botocore",
     ],
 )
+
+pypi_package(
+    name = "mysql-connector-python",
+    sha256 = "5517802ed71c4d07cfd7e73d4301d45410cdf4b1982e457b4c6abeaa6cf63fac",
+    url = "https://files.pythonhosted.org/packages/95/35/c265446061e0821f50d78f44bf2f266a765755268533fa591b516d433f99/mysql_connector_python-8.0.22-cp38-cp38-manylinux1_x86_64.whl",
+)

--- a/third-party/python/pypi.bzl
+++ b/third-party/python/pypi.bzl
@@ -1,15 +1,15 @@
 load("//antlir/bzl:oss_shim.bzl", "http_file")
 
 def pypi_package(
-    name,
-    url,
-    sha256,
-    deps=None):
+        name,
+        url,
+        sha256,
+        deps = None):
     http_file(
         name = "{}-download".format(name),
         sha256 = sha256,
         urls = [url],
-        visibility = []
+        visibility = [],
     )
 
     native.prebuilt_python_library(


### PR DESCRIPTION
Summary:
The sqlite file is already huge and will just continue to grow, which is not
ideal to track in git.

Additionally, moving the snapshot to RDS is much more analogous to our internal
snapshot mysql dbs, and allows us to just track the resulting snapshot storage
id in the repository, making it easier to automate creating and landing diffs
for a regular upstream snapshot cadence.

The connection is only accessible within our AWS VPC, and is restricted with
IAM policies, which the automated snapshot (lambda,service,etc) will eventually
have access to. The database's initial contents were populated from the
existing sqlite database before I deleted it from the repository.

Differential Revision: D25317450

