### PR TITLE
antlir oss [easy]: fix kernel rpm target

### DIFF
--- a/antlir/bzl/oss_shim_impl.bzl
+++ b/antlir/bzl/oss_shim_impl.bzl
@@ -441,7 +441,7 @@ shim = struct(
     http_file = _http_file,
     kernel_get = struct(
         base_target = "//third-party/fedora33/kernel",
-        default = _kernel("5.8.15-301.fc31.x86_64"),
+        default = _kernel("5.8.15-301.fc33.x86_64"),
         get = _kernel,
         versions = kernels,
     ),

--- a/antlir/compiler/items/tests/test_install_file.py
+++ b/antlir/compiler/items/tests/test_install_file.py
@@ -213,3 +213,31 @@ class InstallFileItemTestCase(BaseItemTestCase):
                 ],
                 render_subvol(subvol),
             )
+
+    def test_install_file_large_batched_chmod(self):
+        # Create a large number of files with long names to intentionally
+        # overflow the normal size limit of the chmod call
+        with temp_dir() as td:
+            arg_max = os.sysconf(os.sysconf_names["SC_ARG_MAX"])
+            paths = [
+                f"{td}/{i:0120d}"
+                for i in range(10 + arg_max // (len(td) + 1 + 120))
+            ]
+            # simple check that the large exec behavior would otherwise be
+            # triggered by this test case
+            self.assertGreater(len("\0".join(paths)), arg_max)
+            for path in paths:
+                open(path, "w").close()
+
+            dir_item = _install_file_item(
+                from_target="t",
+                source={"source": td},
+                dest="/d",
+            )
+
+            with TempSubvolumes(sys.argv[0]) as temp_subvolumes:
+                subvol = temp_subvolumes.create("large-chmod")
+                # other tests ensure that the behavior is correct, this test
+                # simply needs to ensure that the calls to `chmod` don't blow
+                # up when there are too many files
+                dir_item.build(subvol, DUMMY_LAYER_OPTS)

--- a/third-party/fedora33/kernel/BUCK
+++ b/third-party/fedora33/kernel/BUCK
@@ -1,62 +1,20 @@
-load("//antlir/bzl:oss_shim.bzl", "buck_genrule", "http_file")
 load("//antlir/bzl:vm.bzl", "vm")
-load("//antlir/vm:kernel.bzl", "build_kernel_artifacts")
 load("//antlir/vm/initrd:defs.bzl", "initrd")
+load(":defs.bzl", "fedora_kernel")
 
-http_file(
-    name = "5.8.15-301.fc31.x86_64-core.rpm",
-    sha256 = "d8f263272b87175ece88f200f6b843c89c4294ee2abf630ff38485abac90fb47",
-    urls = [
-        "http://mirrors.kernel.org/fedora/releases/33/Everything/x86_64/os/Packages/k/kernel-core-5.8.15-301.fc33.x86_64.rpm",
-    ],
-    visibility = [],
-)
-
-http_file(
-    name = "5.8.15-301.fc31.x86_64-headers.rpm",
-    sha256 = "dfbb5d9dba165d13a9a5210cce54f2af13976ff34ae8bc63c02bdc7180719bd1",
-    urls = [
-        "http://mirrors.kernel.org/fedora/releases/33/Everything/x86_64/os/Packages/k/kernel-headers-5.8.11-300.fc33.x86_64.rpm",
-    ],
-)
-
-http_file(
-    name = "5.8.15-301.fc31.x86_64-devel.rpm",
-    sha256 = "206daac2df7f704a0811c1ec7dd4833ae346315a351e2795a6d3710826440d40",
-    urls = [
-        "http://mirrors.kernel.org/fedora/releases/33/Everything/x86_64/os/Packages/k/kernel-devel-5.8.15-301.fc33.x86_64.rpm",
-    ],
-)
-
-buck_genrule(
-    name = "5.8.15-301.fc31.x86_64-rpm-exploded",
-    out = ".",
-    cmd = """
-        cd $OUT
-        rpm2cpio $(location :5.8.15-301.fc31.x86_64-core.rpm) | cpio -idm
-        # Removing build and source since they are symlinks that do not exist on the host
-        rm -r lib/modules/5.8.15-301.fc31.x86_64/build lib/modules/5.8.15-301.fc31.x86_64/source
-    """,
-)
-
-buck_genrule(
-    name = "5.8.15-301.fc31.x86_64-vmlinuz",
-    out = "vmlinuz-5.8.15-301.fc31.x86_64",
-    cmd = "cp --reflink=auto $(location :5.8.15-301.fc31.x86_64-rpm-exploded)/lib/modules/5.8.15-301.fc31.x86_64/vmlinuz $OUT",
-)
-
-# Build kernel artifacts and get back a shape instance
-kernel = build_kernel_artifacts(
-    devel_rpm = ":5.8.15-301.fc31.x86_64-devel.rpm",
-    include_vmlinux = False,
-    rpm_exploded = ":5.8.15-301.fc31.x86_64-rpm-exploded",
-    uname = "5.8.15-301.fc31.x86_64",
+kernel = fedora_kernel(
+    core_sha256 = "d8f263272b87175ece88f200f6b843c89c4294ee2abf630ff38485abac90fb47",
+    devel_sha256 = "206daac2df7f704a0811c1ec7dd4833ae346315a351e2795a6d3710826440d40",
+    fedora_release = 33,
+    headers_sha256 = "dfbb5d9dba165d13a9a5210cce54f2af13976ff34ae8bc63c02bdc7180719bd1",
+    headers_version = "5.8.11-300.fc33.x86_64",
+    kernel = "5.8.15-301.fc33.x86_64",
 )
 
 initrd(kernel = kernel)
 
 vm.run(
-    name = "5.8.15-301.fc31.x86_64",
+    name = "5.8.15-301.fc33.x86_64",
     vm_opts = vm.opts(
         kernel = kernel,
     ),

--- a/third-party/fedora33/kernel/defs.bzl
+++ b/third-party/fedora33/kernel/defs.bzl
@@ -1,0 +1,59 @@
+load("//antlir/bzl:oss_shim.bzl", "buck_genrule", "http_file")
+load("//antlir/vm:kernel.bzl", "build_kernel_artifacts")
+
+def fedora_kernel(
+        kernel,
+        fedora_release,
+        core_sha256,
+        headers_sha256,
+        devel_sha256,
+        headers_version = None):
+    if not headers_version:
+        headers_version = kernel
+    url_f = "https://mirrors.kernel.org/fedora/releases/{}/Everything/x86_64/os/Packages/k/kernel-{}-{}.rpm"
+    http_file(
+        name = kernel + "-core.rpm",
+        sha256 = core_sha256,
+        urls = [
+            url_f.format(fedora_release, "core", kernel),
+        ],
+    )
+    http_file(
+        name = kernel + "-headers.rpm",
+        sha256 = headers_sha256,
+        urls = [
+            url_f.format(fedora_release, "headers", headers_version),
+        ],
+    )
+    http_file(
+        name = kernel + "-devel.rpm",
+        sha256 = devel_sha256,
+        urls = [
+            url_f.format(fedora_release, "devel", kernel),
+        ],
+    )
+
+    buck_genrule(
+        name = kernel + "-rpm-exploded",
+        out = ".",
+        cmd = """
+            cd $OUT
+            rpm2cpio $(location :{kernel}-core.rpm) | cpio -idm
+            # Removing build and source since they are symlinks that do not exist on the host
+            rm -rf lib/modules/{kernel}/build lib/modules/{kernel}/source
+        """.format(kernel = kernel),
+    )
+
+    buck_genrule(
+        name = kernel + "-vmlinuz",
+        out = "vmlinuz-" + kernel,
+        cmd = "cp --reflink=auto $(location :{kernel}-rpm-exploded)/lib/modules/{kernel}/vmlinuz $OUT".format(kernel = kernel),
+    )
+
+    # Build kernel artifacts and get back a shape instance
+    return build_kernel_artifacts(
+        devel_rpm = ":{}-devel.rpm".format(kernel),
+        include_vmlinux = False,
+        rpm_exploded = ":{}-rpm-exploded".format(kernel),
+        uname = kernel,
+    )

--- a/third-party/fedora33/kernel/kernels.bzl
+++ b/third-party/fedora33/kernel/kernels.bzl
@@ -1,10 +1,10 @@
 kernels = {
-    "5.8.15-301.fc31.x86_64": struct(
-        uname = "5.8.15-301.fc31.x86_64",
+    "5.8.15-301.fc33.x86_64": struct(
+        uname = "5.8.15-301.fc33.x86_64",
         artifacts = struct(
-            devel = "//third-party/fedora33/kernel:5.8.15-301.fc31.x86_64-devel.rpm",
-            modules = "//third-party/fedora33/kernel:5.8.15-301.fc31.x86_64-modules",
-            vmlinuz = "//third-party/fedora33/kernel:5.8.15-301.fc31.x86_64-vmlinuz",
+            devel = "//third-party/fedora33/kernel:5.8.15-301.fc33.x86_64-devel.rpm",
+            modules = "//third-party/fedora33/kernel:5.8.15-301.fc33.x86_64-modules",
+            vmlinuz = "//third-party/fedora33/kernel:5.8.15-301.fc33.x86_64-vmlinuz",
         ),
         version = struct(
             major = (5, 8),


### PR DESCRIPTION
Summary: This likely broke with D25289020 (https://github.com/facebookincubator/antlir/commit/580473fa64da7f02faf99bfa08874a74f67c09b0) which upgraded to the fedora 33 kernel.

Reviewed By: snarkmaster

Differential Revision: D25400464

