### PR TITLE
antlir: fix nobody user issues in test-run

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -36,7 +36,7 @@
   # these excluded labels you must run `buck test` with the `--always-exclude`
   # option.
   # ie:  `buck test //antlir/rpm:test-yum-dnf-from-snapshot --always-exclude`
-  excluded_labels = exclude_test_if_transitive_dep
+  excluded_labels = exclude_test_if_transitive_dep, disabled
 
 [antlir]
   build_appliance_default = //images/appliance:stable_build_appliance

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,11 @@ jobs:
         run: buck build //...
 
       - name: Run tests
-        run: buck test //... --exclude disabled
+        # Run all tests, excluding any that are disabled (mainly the hidden
+        # layer tests)
+        # TODO(vmagro): re-enable vm tests soon, right now they are
+        # known-broken due to some missing infra
+        run: buck test --always-exclude $(buck query 'set(//...) - set(//antlir/vm/...)')
         # Not all tests pass yet, so we should be giving green signal as long
         # as the build passed in the meantime.
         continue-on-error: true

--- a/antlir/BUCK
+++ b/antlir/BUCK
@@ -14,6 +14,9 @@ python_unittest(
     srcs = [
         "tests/test_common.py",
     ],
+    deps = [
+        ":common",
+    ],
 )
 
 python_library(

--- a/antlir/bzl/tests/BUCK
+++ b/antlir/bzl/tests/BUCK
@@ -46,6 +46,7 @@ image.python_unittest(
     container_opts = image.opts(shadow_proxied_binaries = True),
     run_as_user = "root",
     deps = [
+        "//antlir:config",
         "//antlir:fs_utils",
         "//antlir/rpm:find_snapshot",
     ],

--- a/antlir/bzl/tests/test_image_unittest_repo_server.py
+++ b/antlir/bzl/tests/test_image_unittest_repo_server.py
@@ -8,8 +8,11 @@ import os
 import subprocess
 import unittest
 
+from antlir.config import load_repo_config
 from antlir.fs_utils import temp_dir
 from antlir.rpm.find_snapshot import snapshot_install_dir
+
+REPO_CFG = load_repo_config()
 
 
 class ImageUnittestTestRepoServer(unittest.TestCase):
@@ -17,7 +20,7 @@ class ImageUnittestTestRepoServer(unittest.TestCase):
         snapshot_dir = snapshot_install_dir(
             "//antlir/rpm:repo-snapshot-for-tests"
         )
-        for prog in ("dnf", "yum"):
+        for prog in REPO_CFG.rpm_installers_supported:
             with temp_dir() as td:
                 os.mkdir(td / ".meta")
                 subprocess.check_call(

--- a/antlir/compiler/items/BUCK
+++ b/antlir/compiler/items/BUCK
@@ -118,6 +118,7 @@ python_unittest(
     },
     deps = [
         ":rpm_action_base_testlib",
+        "//antlir:config",
         "//antlir:find_built_subvol",
         "//antlir:testlib_layer_resource",
     ],

--- a/antlir/compiler/items/tests/test_rpm_action.py
+++ b/antlir/compiler/items/tests/test_rpm_action.py
@@ -8,6 +8,7 @@ import os
 import sys
 from contextlib import contextmanager
 
+from antlir.config import load_repo_config
 from antlir.fs_utils import Path, temp_dir
 from antlir.rpm.rpm_metadata import RpmMetadata, compare_rpm_versions
 from antlir.rpm.yum_dnf_conf import YumDnf
@@ -22,6 +23,9 @@ from .rpm_action_base import RpmActionItemTestBase
 
 
 DUMMY_LAYER_OPTS_BA = get_dummy_layer_opts_ba()
+
+
+REPO_CFG = load_repo_config()
 
 
 class InstallerIndependentRpmActionItemTest(BaseItemTestCase):
@@ -44,6 +48,12 @@ class InstallerIndependentRpmActionItemTest(BaseItemTestCase):
 
 class RpmActionItemTestImpl(RpmActionItemTestBase):
     "Subclasses run these tests with concrete values of `self._YUM_DNF`."
+
+    def setUp(self):
+        if self._YUM_DNF.value not in REPO_CFG.rpm_installers_supported:
+            self.skipTest(
+                f"'{self._YUM_DNF}' not in '{REPO_CFG.rpm_installers_supported}'"
+            )
 
     def test_rpm_action_item_build_appliance(self):
         self._check_rpm_action_item_build_appliance(
@@ -293,6 +303,6 @@ class DnfRpmActionItemTestCase(RpmActionItemTestImpl, BaseItemTestCase):
 
     def test_rpm_action_item_install_local_dnf(self):
         with self._test_rpm_action_item_install_local_setup() as r:
-            pop_path(r, "var/lib/yum")
-            pop_path(r, "var/log/yum.log")
+            pop_path(r, "var/lib/yum", None)
+            pop_path(r, "var/log/yum.log", None)
             check_common_rpm_render(self, r, "dnf")

--- a/antlir/compiler/tests/test_image_layer.py
+++ b/antlir/compiler/tests/test_image_layer.py
@@ -349,7 +349,7 @@ class ImageLayerTestCase(unittest.TestCase):
                 pop_path(r, "rpm_test"),
             )
 
-            check_common_rpm_render(self, r, "yum")
+            check_common_rpm_render(self, r, REPO_CFG.rpm_installer_default)
 
     def _check_installed_files_bar(self, r):
         (  # We don't know the exact sizes because these 2 may be wrapped

--- a/antlir/nspawn_in_subvol/plugins/BUCK
+++ b/antlir/nspawn_in_subvol/plugins/BUCK
@@ -74,7 +74,10 @@ python_unittest(
         (100, ":yum_dnf_versionlock"),
         (100, "//antlir/nspawn_in_subvol:plugin_hooks"),
     ],
-    deps = [":testlib_rpm_base"],
+    deps = [
+        ":testlib_rpm_base",
+        "//antlir/rpm:common",
+    ],
 )
 
 python_library(

--- a/antlir/nspawn_in_subvol/plugins/tests/test_repo_servers.py
+++ b/antlir/nspawn_in_subvol/plugins/tests/test_repo_servers.py
@@ -13,9 +13,13 @@ import unittest
 from contextlib import contextmanager
 
 from antlir.common import check_popen_returncode
+from antlir.config import load_repo_config
 
 from .. import launch_repo_servers
 from .rpm_base import RpmNspawnTestBase
+
+
+REPO_CFG = load_repo_config()
 
 
 class TestImpl:
@@ -58,6 +62,12 @@ class TestImpl:
                 (seen_repomds, expected_repomds),
             )
         check_popen_returncode(tee)
+
+    def setUp(self):
+        if self._PROG not in REPO_CFG.rpm_installers_supported:
+            self.skipTest(
+                f"'{self._PROG}'' not in '{REPO_CFG.rpm_installers_supported}'"
+            )
 
     def test_repo_servers(self):
         # Get basic coverage for our non-trivial debug log code.

--- a/antlir/nspawn_in_subvol/plugins/tests/test_yum_dnf_versionlock.py
+++ b/antlir/nspawn_in_subvol/plugins/tests/test_yum_dnf_versionlock.py
@@ -9,6 +9,9 @@ import subprocess
 import tempfile
 from contextlib import contextmanager
 from typing import Iterable
+from unittest import skipIf
+
+from antlir.rpm.common import yum_is_dnf, has_yum
 
 from .rpm_base import RpmNspawnTestBase
 
@@ -64,5 +67,6 @@ class DnfVersionlockTestCase(TestImpl, RpmNspawnTestBase):
     _PROG = "dnf"
 
 
+@skipIf(yum_is_dnf() or not has_yum(), "yum == dnf or yum missing")
 class YumVersionlockTestCase(TestImpl, RpmNspawnTestBase):
     _PROG = "yum"

--- a/antlir/nspawn_in_subvol/tests/test_run.py
+++ b/antlir/nspawn_in_subvol/tests/test_run.py
@@ -344,7 +344,12 @@ class NspawnTestCase(NspawnTestBase):
     def test_hostname(self):
         ret = self._nspawn_in(
             (__package__, "test-layer"),
-            ["--hostname=test-host.com", "--", "/bin/hostname"],
+            [
+                "--hostname=test-host.com",
+                "--",
+                "cat",
+                "/proc/sys/kernel/hostname",
+            ],
             stdout=subprocess.PIPE,
             check=True,
         )

--- a/antlir/tests/subvol_helpers.py
+++ b/antlir/tests/subvol_helpers.py
@@ -30,12 +30,12 @@ def render_subvol(subvol: Subvol):
         subvol.set_readonly(was_readonly)
 
 
-def pop_path(render, path):
+def pop_path(render, path, *default):
     assert not isinstance(path, bytes), path  # Renderings are `str`
     parts = path.lstrip("/").split("/")
     for part in parts[:-1]:
         render = render[1][part]
-    return render[1].pop(parts[-1])
+    return render[1].pop(parts[-1], *default)
 
 
 # Future: this isn't really the right place for it, but for now we just have

--- a/images/appliance/BUCK
+++ b/images/appliance/BUCK
@@ -3,7 +3,7 @@ load("//antlir/bzl:image.bzl", "image")
 load("//antlir/bzl:oss_shim.bzl", "http_file")
 load("//antlir/bzl:rpm_repo_snapshot.bzl", "default_rpm_repo_snapshot_for", "install_rpm_repo_snapshot", "set_up_rpm_repo_snapshots")
 
-stable_build_appliance_sha = "3643e1e66281def91655202a772af41c8ac8274291dbd0e35231d8d6073fbeb8"
+stable_build_appliance_sha = "a6c024a253199ed673b05510bff8c6a76ebd5c0491c139201450e2f088dcad6e"
 
 http_file(
     name = "stable_build_appliance.sendstream.zst",
@@ -44,6 +44,7 @@ image.layer(
             "btrfs-progs",
             "coreutils",
             "dnf",  # For installing rpms
+            "dnf-command(versionlock)",
             "dnf-utils",
             "gcc",  # build code in foreign_layers
             "iproute",


### PR DESCRIPTION
Summary:
nobody may have different ids on the host vs in the image (for example,
when not using a centos/fedora host to build an image)

This fixes both test_boot_unprivileged_user and test_logs_directory
which used `whoami`

Differential Revision: D25718776

