### PR TITLE
antlir oss: fix docs publishing (for real this time)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,22 +9,24 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
 
       - name: Add tools/ to PATH
         run: echo "$(pwd)/tools" >> $GITHUB_PATH
 
       - name: Install docs tools
         run: yarn
-        working-directory: website
+        working-directory: antlir/website
 
       - name: Build docs
         run: yarn build
-        working-directory: website
+        working-directory: antlir/website
 
       - name: Deploy to gh-pages
         uses: JamesIves/github-pages-deploy-action@3.6.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
-          FOLDER: website/build
+          FOLDER: antlir/website/build
           CLEAN: true

--- a/antlir/website/gen/bzldoc.py
+++ b/antlir/website/gen/bzldoc.py
@@ -175,7 +175,7 @@ def bzldoc():
 
     bzls = args.bzls
     outdir = args.outdir
-    assert outdir.exists()
+    os.makedirs(outdir, exist_ok=True)
 
     repo_root = find_buck_cell_root()
 

--- a/antlir/website/package.json
+++ b/antlir/website/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "yarn bzldoc && docusaurus start",
     "build": "yarn bzldoc && yarn docusaurus build",
-    "bzldoc": "buck run //antlir/website/gen:bzldoc -- ../bzl/*.bzl ../bzl/**/*.bzl ./docs/api/",
+    "bzldoc": "cd .. && buck run //antlir/website/gen:bzldoc -- $(pwd)/bzl/*.bzl $(pwd)/bzl/**/*.bzl $(pwd)/website/docs/api/",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "ci": "yarn lint && yarn prettier:diff",


### PR DESCRIPTION
Summary:
Clearly I cannot get this working internally only, so here goes.

There are some weird differences between the globbing as used by github
actions and sandcastle, so explicitly use `$(pwd)` instead.

Test Plan:
pushed this to the `main` of my fork and the workflow ran successfully

Reviewers: lesha, lsalis

Subscribers:

Tasks:

Tags: