### PR TITLE
Allow manually triggering the build appliance workflow

### DIFF
--- a/.github/workflows/update-build-appliance.yml
+++ b/.github/workflows/update-build-appliance.yml
@@ -4,7 +4,8 @@ on:
     paths:
       - 'images/appliance/BUCK'
       - '.github/workflows/update-build-appliance.yml'
-
+  workflow_dispatch:
+  
 jobs:
   build-and-upload:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
According to https://docs.github.com/en/actions/reference/events-that-trigger-workflows#manual-events, this is how you enable the ability to manually trigger workflows.