### PR TITLE
[antlir][oss]  Use generic buck_genrule for rust build macros

### DIFF
--- a/third-party/rust/defs.bzl
+++ b/third-party/rust/defs.bzl
@@ -118,7 +118,7 @@ def rust_buildscript_genrule_filter(
         env,
         target,
     )
-    native.cxx_genrule(
+    buck_genrule(
         name = name,
         out = outfile,
         cmd = pre +
@@ -139,8 +139,9 @@ def rust_buildscript_genrule_srcs(
         env = None,
         target = None,
         srcs = None):
+
     pre = _make_preamble("$OUT", package_name, version, features, cfgs, env, target)
-    native.cxx_genrule(
+    buck_genrule(
         name = name,
         out = name + "-outputs",
         srcs = srcs,
@@ -151,7 +152,7 @@ def rust_buildscript_genrule_srcs(
     )
     mainrule = ":" + name
     for file in files:
-        native.cxx_genrule(
+        buck_genrule(
             name = "{}={}".format(name, file),
             out = file,
             cmd = "mkdir -p \\$(dirname $OUT) && cp $(location {main})/{file} $OUT".format(


### PR DESCRIPTION
It doesn't appear that the use of `native.cxx_genrule` is necessary to
build the rust third-party deps.  So, instead of adding this complexity,
lets just not use it.

Note: it's possible that there is some future dep that will require
this, `cxx_genrule` is apparently useful for wrapping compiler calls
(see https://buck.build/rule/cxx_genrule.html), but it doesn't appear to
actually be needed, and fwiw, it's not really used inside FB...

Test Plan: existing tests