### PR TITLE
antlir: rewrite extractor in rust

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -52,4 +52,4 @@
   rpm_installer_default = dnf
   rpm_installers_supported = dnf
   host_mounts_allowed_in_targets = //images/appliance:host-build-appliance //images/appliance:features-for-layer-host-build-appliance
-  artifact_key_to_path = build_appliance.newest //images/appliance:stable-build-appliance vm.rootfs.layer.rc //images/base:fedora.vm vm.rootfs.layer.stable //images/base:fedora.vm vm.rootfs.btrfs.rc //images/base:fedora.vm.btrfs vm.rootfs.btrfs.stable //images/base:fedora.vm.btrfs
+  artifact_key_to_path = build_appliance.newest //images/appliance:stable-build-appliance extractor.common_deps //images/appliance:stable-build-appliance vm.rootfs.layer.rc //images/base:fedora.vm vm.rootfs.layer.stable //images/base:fedora.vm vm.rootfs.btrfs.rc //images/base:fedora.vm.btrfs vm.rootfs.btrfs.stable //images/base:fedora.vm.btrfs

--- a/antlir/bzl/genrule/extractor/BUCK
+++ b/antlir/bzl/genrule/extractor/BUCK
@@ -1,42 +1,24 @@
-load("//antlir/bzl:constants.bzl", "REPO_CFG")
-load("//antlir/bzl:image.bzl", "image")
-load("//antlir/bzl:oss_shim.bzl", "python_binary", "third_party")
+load("//antlir/bzl:oss_shim.bzl", "rust_binary", "third_party")
 
-image.layer(
-    name = "extract-tools-layer",
-    # We use the default build appliance with the assumption
-    # that it has all the right tools we need (ie, bin-utils).
-    # Eventually the hope is that the extract binary from ths
-    # tool would end up being incliuded in the BA because
-    # it is so awesome and everyone wants to use it. Until
-    # then we will settle for this.
-    parent_layer = REPO_CFG.build_appliance_default,
-    features = [
-        image.ensure_dirs_exist(
-            "/output",
-        ),
-        image.install_buck_runnable(
-            "//antlir/bzl/genrule/extractor:extract",
-            "/extract",
-        ),
-    ],
-    antlir_rule = "user-internal",
-    visibility = ["//antlir/..."],
-)
-
-python_binary(
+rust_binary(
     name = "extract",
-    srcs = [
-        "extract.py",
-    ],
-    main_module = "antlir.bzl.genrule.extractor.extract",
-    # this runs in a layer, so should be self-contained to work in OSS
-    par_style = "xar",
+    srcs = ["extract.rs"],
+    # this is installed in a wide variety of containers, so do as much static
+    # linkage as possible
+    link_style = "static",
     deps = [
-        "//antlir:fs_utils",
         third_party.library(
-            "pyelftools",
-            platform = "python",
-        ),
+            lib,
+            platform = "rust",
+        )
+        for lib in [
+            "anyhow",
+            "goblin",
+            "once_cell",
+            "slog",
+            "slog_glog_fmt",
+            "structopt",
+            "regex",
+        ]
     ],
 )

