### PR TITLE
Add rust_library to oss_shim and use shims for third-party rust

### DIFF
--- a/antlir/bzl/oss_shim.bzl
+++ b/antlir/bzl/oss_shim.bzl
@@ -114,6 +114,7 @@ kernel_get = shim.kernel_get
 do_not_use_repo_cfg = shim.do_not_use_repo_cfg
 rpm_vset = shim.rpm_vset
 rust_binary = shim.rust_binary
+rust_library = shim.rust_library
 rust_unittest = shim.rust_unittest
 target_utils = shim.target_utils
 third_party = shim.third_party

--- a/antlir/bzl/oss_shim_impl.bzl
+++ b/antlir/bzl/oss_shim_impl.bzl
@@ -403,7 +403,11 @@ def _rust_binary(*args, **kwargs):
             deps = kwargs.get("deps", []) + kwargs.get("test_deps", []),
             labels = kwargs.get("labels", []),
             crate = kwargs.get("crate", kwargs.get("name").replace("-", "_")),
+            crate_root = kwargs.get("crate_root"),
         )
+
+def _rust_library(*args, **kwargs):
+    _wrap_internal(native.rust_library, args, kwargs)
 
 # Use = in the default filename to avoid clashing with RPM names.
 # The constant must match `update_allowed_versions.py`.
@@ -503,6 +507,7 @@ shim = struct(
     python_library = _python_library,
     python_unittest = _python_unittest,
     rust_binary = _rust_binary,
+    rust_library = _rust_library,
     rust_unittest = _rust_unittest,
     rpm_vset = _rpm_vset,  # Not wrapped due to perf paranoia.
     target_utils = struct(


### PR DESCRIPTION
Summary: To support compilation of third-party rust libraries against a target platform, we need to use the oss_shim versions.

Reviewed By: vmagro

Differential Revision: D29071528

