### PR TITLE
[antlir][oss] Update stable build appliance version and URL

### DIFF
--- a/images/appliance/BUCK
+++ b/images/appliance/BUCK
@@ -8,7 +8,7 @@ http_file(
     name = "stable-build-appliance.sendstream.zst",
     sha256 = stable_build_appliance_sha,
     urls = [
-        "https://antlir.s3.us-east-2.amazonaws.com/images/appliance/stable_build_appliance.sendstream.zst." + stable_build_appliance_sha,
+        "https://antlir.s3.us-east-2.amazonaws.com/images/appliance/stable-build-appliance.sendstream.zst." + stable_build_appliance_sha,
     ],
 )
 

--- a/images/appliance/stable_appliance.bzl
+++ b/images/appliance/stable_appliance.bzl
@@ -1,1 +1,1 @@
-stable_build_appliance_sha = "8e92289ce20b4aa6a55c61f4eddb86b53c34f1c885f700bd53ad331b469b2842"
+stable_build_appliance_sha = "6c5a7a358639a2a48ea980c9874e052129e0bc3aa1f4a6a92ab210a43581d79d"


### PR DESCRIPTION
Summary:
Recently the S3 URL for the stable build appliance was changed to use
`-` instead of `_`.  This updates the relevant target *and* the hash so
that it doesn't break the github actions.

Test Plan:  CI