### PR TITLE
antlir oss: test results parser with blocklist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
       - name: Run tests
         # Run all tests, excluding any that are disabled (mainly the hidden
         # layer tests)
+        # TODO(vmagro): cxx_test is excluded because the Buck test runner
+        # assumes that test output ends up in a certain spot on the host.
         # TODO(vmagro): re-enable vm tests soon, right now they are
         # known-broken due to some missing infra.
         run: buck test --always-exclude $(buck query 'set(//...) - kind(cxx_test, //...) - set(//antlir/vm/...)')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,6 @@ jobs:
       - name: Build base image(s)
         run: buck build //images/base/...
 
-      - name: Build all targets
-        run: buck build //...
-
       - name: Run cxx tests
         # TODO(vmagro): cxx_tests are excluded from 'buck test' because the
         # test runner assumes that test output ends up in a certain spot on the
@@ -77,7 +74,11 @@ jobs:
         # assumes that test output ends up in a certain spot on the host.
         # TODO(vmagro): re-enable vm tests soon, right now they are
         # known-broken due to some missing infra.
-        run: buck test --always-exclude $(buck query 'set(//...) - kind(cxx_test, //...) - set(//antlir/vm/...)')
-        # Not all tests pass yet, so we should be giving green signal as long
-        # as the build passed in the meantime.
-        continue-on-error: true
+        # TODO(lsalis): re-enable locale tests when there is a working
+        # alternative to build-locale-archive for fedora
+        run: |
+            buck test --always-exclude $(buck query 'set(//...) - kind(cxx_test, //...) - set(//antlir/vm/...) - set(//antlir/bzl/foreign/locale/...)') --xml tests.xml > buck.log 2> buck.err || true
+            echo Buck stderr
+            cat buck.err
+            echo Test results
+            ./tools/results_parser.py tests.xml

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ buck-image-out
 **/*.swp
 .vscode/
 *.local
+
+__pycache__/

--- a/antlir/BUCK
+++ b/antlir/BUCK
@@ -67,7 +67,7 @@ export_file(
     python_unittest(
         name = "test-fs-utils-path-resource-" + style,
         srcs = {
-            "//antlir:tests/test_fs_utils_path_resource.py": "tests/test_fs_utils_path_resource.py",
+            ":tests/test_fs_utils_path_resource.py": "tests/test_fs_utils_path_resource.py",
         },
         par_style = style,
         resources = {":test-helper-binary": "tests/helper-binary"},

--- a/antlir/bzl/foreign/rpmbuild/tests/BUCK
+++ b/antlir/bzl/foreign/rpmbuild/tests/BUCK
@@ -75,6 +75,8 @@ image.layer(
                 path = "toy.rpm",
             ),
         ]),
+        image.ensure_dirs_exist("/antlir"),
+        image.install(image.source(":toy-rpm", path = "toy.rpm"), "/antlir/toy.rpm"),
     ],
     # The test BA has yum/dnf conf with gpgcheck=1 and localpkg_gpgcheck=1 so
     # installing an unsigned RPM will fail.

--- a/antlir/bzl/foreign/rpmbuild/tests/test_install_signed_toy_rpm.py
+++ b/antlir/bzl/foreign/rpmbuild/tests/test_install_signed_toy_rpm.py
@@ -14,11 +14,19 @@ class InstallSignedToyRpmTestCase(unittest.TestCase):
         self.assertTrue(os.path.exists("/usr/bin/toy_src_file"))
         self.assertFalse(os.path.exists("/antlir-rpm-gpg-keys"))
 
-    def test_rpm_signature(self):
+    def test_installed_rpm_signature(self):
         info = subprocess.check_output(
-            ["rpm", "-q", "toy", "--queryformat", "%{SIGPGP:pgpsig}"], text=True
+            ["rpm", "-qi", "toy"],
+            text=True,
         )
-        self.assertRegex(info, "RSA/SHA256, .*, Key ID 4785998712764132")
+        self.assertIn("Key ID 4785998712764132", info)
+
+    def test_rpm_file_signature(self):
+        info = subprocess.check_output(
+            ["rpm", "-qip", "/antlir/toy.rpm"],
+            text=True,
+        )
+        self.assertIn("Key ID 4785998712764132", info)
 
     def test_key_import(self):
         keys = subprocess.check_output(

--- a/antlir/bzl/oss_shim_impl.bzl
+++ b/antlir/bzl/oss_shim_impl.bzl
@@ -328,6 +328,7 @@ def _impl_python_unittest(
         par_style = None,
         tags = None,
         resources = None,
+        srcs = None,
         **kwargs):
     native.python_test(
         deps = _normalize_deps(deps),
@@ -335,6 +336,7 @@ def _impl_python_unittest(
         needed_coverage = _normalize_coverage(needed_coverage),
         package_style = _normalize_pkg_style(par_style),
         resources = _normalize_resources(resources),
+        srcs = _invert_dict(srcs),
         **kwargs
     )
 

--- a/tools/blocklist.py
+++ b/tools/blocklist.py
@@ -1,0 +1,33 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import re
+
+blocklist = [
+    "//antlir:test-subvol-utils - test_mark_readonly_and_send_to_new_loopback",
+    "//antlir:test-subvol-utils - test_mark_readonly_and_send_to_new_loopback_with_multi_pass",
+    # Not sure why these are failing in OSS, there seems to be something broken
+    # with the shadow code on the OSS BA
+    "//antlir/nspawn_in_subvol/plugins:test-rpm-installer-shadow-paths - test_update_shadowed_file_booted",
+    "//antlir/nspawn_in_subvol/plugins:test-rpm-installer-shadow-paths - test_update_shadowed_file_non_booted",
+    "//antlir/nspawn_in_subvol/plugins:test-rpm-installer-shadow-paths - test_install_via_default_shadowed_installer",
+    "//antlir/nspawn_in_subvol/plugins:test-rpm-installer-shadow-paths - test_install_via_manually_shadowed_installer",
+    "//antlir/nspawn_in_subvol/plugins:test-rpm-installer-shadow-paths - test_install_via_nondefault_snapshot",
+    "//antlir/nspawn_in_subvol/plugins:test-rpm-installer-shadow-paths - test_install_via_nondefault_snapshot_no_shadowing",
+    "//antlir/nspawn_in_subvol/plugins:test-rpm-installer-shadow-paths - test_update_shadowed_file_booted",
+    "//antlir/nspawn_in_subvol/plugins:test-rpm-installer-shadow-paths - test_update_shadowed_file_non_booted",
+    "//antlir/rpm:test-yum-dnf-from-snapshot-shadowed - test_update_shadowed",
+    "//antlir/rpm:test-yum-dnf-from-snapshot-unshadowed - test_update_shadowed",
+    # These tests pass locally on my Arch Desktop, but fail on GH Actions
+    "//antlir/compiler/items:test-items - test_receive_sendstream",
+    "//antlir/compiler/items:test-rpm-action - test_rpm_action_item_auto_downgrade",
+    "//antlir/compiler:test-image-layer - test_foreign_layer",
+    "//antlir/compiler:test-image-layer - test_layer_from_demo_sendstreams",
+    "//antlir/rpm:test-rpm-metadata - test_rpm_metadata_from_subvol",
+    "//antlir:test-subvol-utils - test_receive",
+    "//antlir:test-unshare - test_pid_namespace",
+]
+
+blocklist = [re.compile(b) for b in blocklist]

--- a/tools/results_parser.py
+++ b/tools/results_parser.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Called from GitHub Actions to reformat the results from `buck test` into
+# something more usable
+
+import argparse
+import enum
+import sys
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+
+from blocklist import blocklist
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("xml")
+parser.add_argument("--no-details", action="store_true")
+
+args = parser.parse_args()
+
+tree = ET.parse(args.xml)
+root = tree.getroot()
+
+
+class Status(enum.Enum):
+    PASS = "PASS"
+    FAIL = "FAIL"
+
+
+@dataclass(frozen=True)
+class Result(object):
+    target: str
+    name: str
+    status: str
+    message: str
+    stacktrace: str
+
+    @property
+    def full_name(self) -> str:
+        return f"{self.target} - {self.name}"
+
+
+results = []
+
+for test in root:
+    target = test.attrib["name"]
+    for result in test:
+        results.append(
+            Result(
+                target=target,
+                name=result.attrib["name"],
+                status=Status(result.attrib["status"]),
+                message=result.find("message").text,
+                stacktrace=result.find("stacktrace").text,
+            )
+        )
+
+
+# filter out tests that are disabled with the OSS blocklist
+blocked_tests = [
+    case
+    for case in results
+    if any(block.match(case.full_name) for block in blocklist)
+]
+results = [
+    case
+    for case in results
+    if not any(block.match(case.full_name) for block in blocklist)
+]
+
+passed_count = sum(1 for case in results if case.status == Status.PASS)
+failed_count = sum(1 for case in results if case.status == Status.FAIL)
+print(f"{len(results)} total test cases")
+
+print(f"\033[92mPASSED {passed_count} test cases:")
+for case in results:
+    if case.status != Status.PASS:
+        continue
+    print(f"\033[92m  {case.full_name}")
+
+print("\033[0m")
+
+print(f"{len(blocked_tests)} disabled tests still ran")
+for case in blocked_tests:
+    print(f"  {case.full_name} - {case.status}")
+
+# print failures at the end since that is more visible on GitHub Actions
+print(f"\033[91mFAIL {failed_count} test cases:")
+for case in results:
+    if case.status != Status.FAIL:
+        continue
+    print(f"\033[91m  {case.full_name}")
+    if not args.no_details:
+        details = (
+            case.message.splitlines()
+            + ["\n"]
+            + case.stacktrace.splitlines()
+            + ["\n\n"]
+        )
+        details = "\n".join(["\033[91m    " + line for line in details])
+        print(details)
+
+print("\033[0m")
+
+if failed_count:
+    sys.exit(1)


### PR DESCRIPTION
Summary:
We need a mechanism similar to TestConsole's test disable feature in
OSS.
Initial blocklist is the tests that are currently failing, so that all
signal will be expected to be green going forward (we should still try
to fix the failures, but this will make it more obvious if new ones are
introduced)

Differential Revision: D25827791

