### PR TITLE
Add clang to the open source build appliance + remove bsdtar

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -45,8 +45,8 @@
   excluded_labels = exclude_test_if_transitive_dep, disabled
 
 [antlir]
-  build_appliance_default = //images/appliance:stable_build_appliance
+  build_appliance_default = //images/appliance:stable-build-appliance
   rpm_installer_default = dnf
   rpm_installers_supported = dnf
-  host_mounts_allowed_in_targets = //images/appliance:host_build_appliance //images/appliance:features-for-layer-host_build_appliance
-  artifact_key_to_path = build_appliance.newest //images/appliance:stable_build_appliance vm.rootfs.layer.rc //images/base:fedora.vm vm.rootfs.layer.stable //images/base:fedora.vm vm.rootfs.btrfs.rc //images/base:fedora.vm.btrfs vm.rootfs.btrfs.stable //images/base:fedora.vm.btrfs
+  host_mounts_allowed_in_targets = //images/appliance:host-build-appliance //images/appliance:features-for-layer-host-build-appliance
+  artifact_key_to_path = build_appliance.newest //images/appliance:stable-build-appliance vm.rootfs.layer.rc //images/base:fedora.vm vm.rootfs.layer.stable //images/base:fedora.vm vm.rootfs.btrfs.rc //images/base:fedora.vm.btrfs vm.rootfs.btrfs.stable //images/base:fedora.vm.btrfs

--- a/.github/workflows/update-build-appliance.yml
+++ b/.github/workflows/update-build-appliance.yml
@@ -29,7 +29,7 @@ jobs:
         run: buck --version
 
       - name: Build appliance sendstream
-        run: buck build -c python.package_style=standalone --out stable_build_appliance.sendstream.zst //images/appliance:bootstrap_build_appliance.sendstream.zst
+        run: buck build -c python.package_style=standalone --out stable-build-appliance.sendstream.zst //images/appliance:bootstrap-build-appliance.sendstream.zst
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -41,9 +41,9 @@ jobs:
       - name: Upload to S3
         run: |
           set -euo pipefail
-          sha="$(sha256sum stable_build_appliance.sendstream.zst | awk '{ print $1 }')"
-          aws s3 cp stable_build_appliance.sendstream.zst "s3://antlir/images/appliance/stable_build_appliance.sendstream.zst.$sha"
-          rm stable_build_appliance.sendstream.zst
+          sha="$(sha256sum stable-build-appliance.sendstream.zst | awk '{ print $1 }')"
+          aws s3 cp stable-build-appliance.sendstream.zst "s3://antlir/images/appliance/stable-build-appliance.sendstream.zst.$sha"
+          rm stable-build-appliance.sendstream.zst
           echo "stable_build_appliance_sha = \"$sha\"" > images/appliance/stable_appliance.bzl
 
       - name: Commit new hash

--- a/antlir/website/docs/installing.md
+++ b/antlir/website/docs/installing.md
@@ -46,7 +46,7 @@ buck fetch //...
 A quick test to confirm that your environment is setup correctly:
 
 ```
-buck run //images/appliance:stable_build_appliance-container
+buck run //images/appliance:stable-build-appliance-container
 ```
 
 This will give you a shell in the container that Antlir uses for container

