### PR TITLE
Fix dir permissions bug in test

### DIFF
--- a/antlir/compiler/test_images/BUCK
+++ b/antlir/compiler/test_images/BUCK
@@ -173,7 +173,7 @@ image.feature(
         image.ensure_subdirs_exist("/foo/bar", "baz"),
         image.ensure_dirs_exist(
             "/alpha",
-            mode = "a+rw",
+            mode = "a+rx",
         ),
         image.ensure_subdirs_exist(
             "/alpha",

--- a/antlir/compiler/tests/sample_items.py
+++ b/antlir/compiler/tests/sample_items.py
@@ -96,7 +96,7 @@ ID_TO_ITEM = {
         from_target=T_DIRS, into_dir="/foo/bar", basename="baz"
     ),
     "alpha": EnsureDirsExistItem(
-        from_target=T_DIRS, into_dir="/", basename="alpha", mode="a+rw"
+        from_target=T_DIRS, into_dir="/", basename="alpha", mode="a+rx"
     ),
     "alpha/beta": EnsureDirsExistItem(
         from_target=T_DIRS, into_dir="/alpha", basename="beta", mode="a+rwx"


### PR DESCRIPTION
Summary: As pointed out on https://www.internalfb.com/diff/D25682158 (https://github.com/facebookincubator/antlir/commit/b72001f56b72503c35787bbb9d21f95d92ea168f)?dst_version_fbid=393455321928372&transaction_fbid=550513229241052 this inadvertently broke a test so fixed it by changing permissions of the parent dir.

Reviewed By: vmagro

Differential Revision: D25805740

