### PR TITLE
antlir oss: fix docs build

### DIFF
--- a/antlir/website/gen/index.js
+++ b/antlir/website/gen/index.js
@@ -17,17 +17,14 @@ const exec = util.promisify(require('child_process').exec);
 // eslint-disable-next-line no-unused-vars
 module.exports = (context, options) => {
   const bzlDir = path.resolve(context.siteDir, '../bzl');
-  const bzlGlobs = [
-    `${bzlDir}/*.bzl`,
-    `${bzlDir}/**/*.bzl`,
-    `${bzlDir}/genrule/facebook/chef_solo/*.bzl`,
-  ];
   return {
     name: 'bzldoc',
     async loadContent() {
       const out = `${context.siteDir}/docs/api/`;
       await exec(
-        `buck run //antlir/website/gen:bzldoc -- ${bzlGlobs.join(' ')} ${out}`,
+        `shopt -s globstar && buck run //antlir/website/gen:bzldoc -- ${bzlDir}/**/*.bzl ${out}`, {
+          shell: "/bin/bash",
+        }
       );
       return null;
     },

--- a/antlir/website/package.json
+++ b/antlir/website/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "yarn bzldoc && docusaurus start",
     "build": "yarn bzldoc && yarn docusaurus build",
-    "bzldoc": "cd .. && buck run //antlir/website/gen:bzldoc -- $(pwd)/bzl/*.bzl $(pwd)/bzl/**/*.bzl $(pwd)/bzl/genrule/facebook/chef_solo/*.bzl $(pwd)/website/docs/api/",
+    "bzldoc": "/bin/bash -c 'shopt -s globstar && cd .. && buck run //antlir/website/gen:bzldoc -- $(pwd)/bzl/**/*.bzl $(pwd)/website/docs/api/'",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "ci": "yarn lint && yarn prettier:diff",

--- a/antlir/website/sidebars.js
+++ b/antlir/website/sidebars.js
@@ -80,7 +80,9 @@ module.exports = {
           'VM Runtime': ['runtime/vm-runtime/vm-unittest'],
         },
         'api/shape',
-        'api/genrule/facebook/chef_solo/chef_solo',
+        fbInternalOnly([
+          'api/genrule/facebook/chef_solo/chef_solo',
+        ]),
         'api/flavor_helpers',
       ],
     },


### PR DESCRIPTION
Summary:
Set `nullglob` to avoid breaking oss build due to non-existent `facebook`
directory for chef solo docs.

Reviewed By: zeroxoneb

Differential Revision: D28475652

