### PR TITLE
antlir oss: run oss tests internally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
         # known-broken due to some missing infra.
         # TODO(lsalis): re-enable locale tests when there is a working
         # alternative to build-locale-archive for fedora
+        # WARNING: keep this query in sync with the internal one in antlir.td
+        # to ensure the same set of tests is run internally and externally
         run: |
             buck test --always-exclude $(buck query 'set(//...) - kind(cxx_test, //...) - set(//antlir/vm/...) - set(//antlir/bzl/foreign/locale/...)') --xml tests.xml > buck.log 2> buck.err || true
             echo Buck stderr

--- a/antlir/bzl/foreign/extractor/BUCK
+++ b/antlir/bzl/foreign/extractor/BUCK
@@ -29,6 +29,8 @@ python_binary(
         "extract.py",
     ],
     main_module = "antlir.bzl.foreign.extractor.extract",
+    # this runs in a layer, so should be self-contained to work in OSS
+    par_style = "xar",
     deps = [
         "//antlir:fs_utils",
         third_party.library(

--- a/third-party/fedora33/busybox/BUCK
+++ b/third-party/fedora33/busybox/BUCK
@@ -14,8 +14,10 @@ buck_genrule(
     bash = """
 set -ue
 mkdir `dirname ${OUT}`
-rpm2cpio $(location :busybox-download) | cpio -idv -D ${TMP} ./sbin/busybox
+pushd ${TMP}
+rpm2cpio $(location :busybox-download) | cpio -idv ./sbin/busybox
 mv ${TMP}/sbin/busybox ${OUT}
+popd
     """,
     visibility = ["PUBLIC"],
 )

--- a/third-party/python/BUCK
+++ b/third-party/python/BUCK
@@ -110,4 +110,23 @@ pypi_package(
     name = "jinja2",
     sha256 = "03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419",
     url = "https://files.pythonhosted.org/packages/7e/c2/1eece8c95ddbc9b1aeb64f5783a9e07a286de42191b7204d67b7496ddf35/Jinja2-2.11.3-py2.py3-none-any.whl",
+    deps = [
+        ":markupsafe",
+        ":setuptools",
+    ],
+)
+
+pypi_package(
+    name = "setuptools",
+    sha256 = "0e86620d658c5ca87a71a283bd308fcaeb4c33e17792ef6f081aec17c171347f",
+    url = "https://files.pythonhosted.org/packages/15/0e/255e3d57965f318973e417d5b7034223f1223de500d91b945ddfaef42a37/setuptools-53.0.0-py3-none-any.whl",
+)
+
+# This is the first platform-dependent wheel (with native code) that we are
+# using in Antlir. This is the most likely to be problematic with Python
+# version changes
+pypi_package(
+    name = "markupsafe",
+    sha256 = "6f1e273a344928347c1290119b493a1f0303c52f5a5eae5f16d74f48c15d4a85",
+    url = "https://files.pythonhosted.org/packages/be/2e/ad118ca191e44dc6f87182310e5be51da71d4b81ac659e5f8d5f18251806/MarkupSafe-1.1.1-cp39-cp39-manylinux2010_x86_64.whl",
 )

--- a/tools/blocklist.py
+++ b/tools/blocklist.py
@@ -30,6 +30,9 @@ blocklist = [
     "//antlir/rpm:test-rpm-metadata - test_rpm_metadata_from_subvol",
     "//antlir:test-subvol-utils - test_receive",
     "//antlir:test-unshare - test_pid_namespace",
+    # This is heavily dependent on build settings, and we only care about the
+    # internal build size (for now anyway)
+    "//antlir/linux/bootloader:base-size - sh_test",
 ]
 
 blocklist = [re.compile(b) for b in blocklist]

--- a/tools/results_parser.py
+++ b/tools/results_parser.py
@@ -96,9 +96,9 @@ for case in results:
     print(f"\033[91m  {case.full_name}")
     if not args.no_details:
         details = (
-            case.message.splitlines()
+            (case.message or "").splitlines()
             + ["\n"]
-            + case.stacktrace.splitlines()
+            + (case.stacktrace or "").splitlines()
             + ["\n\n"]
         )
         details = "\n".join(["\033[91m    " + line for line in details])


### PR DESCRIPTION
Summary:
Previously `antlir-oss-smoke-test` just checked that the Buck target graph
evaluated without any errors. That was a somewhat useful test, but fell short
of actually testing that Antlir would actually work. It was still possible to
subtly break things (like the base build appliance missing `getfattr`
D26519431 (https://github.com/facebookincubator/antlir/commit/ff01d657d8a95bae36ae081b7b18ba73522cfb56)) without realizing.

This diff runs the same test suite that runs on GitHub internally on diffs.
Technically this is not every test, as a small list are known to be broken on
OSS Antlir, and care should be taken to ensure that the exclusion list query is
kept up-to-date in both places

Differential Revision: D26519570

