### PR TITLE
[antlir][oss] Add support for `cpp_library` in the oss shim

### DIFF
--- a/antlir/bzl/oss_shim.bzl
+++ b/antlir/bzl/oss_shim.bzl
@@ -33,6 +33,25 @@ def cpp_binary(*args, **kwargs):
     _check_args("cpp_binary", args, kwargs, _CPP_BINARY_KWARGS)
     shim.cpp_binary(**kwargs)
 
+_CPP_LIBRARY_KWARGS = _make_rule_kwargs_dict(
+    [
+        "name",
+        "srcs",
+        "deps",
+        "compiler_flags",
+        "headers",
+        "include_directories",
+        "linker_flags",
+        "preferred_linkage",
+        "visibility",
+        "external_deps"
+    ],
+)
+
+def cpp_library(*args, **kwargs):
+    _check_args("cpp_library", args, kwargs, _CPP_LIBRARY_KWARGS)
+    shim.cpp_library(**kwargs)
+
 _CPP_UNITTEST_KWARGS = _make_rule_kwargs_dict(
     ["name", "deps", "env", "headers", "srcs", "tags", "use_default_test_main", "visibility", "external_deps"],
 )

--- a/antlir/bzl/oss_shim_impl.bzl
+++ b/antlir/bzl/oss_shim_impl.bzl
@@ -287,6 +287,17 @@ def _impl_cpp_binary(name, tags = [], **kwargs):
 def _cpp_binary(*args, **kwargs):
     _wrap_internal(_impl_cpp_binary, args, kwargs)
 
+def _impl_cpp_library(name, tags = [], **kwargs):
+    native.cxx_library(
+        name = name,
+        labels = tags,
+        deps = _normalize_deps(kwargs.pop("deps", []), _cxx_external_deps(kwargs)),
+        **kwargs
+    )
+
+def _cpp_library(*args, **kwargs):
+    _wrap_internal(_impl_cpp_library, args, kwargs)
+
 def _impl_cpp_unittest(name, tags = [], **kwargs):
     native.cxx_test(
         name = name,
@@ -486,6 +497,7 @@ shim = struct(
         get_project_root_from_gen_dir = _get_project_root_from_gen_dir,
     ),
     cpp_binary = _cpp_binary,
+    cpp_library = _cpp_library,
     cpp_unittest = _cpp_unittest,
     #
     # Constants

--- a/third-party/rust/defs.bzl
+++ b/third-party/rust/defs.bzl
@@ -5,6 +5,7 @@ load(
     "//antlir/bzl:oss_shim.bzl",
     "buck_genrule",
     "cpp_binary",
+    "cpp_library",
     "rust_binary",
     "rust_library",
 )
@@ -282,7 +283,7 @@ def third_party_rust_cxx_library(name, **kwargs):
     # cxx_library rules do not play nicely with the vendoring hack we employ for
     # rust, so just pass the sources unmodified and rely on antlir vendoring the
     # C files necessary, but we can still avoid vendoring any rust code.
-    native.cxx_library(name = name, **kwargs)
+    cpp_library(name = name, **kwargs)
 
 def third_party_rust_prebuilt_cxx_library(name, **kwargs):
     fail(


### PR DESCRIPTION
This is necessary to properly support rust compilation.

Test Plan:
  Existing tests should continue to pass