### PR TITLE
antlir vm: use the `btrfs` cli installed into the initrd

### DIFF
--- a/antlir/vm/initrd/seedroot-device-add.service
+++ b/antlir/vm/initrd/seedroot-device-add.service
@@ -1,11 +1,9 @@
 [Unit]
 Description=Add /dev/vdb to /sysroot
-Requires=dev-vdb.device
-After=dev-vdb.device
+Requires=dev-vdb.device sysroot.mount
+After=dev-vdb.device sysroot.mount
 
 [Service]
 Type=oneshot
-RootDirectory=/sysroot
-MountAPIVFS=true
-ExecStart=/usr/sbin/btrfs device add /dev/vdb /
+ExecStart=/usr/sbin/btrfs device add /dev/vdb /sysroot
 RemainAfterExit=yes


### PR DESCRIPTION
Summary:
Since D26854165, we have had `/usr/sbin/btrfs` in the initrd.
This is simpler than using a mount namespace in the seedroot-device-add
unit, and allows booting root disks without `btrfs-progs` installed.

Test Plan:
I ran it on my arch box, it still fails to boot due to compiler platform
issues, but it is able to invoke `btrfs`

Reviewers: lsalis

Subscribers:

Tasks:

Tags: