### PR TITLE
antlir: some rust setup work

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -26,6 +26,9 @@
   gtest_dep = //third-party/cxx:gtest
   should_remap_host_platform = true
 
+[rust]
+  default_edition = 2018
+
 [project]
   ignore = .git, .hg, buck-image-out
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,7 @@
   path = third-party/cxx/googletest
   url = https://github.com/google/googletest.git
   ignore = untracked
+[submodule "third-party/rust"]
+  path = third-party/rust
+  url = https://github.com/facebookincubator/antlir.git
+  ignore = untracked

--- a/antlir/bzl/oss_shim.bzl
+++ b/antlir/bzl/oss_shim.bzl
@@ -112,6 +112,7 @@ http_file = shim.http_file
 kernel_get = shim.kernel_get
 do_not_use_repo_cfg = shim.do_not_use_repo_cfg
 rpm_vset = shim.rpm_vset
+rust_binary = shim.rust_binary
 rust_unittest = shim.rust_unittest
 target_utils = shim.target_utils
 third_party = shim.third_party

--- a/antlir/bzl/oss_shim_impl.bzl
+++ b/antlir/bzl/oss_shim_impl.bzl
@@ -194,6 +194,11 @@ def _third_party_library(project, rule = None, platform = None):
     if not platform:
         platform = _DEFAULT_NATIVE_PLATFORM
 
+    if platform == "rust":
+        if not rule == project:
+            fail("rust dependencies must omit rule or be identical to project")
+        return "//third-party/rust:" + project
+
     if platform == "python":
         if not rule == project:
             fail("python projects must omit rule or be identical to project")
@@ -359,6 +364,9 @@ def _python_unittest(*args, **kwargs):
 def _rust_unittest(*args, **kwargs):
     _wrap_internal(native.rust_test, args, kwargs)
 
+def _rust_binary(*args, **kwargs):
+    _wrap_internal(native.rust_binary, args, kwargs)
+
 # Use = in the default filename to avoid clashing with RPM names.
 # The constant must match `update_allowed_versions.py`.
 # Omits `_wrap_internal` due to perf paranoia -- we have a callsite per RPM.
@@ -471,6 +479,7 @@ shim = struct(
     python_binary = _python_binary,
     python_library = _python_library,
     python_unittest = _python_unittest,
+    rust_binary = _rust_binary,
     rust_unittest = _rust_unittest,
     rpm_vset = _rpm_vset,  # Not wrapped due to perf paranoia.
     target_utils = struct(

--- a/third-party/README.md
+++ b/third-party/README.md
@@ -18,3 +18,22 @@ add or change this list.
 This contains python3 libraries that are provided the default `pypi` repositories.  Only `python3`
 is supported.  Adding or updating libraries here is currently a manual process.  Talk to @zeroxoneb
 if you need to modify anything here.
+
+### `rust`
+
+Rust crates are exposed as a submodule, the source of which is another branch
+in this repository. This allows us to avoid vendoring another copy of all
+these third-party deps internally. This is a little inconvenient to deal
+with, but these crates change relatively infrequently, and not vendoring the
+sources in fbcode is a huge benefit to general usability.
+
+The submodule is managed by
+[reindeer](https://github.com/facebookincubator/reindeer/) which vendors the
+sources and generates buck targets.
+To add/remove/update a crate:
+1) checkout the `rust-reindeer` branch in git
+2) make the necessary change in `Cargo.toml`
+3) run `reindeer vendor && reindeer buckify`
+4) push the change to GitHub
+5) update the commit in `rust.submodule.txt` (or checkout the new revision
+before submitting a PR)


### PR DESCRIPTION
Summary:
I am working on some diffs that add rust binaries to antlir, so add some
supporting infra before that can happen.

- rust_binary macro
- third_party support (uses fbsource/third-party internally, third-party/rust externally)
- enable autocargo

Reviewed By: snarkmaster

Differential Revision: D26992567

