### PR TITLE
antlir oss: fix build of test-fs-utils-path-resource-{zip,fastzip}

### DIFF
--- a/antlir/BUCK
+++ b/antlir/BUCK
@@ -67,7 +67,7 @@ export_file(
     python_unittest(
         name = "test-fs-utils-path-resource-" + style,
         srcs = {
-            "//antlir:tests/test_fs_utils_path_resource.py": "tests/test_fs_utils_path_resource.py",
+            ":tests/test_fs_utils_path_resource.py": "tests/test_fs_utils_path_resource.py",
         },
         par_style = style,
         resources = {":test-helper-binary": "tests/helper-binary"},

--- a/antlir/bzl/oss_shim_impl.bzl
+++ b/antlir/bzl/oss_shim_impl.bzl
@@ -328,6 +328,7 @@ def _impl_python_unittest(
         par_style = None,
         tags = None,
         resources = None,
+        srcs = None,
         **kwargs):
     native.python_test(
         deps = _normalize_deps(deps),
@@ -335,6 +336,7 @@ def _impl_python_unittest(
         needed_coverage = _normalize_coverage(needed_coverage),
         package_style = _normalize_pkg_style(par_style),
         resources = _normalize_resources(resources),
+        srcs = _invert_dict(srcs),
         **kwargs
     )
 


### PR DESCRIPTION
Summary:
This was using the wrong srcs dict form, I changed it internally and
didn't test it again in a PR because I was incorrectly confident.

Differential Revision: D25808814

