### PR TITLE
antlir oss: workflow to build and upload ba

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,15 +40,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          # Annoyingly, the same python version used to build the stable ba
-          # must also exist in the host.
-          # TODO: figure out how python version is leaking from the BA -> host.
           python-version: '~3.9'
-
-      # .buckconfig explicitly references /usr/bin/python3, so the desired
-      # version of python must be present there
-      - name: Symlink Python3.9
-        run: sudo ln -sf $(which python3.9) /usr/bin/python3
 
       - name: Fetch buck
         run: buck --version

--- a/.github/workflows/update-build-appliance.yml
+++ b/.github/workflows/update-build-appliance.yml
@@ -1,0 +1,108 @@
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'images/appliance/BUCK'
+      - '.github/workflows/update-build-appliance.yml'
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Checkout submodules
+        run: git submodule update --init
+
+      - name: Install system dependencies
+        run: sudo apt-get install -y attr libcap-ng-dev systemd-container
+
+      - name: Set up $PATH
+        run: echo $(pwd)/tools > $GITHUB_PATH
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '~3.9'
+
+      - name: Fetch buck
+        run: buck --version
+
+      - name: Build appliance sendstream
+        run: buck build -c python.package_style=standalone --out stable_build_appliance.sendstream.zst //images/appliance:bootstrap_build_appliance.sendstream.zst
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_GH_ACTIONS_USER_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_GH_ACTIONS_USER_SECRET_KEY }}
+          aws-region: us-east-2
+
+      - name: Upload to S3
+        run: |
+          set -euo pipefail
+          sha="$(sha256sum stable_build_appliance.sendstream.zst | awk '{ print $1 }')"
+          aws s3 cp stable_build_appliance.sendstream.zst "s3://antlir/images/appliance/stable_build_appliance.sendstream.zst.$sha"
+          rm stable_build_appliance.sendstream.zst
+          echo "stable_build_appliance_sha = \"$sha\"" > images/appliance/stable_appliance.bzl
+
+      - name: Commit new hash
+        run: |
+          set -euo pipefail
+          git checkout -B upload-stable-build-appliance main
+          git add images/appliance/stable_appliance.bzl
+          git config user.name GitHub
+          git config user.email noreply@github.com
+          git commit -F- <<EOF
+          antlir oss: update stable build appliance
+
+          Summary:
+          Update the stable build appliance using the most recent changes on
+          the 'main' branch (specifically the commit ${{ github.sha }}).
+          Currently the image artifacts referenced here are permanent,
+          however at some point automation may delete images that are older
+          than 6 months, which is our reproducibility target.
+
+          This version of the build appliance has already been validated by
+          building the base image(s) shipped with Antlir.
+
+          antlir_oss oncall: please import and land this PR internally, it
+          will then automatically be closed.
+
+          https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EOF
+
+      # Validate the appliance after committing the new stable hash. This
+      # avoids inplace python shenanigans as well as actually exercising the
+      # new stable build appliance in the same manner as normal use
+      # (downloading it from S3)
+      - name: Validate new appliance
+        run: buck build //images/base/...
+
+      - name: Push commit
+        run:
+          # force pushing will update any PR that already exists
+          git push -f -u origin upload-stable-build-appliance
+
+      - name: Submit PR
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            let pulls = await github.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: context.repo.owner + ':upload-stable-build-appliance',
+            });
+            let pull = pulls.data.shift();
+            // only create a new pull if one doesn't already exist
+            if (!pull) {
+              await github.pulls.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: 'Update stable build appliance',
+                head: 'upload-stable-build-appliance',
+                base: 'main',
+              });
+            }


### PR DESCRIPTION
Summary:
Create a GitHub Actions workflow that builds and uploads a new version of the
stable build appliance image in S3 whenever the appliance BUCK file changes (a
proxy for deps, since it doesn't have any feature deps, just the compiler).

Note that commits that simply update the revision (such as the automatic PRs)
do not trigger this rebuild flow, since it is in a separate file.

Reviewed By: zeroxoneb

Differential Revision: D25726235