--- a/antlir/bzl/genrule/extractor/extract.rs
+++ b/antlir/bzl/genrule/extractor/extract.rs
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#![deny(warnings)]
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{bail, Context, Result};
+use goblin::elf::Elf;
+use once_cell::sync::Lazy;
+use slog::{debug, o, warn};
+use structopt::StructOpt;
+
+static LOGGER: Lazy<slog::Logger> = Lazy::new(|| slog_glog_fmt::facebook_logger().unwrap());
+static LDSO_RE: Lazy<regex::Regex> = Lazy::new(|| {
+    regex::RegexBuilder::new(r#"^\s*(?P<name>.+)\s+=>\s+(?P<path>.+)\s+\(0x[0-9a-f]+\)$"#)
+        .multi_line(true)
+        .build()
+        .unwrap()
+});
+
+trait PathExt {
+    /// Joining absolute paths is annoying, so add an extension trait for
+    /// `force_join` which makes it easy.
+    fn force_join<P: AsRef<Path>>(&self, path: P) -> PathBuf;
+}
+
+impl PathExt for PathBuf {
+    fn force_join<P: AsRef<Path>>(&self, path: P) -> PathBuf {
+        self.as_path().force_join(path)
+    }
+}
+
+impl PathExt for Path {
+    fn force_join<P: AsRef<Path>>(&self, path: P) -> PathBuf {
+        match path.as_ref().is_absolute() {
+            false => self.join(path),
+            true => self.join(
+                path.as_ref()
+                    .strip_prefix("/")
+                    .expect("absolute paths will always start with /"),
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ExtractFile {
+    /// Absolute path (including --src-dir if applicable) where a file should be
+    /// copied from.
+    from: PathBuf,
+    /// Absolute path (not including --dst-dir) where a file should be copied to.
+    to: PathBuf,
+}
+
+#[derive(Debug)]
+struct Binary {
+    // root to consider for this binary, either / or --src-dir
+    root: PathBuf,
+    file: ExtractFile,
+    interpreter: PathBuf,
+}
+
+/// In all the cases that we care about, a library will live under /lib64, but
+/// this directory will be a symlink to /usr/lib64. To avoid build conflicts with
+/// other image layers, replace it.
+fn ensure_usr<P: AsRef<Path>>(path: P) -> PathBuf {
+    match path.as_ref().starts_with("/usr") {
+        true => path.as_ref().to_path_buf(),
+        false => Path::new("/usr/").force_join(path),
+    }
+}
+
+impl Binary {
+    pub fn new(root: PathBuf, src: PathBuf, dst: PathBuf) -> Result<Self> {
+        let bytes =
+            std::fs::read(&src).with_context(|| format!("failed to load binary '{:?}'", &src))?;
+
+        let elf = Elf::parse(&bytes).context("failed to parse elf")?;
+        let interpreter: PathBuf = elf
+            .interpreter
+            .unwrap_or_else(|| {
+                // The PT_INTERP header in an ELF allows setting an explicit
+                // interpreter. However, this may be omitted (as is the case in
+                // some of the libraries we explicitly extract), in which case
+                // we can just use a sensible default.
+                warn!(LOGGER, "no interpreter found for {:?}, using default '/usr/lib64/ld-linux-x86-64.so.2'", &src);
+                "/usr/lib64/ld-linux-x86-64.so.2".into()
+            })
+            .into();
+
+        Ok(Self {
+            root,
+            file: ExtractFile { from: src, to: dst },
+            interpreter,
+        })
+    }
+
+    pub fn try_parse_buck(s: &str) -> Result<Self> {
+        let parts: Vec<_> = s.splitn(2, ':').collect();
+        if parts.len() != 2 {
+            bail!("expected two colon-separated paths");
+        }
+        Self::new("/".into(), parts[0].into(), parts[1].into())
+    }
+
+    /// Find all transitive dependencies of this binary. Return ExtractFile
+    /// structs for this binary, its interpreter and all dependencies.
+    fn extracts(&self) -> Result<Vec<ExtractFile>> {
+        let log = LOGGER.new(o!("binary" => self.file.from.to_string_lossy().to_string()));
+
+        let output = Command::new(self.root.force_join(&self.interpreter))
+            .arg("--list")
+            .arg(&self.file.from)
+            .output()
+            .with_context(|| format!("failed to list libraries for {:?}", self.file.from))?;
+        let ld_output_str =
+            std::str::from_utf8(&output.stdout).context("ld.so output not utf-8")?;
+
+        Ok(LDSO_RE
+            .captures_iter(ld_output_str)
+            .map(|cap| {
+                let name = cap.name("name").unwrap().as_str();
+                let path = Path::new(cap.name("path").unwrap().as_str());
+                debug!(log, "{} provided by {:?}", name, path);
+                // There is not a bulletproof way to tell if a dependency is
+                // supposed to be relative to the source location or not based
+                // solely on the ld.so output.
+                // As a simple heuristic, guess that if the directory is the
+                // same as that of the binary, it should be installed at the
+                // same relative location to the binary destination.
+                // Importantly, this heuristic can only ever produce an
+                // incorrect result with buck-built binaries (the only kind
+                // where destination is not necessarily the same as the source),
+                // and if a binary really has an absolute dependency on buck-out,
+                // there is nothing we can do about it.
+                let bin_src_parent = self.file.from.parent().unwrap();
+                if path.starts_with(&bin_src_parent) {
+                    debug!(log, "{} seems to be installed at a relative path", name);
+                    let relpath = path.strip_prefix(bin_src_parent).unwrap();
+                    let bin_dst_parent = self.file.to.parent().unwrap();
+                    return ExtractFile {
+                        from: self.root.force_join(path),
+                        to: bin_dst_parent.join(relpath),
+                    };
+                }
+                ExtractFile {
+                    from: path.to_path_buf(),
+                    to: ensure_usr(path),
+                }
+            })
+            // also include the binary itself and its interpreter
+            .chain(vec![
+                self.file.clone(),
+                ExtractFile {
+                    from: self.root.force_join(&self.interpreter),
+                    to: ensure_usr(&self.interpreter),
+                },
+            ])
+            .collect())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+struct ExtractOpts {
+    /// Root source directory for where to find binaries
+    #[structopt(long)]
+    src_dir: PathBuf,
+
+    /// Root destination directory for where to copy binaries
+    #[structopt(long)]
+    dst_dir: PathBuf,
+
+    /// Binaries to extract. Extracts the given absolute paths from --src-dir
+    /// into the same location in --dst-dir.
+    #[structopt(long = "binary")]
+    binaries: Vec<String>,
+
+    /// Buck-built binaries to extract. Same format as --binary, but src is
+    /// treated as an absolute path.
+    #[structopt(long = "buck-binary")]
+    buck_binaries: Vec<String>,
+}
+
+fn main() -> Result<()> {
+    let opt = ExtractOpts::from_args();
+    let top_src_dir = opt.src_dir;
+    let top_dst_dir = opt.dst_dir;
+
+    let binaries: Vec<Binary> = opt
+        .binaries
+        .into_iter()
+        .map(|s| Binary::new(top_src_dir.clone(), top_src_dir.force_join(&s), s.into()))
+        .chain(
+            opt.buck_binaries
+                .into_iter()
+                .map(|s| Binary::try_parse_buck(&s)),
+        )
+        .collect::<Result<_>>()?;
+
+    let extract_files: Vec<_> = binaries
+        .into_iter()
+        .map(|bin| bin.extracts())
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect();
+
+    // map dst -> src to dedupe file copies for libraries that might be depended
+    // on multiple times
+    let copy_files: HashMap<PathBuf, PathBuf> = extract_files
+        .into_iter()
+        .map(|ex| {
+            let dst = top_dst_dir.force_join(ex.to);
+            (dst, ex.from)
+        })
+        .collect();
+
+    for (dst, src) in &copy_files {
+        debug!(LOGGER, "copying {:?} -> {:?}", src, dst);
+        fs::create_dir_all(dst.parent().unwrap()).context("failed to create dest dir")?;
+        fs::copy(src, dst)?;
+    }
+
+    Ok(())
+}

--- a/antlir/bzl/genrule/extractor/tests/BUCK
+++ b/antlir/bzl/genrule/extractor/tests/BUCK
@@ -1,7 +1,6 @@
-load("//antlir/bzl:constants.bzl", "REPO_CFG")
 load("//antlir/bzl:image.bzl", "image")
 load("//antlir/bzl:layer_resource.bzl", "layer_resource")
-load("//antlir/bzl:oss_shim.bzl", "python_unittest")
+load("//antlir/bzl:oss_shim.bzl", "python_unittest", "rust_binary")
 load("//antlir/bzl/genrule/extractor:extract.bzl", "extract")
 
 image.layer(
@@ -11,9 +10,26 @@ image.layer(
             binaries = [
                 "/usr/lib/systemd/systemd",
             ],
-            source = REPO_CFG.build_appliance_default,
+            buck_binaries = {
+                ":repo-built-binary": "/usr/bin/repo-built-binary",
+            },
+            source = ":source",
         ),
     ],
+    visibility = ["//antlir/bzl/genrule/extractor/tests/..."],
+)
+
+extract.source_layer(
+    name = "source",
+    features = [
+        image.rpms_install(["systemd"]),
+    ],
+)
+
+rust_binary(
+    name = "repo-built-binary",
+    srcs = ["repo_built_binary.rs"],
+    crate_root = "repo_built_binary.rs",
 )
 
 python_unittest(
@@ -21,7 +37,7 @@ python_unittest(
     srcs = ["test_extracted.py"],
     resources = {
         layer_resource(":extracted"): "layer",
-        layer_resource(REPO_CFG.build_appliance_default): "source",
+        layer_resource(":source"): "source",
     },
     deps = [
         "//antlir:fs_utils",

--- a/antlir/bzl/genrule/extractor/tests/repo_built_binary.rs
+++ b/antlir/bzl/genrule/extractor/tests/repo_built_binary.rs
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+fn main() {
+    println!("Hello world!");
+}

--- a/antlir/bzl/genrule/extractor/tests/test_extracted.py
+++ b/antlir/bzl/genrule/extractor/tests/test_extracted.py
@@ -38,3 +38,9 @@ class TestExtracted(unittest.TestCase):
         subvol = layer_resource_subvol(__package__, "layer")
         self.assertFalse(subvol.path("/lib64").exists())
         self.assertTrue(subvol.path("/usr/lib64/libc.so.6"))
+
+    def test_repo_built_binary_runs(self):
+        subvol = layer_resource_subvol(__package__, "layer")
+        subvol.run_as_root(
+            [subvol.path("/usr/bin/repo-built-binary")], check=True
+        )

--- a/antlir/linux/bootloader/BUCK
+++ b/antlir/linux/bootloader/BUCK
@@ -1,12 +1,13 @@
 load("//antlir/bzl:image.bzl", "image")
 load("//antlir/bzl:oss_shim.bzl", "buck_sh_test", "kernel_get")
 load("//antlir/bzl:systemd.bzl", "systemd")
+load("//antlir/bzl/genrule/extractor:extract.bzl", "extract")
 load("//antlir/bzl/linux:defs.bzl", "linux")
 load("//antlir/linux:defs.bzl", "antlir_linux_build_opts")
 load(":initrd_release.bzl", "initrd_release")
 load(":systemd.bzl", "clone_systemd")
 
-image.layer(
+extract.source_layer(
     name = "deps",
     features = [
         image.rpms_install([

--- a/antlir/linux/bootloader/debug/BUCK
+++ b/antlir/linux/bootloader/debug/BUCK
@@ -2,8 +2,7 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load("//antlir/bzl:image.bzl", "image")
 load("//antlir/bzl:oss_shim.bzl", "kernel_get")
 load("//antlir/bzl:systemd.bzl", "systemd", SYSTEMD_PROVIDER_ROOT = "PROVIDER_ROOT")
-load("//antlir/bzl/genrule/extractor:extract.bzl", "extract")
-load("//antlir/bzl/linux:busybox.bzl", "busybox")
+load("//antlir/bzl/linux:defs.bzl", "linux")
 load("//antlir/linux:defs.bzl", "antlir_linux_build_opts")
 
 DEPS_TARGET = "//antlir/linux/bootloader:deps"
@@ -11,13 +10,10 @@ DEPS_TARGET = "//antlir/linux/bootloader:deps"
 # Some systemd units and binaries that are only useful for debugging and not
 # during normal boots
 systemd_debug = [
-    extract.extract(
-        binaries = [
-            "/usr/bin/systemd-analyze",
-        ],
-        dest = "/",
-        source = DEPS_TARGET,
-    ),
+    # We don't have to use the extractor here, since the libraries loaded by
+    # the systemd binaries that we want will already be present in the base
+    # initrd.
+    image.clone(DEPS_TARGET, "/usr/bin/systemd-analyze", "/usr/bin/systemd-analyze"),
     image.ensure_dirs_exist(SYSTEMD_PROVIDER_ROOT),
     image.clone(
         DEPS_TARGET,
@@ -29,11 +25,12 @@ systemd_debug = [
 image.layer(
     name = "debug-append",
     features = [
+        linux.filesystem.install(),
         # NOTE: while busybox still exists for /usr/bin/mount in the base
         # initrd, this is technically duplicated. However image.ensure_file_symlink
         # does not allow dangling symlinks so just take the easy way out and
         # clone the binary again
-        busybox.install(
+        linux.busybox.install(
             DEPS_TARGET,
             src_path = "/usr/sbin/busybox",
         ),

--- a/third-party/rust/defs.bzl
+++ b/third-party/rust/defs.bzl
@@ -156,7 +156,7 @@ def third_party_rust_library(name, srcs, crate, crate_root, platform = {}, dlope
     native.genrule(
         name = archive_target,
         out = ".",
-        cmd = "$(exe //third-party/rust:download) $(location //third-party/rust:Cargo.lock) {} {} $OUT".format(shell.quote(crate), shell.quote(crate_root)),
+        cmd = "$(exe //third-party/rust:download) $(location //third-party/rust:Cargo.lock) {} $OUT".format(shell.quote(crate_root)),
     )
     source_targets = {_extract_from_archive(archive_target, src): src for src in srcs}
 

--- a/third-party/rust/download.py
+++ b/third-party/rust/download.py
@@ -28,7 +28,6 @@ def main():
 
     match = CRATE_VERSION_RE.match(args.crate_root)
     assert match is not None
-    assert match.group("crate") == args.crate, f"expected crate parsed from {args.crate_root} to be {args.crate}"
     crate = args.crate
     version = match.group("ver")
 

--- a/third-party/rust/download.py
+++ b/third-party/rust/download.py
@@ -15,7 +15,6 @@ CRATE_VERSION_RE = re.compile(r"^vendor/(?P<crate>.*)-(?P<ver>\d+.*?)/")
 
 parser = argparse.ArgumentParser()
 parser.add_argument("cargo_lock")
-parser.add_argument("crate")
 parser.add_argument("crate_root")
 parser.add_argument("out")
 
@@ -28,26 +27,23 @@ def main():
 
     match = CRATE_VERSION_RE.match(args.crate_root)
     assert match is not None
-    crate = args.crate
+    crates_io_name = match.group("crate")
     version = match.group("ver")
 
     os.makedirs(os.path.join(args.out, "vendor"))
 
     for package in cargo_lock["package"]:
-        if package["name"] == crate and package["version"] == version:
+        if package["name"] == crates_io_name and package["version"] == version:
             assert (
                 package["source"]
                 == "registry+https://github.com/rust-lang/crates.io-index"
             ), "non-crates.io packages not supported"
-            url = f"https://static.crates.io/crates/{crate}/{crate}-{version}.crate"
+            url = f"https://static.crates.io/crates/{crates_io_name}/{crates_io_name}-{version}.crate"
             print(url)
             resp = requests.get(url)
-            assert (
-                hashlib.sha256(resp.content).hexdigest() == package["checksum"]
-            )
-            tar = tarfile.TarFile(
-                fileobj=gzip.GzipFile(fileobj=BytesIO(resp.content))
-            )
+            assert resp.status_code == 200, resp.status_code
+            assert hashlib.sha256(resp.content).hexdigest() == package["checksum"]
+            tar = tarfile.TarFile(fileobj=gzip.GzipFile(fileobj=BytesIO(resp.content)))
             tar.extractall(os.path.join(args.out, "vendor"))
 
             return


### PR DESCRIPTION
Summary:
It was getting very unwieldy to maintain paths of relative vs absolute
dependency paths in Python, so I rewrote this in Rust.
Existing unit tests still pass, I will make a subsequent diff that adds a test for an
fbcode repo built binary (which requires a few small tweaks because they cannot
be rooted in `/source`)

Differential Revision: D27062635