--- a/images/appliance/BUCK
+++ b/images/appliance/BUCK
@@ -5,7 +5,7 @@ load("//antlir/bzl:rpm_repo_snapshot.bzl", "default_rpm_repo_snapshot_for", "ins
 load(":stable_appliance.bzl", "stable_build_appliance_sha")
 
 http_file(
-    name = "stable_build_appliance.sendstream.zst",
+    name = "stable-build-appliance.sendstream.zst",
     sha256 = stable_build_appliance_sha,
     urls = [
         "https://antlir.s3.us-east-2.amazonaws.com/images/appliance/stable_build_appliance.sendstream.zst." + stable_build_appliance_sha,
@@ -13,8 +13,8 @@ http_file(
 )
 
 image.sendstream_layer(
-    name = "stable_build_appliance",
-    source = ":stable_build_appliance.sendstream.zst",
+    name = "stable-build-appliance",
+    source = ":stable-build-appliance.sendstream.zst",
     build_opts = image.opts(
         build_appliance = DO_NOT_USE_BUILD_APPLIANCE,
     ),
@@ -32,14 +32,13 @@ install_snapshots = [
 
 # This is the origin of the stable_build_appliance artifact uploaded to S3.
 image.layer(
-    name = "bootstrap_build_appliance",
+    name = "bootstrap-build-appliance",
     features = [
         # Note: need this because the yum_dnf_from_snapshot code can't deal
         # with this directory not existing.
         image.ensure_subdirs_exist("/etc", "yum"),
         image.rpms_install([
             "attr",
-            "bsdtar",  # For building reproducible archives
             "btrfs-progs",
             "coreutils",
             "dnf",  # For installing rpms
@@ -63,7 +62,7 @@ image.layer(
         # build appliance should be able to rebuild itself or any changes that
         # might have been introduced since publishing.
         # build_appliance = ":host_build_appliance",
-        build_appliance = ":stable_build_appliance",
+        build_appliance = ":stable-build-appliance",
         rpm_repo_snapshot = "//snapshot:fedora33",
     ),
     enable_boot_target = True,
@@ -75,8 +74,8 @@ image.layer(
 # at build time, but any breakage will be surfaced by CI (and any automated
 # build of the BA will do the right thing already).
 image.package(
-    name = "bootstrap_build_appliance.sendstream.zst",
-    layer = ":bootstrap_build_appliance",
+    name = "bootstrap-build-appliance.sendstream.zst",
+    layer = ":bootstrap-build-appliance",
 )
 
 # Host build appliance should never have to be used outside of the original
@@ -84,7 +83,7 @@ image.package(
 # It requires an rpm-based host system on which to build the bootstrapped build
 # appliance, which should be used for all subsequent operations.
 image.layer(
-    name = "host_build_appliance",
+    name = "host-build-appliance",
     features = [
         image.ensure_subdirs_exist("/", "var"),
         image.ensure_subdirs_exist("/var", "tmp"),

--- a/images/appliance/README.md
+++ b/images/appliance/README.md
@@ -4,32 +4,32 @@ This way, `antlir` can easily make assumptions about the tooling available to
 build an image, without relying on complicated host setup (or even an
 rpm-based distribution)
 
-stable_build_appliance
+stable-build-appliance
 ======================
 
-`//images/appliance:stable_build_appliance` is the default appliance used to
+`//images/appliance:stable-build-appliance` is the default appliance used to
 build images. It comes from an artifact stored in S3, which provides big perf
 wins (it takes ~5 minutes to rebuild this appliance image). The downside to
 using a stable image is that it is slightly complicated to iterate on the
 appliance image itself.
 
-Building a new stable_build_appliance
+Building a new stable-build-appliance
 -------------------------------------
 
-The current process to build a new `stable_build_appliance` is via the
+The current process to build a new `stable-build-appliance` is via the
 `host_build_appliance`. This requires `rpm` and friends to be present on the
 build host, and likely other dependencies that are not yet explicitly
 enumerated.
 
 A new version of the appliance can easily be tested on image builds by passsing
-`-c antlir.build_appliance_default=//images/appliance:bootstrap_build_appliance`
+`-c antlir.build-appliance-default=//images/appliance:bootstrap-build-appliance`
 to `buck build`.
 
 Once satisfied, build a sendstream package and upload it to S3
 ```
-$ buck build --show-output //images/appliance:bootstrap_build_appliance.sendstream.zst
-$ sendstream="buck-out/gen/images/appliance/bootstrap_build_appliance.sendstream.zst/layer.sendstream.zst"
-$ aws s3 cp "$sendstream" "s3://antlir/images/appliance/stable_build_appliance.sendstream.zst.$(sha256sum $sendstream)"
+$ buck build --show-output //images/appliance:bootstrap-build-appliance.sendstream.zst
+$ sendstream="buck-out/gen/images/appliance/bootstrap-build-appliance.sendstream.zst/layer.sendstream.zst"
+$ aws s3 cp "$sendstream" "s3://antlir/images/appliance/stable-build-appliance.sendstream.zst.$(sha256sum $sendstream)"
 ```
 Finally, update the URL and `sha256` in `images/appliance/BUCK` to start
 using the prebuilt stable image.


### PR DESCRIPTION
Also, this renames the image layer targets to follow the style of `-` as a separator that we have for exported/usable targets (like python_binary, etc..) 

We don't need `bsdtar` anymore since we're not supporting fully reproducible cpio archives at the moment.