### PR TITLE
Setup an initial "config" cell for the Open source repo

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -1,5 +1,6 @@
 [repositories]
   bazel_skylib = third-party/bazel-skylib
+  config = config
 
 # SKYLARK is the future of Buck, and (perhaps more importantly) does not
 # require a system to have python2 to interpret .bzl/BUCK files
@@ -46,10 +47,3 @@
   # option.
   # ie:  `buck test //antlir/rpm:test-yum-dnf-from-snapshot --always-exclude`
   excluded_labels = exclude_test_if_transitive_dep, disabled
-
-[antlir]
-  build_appliance_default = //images/appliance:stable-build-appliance
-  rpm_installer_default = dnf
-  rpm_installers_supported = dnf
-  host_mounts_allowed_in_targets = //images/appliance:host-build-appliance //images/appliance:features-for-layer-host-build-appliance
-  artifact_key_to_path = build_appliance.newest //images/appliance:stable-build-appliance extractor.common_deps //images/appliance:stable-build-appliance vm.rootfs.layer.rc //images/base:fedora.vm vm.rootfs.layer.stable //images/base:fedora.vm vm.rootfs.btrfs.rc //images/base:fedora.vm.btrfs vm.rootfs.btrfs.stable //images/base:fedora.vm.btrfs

--- a/antlir/bzl/oss_shim_impl.bzl
+++ b/antlir/bzl/oss_shim_impl.bzl
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 load("@bazel_skylib//lib:types.bzl", "types")
+load("@config//:config.bzl", _do_not_use_repo_cfg = "do_not_use_repo_cfg")
 load("//third-party/fedora33/kernel:kernels.bzl", "kernels")
 # @lint-ignore-every BUCKFBCODENATIVE
 
@@ -469,26 +470,7 @@ shim = struct(
         layer = "//antlir/vm:default-image",
         package = "//antlir/vm:default-image.btrfs",
     ),
-    # Future: We could conceivably add OSS support for a `.bzl`-based
-    # deployment-specific customizations, but for now we expect non-FB
-    # customers to use the `[antlir]` section in `.buckconfig`.
-    # Look at `bzl/constants.bzl` for the available options.
-    do_not_use_repo_cfg = {
-        # Future: Once we can guarantee `libcap-ng` to be at least 0.8, add
-        # this in.
-        #
-        # Also check this issue to see if this can be detected from
-        # `cap-ng.h` instead -- once both OSS and FB builds can be
-        # guaranteed to have this issue fixed, we can move the conditonal
-        # compilation into the `.c` file and remove this config.
-        #   https://github.com/stevegrubb/libcap-ng/issues/20
-        #
-        # "libcap_ng_compiler_flags": "-DCAPNG_SUPPORTS_AMBIENT=1",
-        "flavor_to_config": {"default": {
-            "build_appliance": "//images/appliance:stable-build-appliance",
-            "rpm_installer": "dnf",
-        }},
-    },
+    do_not_use_repo_cfg = _do_not_use_repo_cfg,
     export_file = _export_file,
     get_visibility = _normalize_visibility,
     http_file = _http_file,

--- a/config/.buckconfig
+++ b/config/.buckconfig
@@ -1,0 +1,5 @@
+[parser]
+  default_build_file_syntax = SKYLARK
+
+[repositories]
+  config = .

--- a/config/.buckversion
+++ b/config/.buckversion
@@ -1,0 +1,1 @@
+../.buckversion

--- a/config/config.bzl
+++ b/config/config.bzl
@@ -1,0 +1,42 @@
+# This dict is imported into `//antlir/bzl:constants.bzl` to provide per
+# repository configuration.
+do_not_use_repo_cfg = {
+    "artifact_key_to_path": " ".join([
+        (k + " " + v)
+        for k, v in {
+            "build_appliance.newest": "//images/appliance:stable-build-appliance",
+            "extractor.common_deps": "//images/appliance:stable-build-appliance",
+            "vm.rootfs.layer.rc": "//images/base:fedora.vm",
+            "vm.rootfs.layer.stable": "//images/base:fedora.vm",
+            "vm.rootfs.btrfs.rc": "//images/base:fedora.vm.btrfs",
+            "vm.rootfs.btrfs.stable": "//images/base:fedora.vm.btrfs",
+        }.items()
+    ]),
+    "build_appliance_default": "//images/appliance:stable-build-appliance",
+    # Future: Once we can guarantee `libcap-ng` to be at least 0.8, add
+    # this in.
+    #
+    # Also check this issue to see if this can be detected from
+    # `cap-ng.h` instead -- once both OSS and FB builds can be
+    # guaranteed to have this issue fixed, we can move the conditonal
+    # compilation into the `.c` file and remove this config.
+    #   https://github.com/stevegrubb/libcap-ng/issues/20
+    #
+    # "libcap_ng_compiler_flags": "-DCAPNG_SUPPORTS_AMBIENT=1",
+    "flavor_default": "fedora33",
+    "flavor_to_config": {
+        "fedora33": {
+            "build_appliance": "//images/appliance:stable-build-appliance",
+            "rpm_installer": "dnf",
+        }
+    },
+    "host_mounts_allowed_in_targets": " ".join([
+        "//images/appliance:host-build-appliance",
+        "//images/appliance:features-for-layer-host-build-appliance",
+    ]),
+    "host_mounts_for_repo_artifacts": [],
+    "rpm_installer_default": "dnf",
+    "rpm_installers_supported": " ".join([
+        "dnf"
+    ]),
+}


### PR DESCRIPTION
This will ease the transition of Antlir into it's own cell and allow users of the
tool to embed Antlir into their own repositories and provide their own
config.  There is still a fair amount of cleanup to do as this is mostly
just a bulk move, but this at least starts the process.

Test Plan:

Existing tests should still work as expected.