### PR TITLE
antlir oss: add attr to build appliance

### DIFF
--- a/images/appliance/BUCK
+++ b/images/appliance/BUCK
@@ -38,6 +38,7 @@ image.layer(
         # with this directory not existing.
         image.ensure_subdirs_exist("/etc", "yum"),
         image.rpms_install([
+            "attr",
             "bsdtar",  # For building reproducible archives
             "btrfs-progs",
             "coreutils",


### PR DESCRIPTION
Summary:
A call to `getfattr` must have snuck in recently, as OSS CI is failign
because it does not exist.

I really need to make the full OSS CI suite run internally...

Test Plan:
```
$ buck build -c antlir.build_appliance_default=//images/appliance:bootstrap_build_appliance //antlir/bzl/tests:systemd_feature-layer
```

Reviewers: lsalis, #twimage

Subscribers:

Tasks:

Tags: