### PR TITLE
shape.bzl: add ability to render shapes with jinja2 templates

### DIFF
--- a/antlir/BUCK
+++ b/antlir/BUCK
@@ -500,3 +500,14 @@ python_unittest(
         ":serialize-targets-and-outputs-library",
     ],
 )
+
+python_library(
+    name = "render_template",
+    srcs = ["render_template.py"],
+    deps = [
+        third_party.library(
+            "jinja2",
+            platform = "python",
+        ),
+    ],
+)

--- a/antlir/bzl/template.bzl
+++ b/antlir/bzl/template.bzl
@@ -1,0 +1,37 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@bazel_skylib//lib:types.bzl", "types")
+load("//antlir/bzl:oss_shim.bzl", "python_binary")
+
+def template(
+        name,
+        main,
+        includes = None):
+    """
+Create a template target from jinaj2 template files.
+The named target is a python_binary that renders templates from JSON data
+provided on stdin.
+The `main` template is rendered with the input data, and has access to inherit
+from / include any of the templates listed in `includes`.
+"""
+    if not includes:
+        includes = {}
+    if types.is_list(includes):
+        includes = {inc: paths.basename(inc) for inc in includes}
+
+    resources = {
+        main: "main.jinja2",
+    }
+    resources.update(includes)
+
+    python_binary(
+        name = name,
+        main_module = "antlir.render_template",
+        deps = ["//antlir:render_template"],
+        base_module = "antlir.templates",
+        resources = resources,
+    )

--- a/antlir/bzl/tests/shapes/BUCK
+++ b/antlir/bzl/tests/shapes/BUCK
@@ -10,7 +10,7 @@ affiliations_t = shape.shape(faction = str)
 
 # A shape that references buck targets
 lightsaber_t = shape.shape(
-    color = str,
+    color = shape.enum("red", "green", "blue"),
     target = shape.target(optional = True),
     layer_target = shape.layer(optional = True),
 )

--- a/antlir/bzl/tests/shapes/BUCK
+++ b/antlir/bzl/tests/shapes/BUCK
@@ -1,6 +1,7 @@
 load("//antlir/bzl:image.bzl", "image")
 load("//antlir/bzl:oss_shim.bzl", "buck_genrule", "python_library", "python_unittest")
 load("//antlir/bzl:shape.bzl", "shape")
+load("//antlir/bzl:template.bzl", "template")
 
 # There are a lot of shapes that are used in test cases.
 # This would rapidly clutter targets in antlir/bzl/tests, so define them all
@@ -213,6 +214,29 @@ python_unittest(
             ),
             shape = hashable_t,
         ): "data.json",
+        shape.render_template(
+            name = "template",
+            instance = shape.new(
+                hashable_t,
+                name = "Stormtrooper",
+                appears_in = [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                ],
+                friends = [
+                    "Vader",
+                    "Palpatine",
+                    "Tarkin",
+                ],
+                metadata = None,
+            ),
+            shape = hashable_t,
+            template = ":example-template",
+        ): "template.txt",
     },
     deps = [
         ":character_collection_t",
@@ -232,6 +256,11 @@ python_unittest(
             classname = "StormtrooperArgsType",
         ),
     ],
+)
+
+template(
+    name = "example-template",
+    main = "template.jinja2",
 )
 
 # construct a file with some shims to allow the python_unittest below to import

--- a/antlir/bzl/tests/shapes/template.jinja2
+++ b/antlir/bzl/tests/shapes/template.jinja2
@@ -1,0 +1,7 @@
+{{ name }} is a character that appears in episode(s) {{ appears_in|join(", ") }} of
+the Star Wars franchise and is friends with
+{%- for friend in friends %}
+ {{friend -}}
+    {% if loop.length > 2 and loop.revindex0 > 1 %},
+    {%- elif not loop.last %} and{%endif%}
+{%- endfor %}.

--- a/antlir/bzl/tests/shapes/test_shape.py
+++ b/antlir/bzl/tests/shapes/test_shape.py
@@ -51,7 +51,7 @@ class TestShape(unittest.TestCase):
         self.assertEqual(
             lightsaber_fixed,
             lightsaber_t(
-                color="green",
+                color=lightsaber_t.types.color.GREEN,
                 target=Target(
                     name=":luke-lightsaber",
                     path=b"/static/target/path",
@@ -159,7 +159,7 @@ class TestShape(unittest.TestCase):
             + "), "
             "lightsaber=shape("
             + (
-                "color='green', "
+                "color=GREEN, "
                 "target=Target("
                 "name=':luke-lightsaber', path=b'/static/target/path'"
                 "), "
@@ -189,7 +189,7 @@ class TestShape(unittest.TestCase):
             "lightsaber=Optional["
             + (
                 "shape("
-                "color=str, "
+                "color=enum, "
                 "target=Optional[Target], "
                 "layer_target=Optional[LayerTarget]"
                 ")"
@@ -245,7 +245,7 @@ class TestShape(unittest.TestCase):
             "name='Obi-Wan Kenobi', "
             "appears_in=(1, 2, 3, 4, 5, 6), "
             "friends=(shape(name='Yoda'), shape(name='Padme Amidala')), "
-            "lightsaber=shape(color='blue', target=None, layer_target=None), "
+            "lightsaber=shape(color=BLUE, target=None, layer_target=None), "
             "callsign=None, "
             "metadata={'species': 'human'}, "
             "affiliations=shape(faction='Jedi Temple'), "
@@ -262,7 +262,7 @@ class TestShape(unittest.TestCase):
             "friends=Tuple[shape(name=str), ...], "
             "lightsaber=Optional[shape("
             + (
-                "color=str, "
+                "color=enum, "
                 "target=Optional[Target], "
                 "layer_target=Optional[LayerTarget]"
             )

--- a/antlir/bzl/tests/shapes/test_shape.py
+++ b/antlir/bzl/tests/shapes/test_shape.py
@@ -315,3 +315,10 @@ class TestShape(unittest.TestCase):
                 __GENERATED_SHAPE__ = True
                 # this is reserved for the type definitions class
                 types: Sequence[str] = ("hello", "world")
+
+    def test_rendered_template(self):
+        self.assertEqual(
+            "Stormtrooper is a character that appears in episode(s) 1, 2, 3, 4, 5, 6 of\n"
+            "the Star Wars franchise and is friends with Vader, Palpatine and Tarkin.",
+            importlib.resources.read_text(__package__, "template.txt"),
+        )

--- a/antlir/bzl/tests/shapes/test_shape_bzl.py
+++ b/antlir/bzl/tests/shapes/test_shape_bzl.py
@@ -30,6 +30,7 @@ class TestShapeBzl(unittest.TestCase):
             ("hello", shape.field(str, optional=True)),
             (None, shape.field(str, optional=True)),
             ({"a": "b"}, shape.dict(str, str)),
+            ("world", shape.enum("hello", "world")),
             ("/hello/world", shape.path()),
             ("@cell//project/path:rule", shape.target()),
             (":rule", shape.target()),
@@ -54,6 +55,7 @@ class TestShapeBzl(unittest.TestCase):
             ("nope", shape.dict(str, str)),
             ("nope", shape.list(str)),
             ("nope", shape.tuple(str)),
+            ("goodbye", shape.enum("hello", "world")),
             (1, shape.path()),
             (2, shape.target()),
             ("invalid_target", shape.target()),
@@ -111,6 +113,14 @@ class TestShapeBzl(unittest.TestCase):
         with self.assertRaises(Fail):
             shape.new(t, tup=("hello", "2"))
 
+    def test_enum(self):
+        t = shape.shape(e=shape.enum("hello", "world"))
+        self.assertEqual(shape.new(t, e="world"), struct(e="world"))
+        with self.assertRaises(Fail):
+            shape.new(t, e="goodbye")
+        with self.assertRaises(Fail):
+            shape.shape(e=shape.enum("hello", 42))
+
     def test_nested_list(self):
         t = shape.shape(lst=shape.list(shape.shape(answer=int)))
         self.assertEqual(
@@ -164,6 +174,7 @@ class TestShapeBzl(unittest.TestCase):
             hello=str,
             world=shape.field(str, optional=True),
             answer=shape.field(int, default=42),
+            enum=shape.enum("hello", "world"),
             file=shape.path(),
             location=shape.target(),
             nested=shape.field(nested, default=shape.new(nested, inner=True)),
@@ -185,6 +196,10 @@ class TestShapeBzl(unittest.TestCase):
   hello: str
   world: Optional[str] = None
   answer: int = 42
+  class Hello_World(Enum):
+    HELLO = 'hello'
+    WORLD = 'world'
+  enum: Hello_World
   file: Path
   location: Target
   class _2UNYP6wnsQdfqkEJEKDmwaEjpoGm8_8tlX3BIHNt_sQ(Shape):

--- a/antlir/render_template.py
+++ b/antlir/render_template.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+import sys
+
+from jinja2 import Environment, PackageLoader
+
+
+def main():
+    env = Environment(
+        loader=PackageLoader(__package__, "templates"),
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+    data = json.load(sys.stdin)
+
+    template = env.get_template("main.jinja2")
+    print(template.render(**data), end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/antlir/shape.py
+++ b/antlir/shape.py
@@ -8,6 +8,7 @@
 # directly, instead it contains supporting implementations for bzl/shape.bzl.
 # See that file for motivations and usage documentation.
 
+import enum
 import importlib.resources
 import os
 from typing import Type, TypeVar
@@ -119,3 +120,16 @@ class LayerTarget(Target):
     @pydantic.validator("subvol", always=True, pre=True)
     def find_layer_as_subvol(cls, v, *, values):  # noqa B902
         return find_built_subvol(values["path"])
+
+
+class Enum(enum.Enum):
+    def __repr__(self):
+        return self.name
+
+    def __eq__(self, o):
+        # it can sometimes be hard to get the exact same instance of this enum
+        # class due to the way the codegen works, so allow comparisons by value
+        # as well as the normal identity-based comparison
+        if hasattr(o, "value"):
+            return self.value == o.value
+        return super().__eq__(o)  # pragma: no cover

--- a/third-party/python/BUCK
+++ b/third-party/python/BUCK
@@ -105,3 +105,9 @@ pypi_package(
     sha256 = "5609aa6da1123fccfae2e8431a67b4146aa7fad5b3889f808df12b110f230937",
     url = "https://files.pythonhosted.org/packages/6f/50/3d7729d64bb23393aa4c166af250a6e6f9def40c90bf0e9af3c5ad25b6f7/pyelftools-0.27-py2.py3-none-any.whl",
 )
+
+pypi_package(
+    name = "jinja2",
+    sha256 = "03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419",
+    url = "https://files.pythonhosted.org/packages/7e/c2/1eece8c95ddbc9b1aeb64f5783a9e07a286de42191b7204d67b7496ddf35/Jinja2-2.11.3-py2.py3-none-any.whl",
+)


### PR DESCRIPTION
Summary:
It can be very useful to have alternate output forms for shapes (for example,
generating a systemd unit file with a buck macro), so add the option to render
a shape struct into a jinja2 template.

This could potentially be useful in lots of other places in Antlir, where
strings are concatenated and variables are replaced in bash scripts in
genrules, but for now this is just targeting shapes.

Reviewed By: zeroxoneb

Differential Revision: D26491153

