### PR TITLE
antlir oss: enable vmtest

### DIFF
--- a/tools/testinfra/ci_tests_query
+++ b/tools/testinfra/ci_tests_query
@@ -1,1 +1,1 @@
-kind(.*_test, //...) - kind(cxx_test, //...) - set(//antlir/bzl/genrule/locale/...) - set(//antlir/rpm/replay/tests:test-subvol-rpm-compare) - attrfilter(labels, vmtest, //...)
+kind(.*_test, //...) - kind(cxx_test, //...) - set(//antlir/bzl/genrule/locale/...) - set(//antlir/rpm/replay/tests:test-subvol-rpm-compare) - attrfilter(labels, vmtest_cpp, //...)


### PR DESCRIPTION
Summary:
This was previously broken / hard to support, so it was turned off in the
default tests query, but it should at least work in the GitHub Actions
environment now, so I am enabling it.

Differential Revision: D29617423

