### PR TITLE
antlir oss: fix rust deps

### DIFF
--- a/antlir/bzl/oss_shim.bzl
+++ b/antlir/bzl/oss_shim.bzl
@@ -40,6 +40,8 @@ _CPP_LIBRARY_KWARGS = _make_rule_kwargs_dict(
         "deps",
         "compiler_flags",
         "headers",
+        "header_namespace",
+        "exported_headers",
         "include_directories",
         "linker_flags",
         "preferred_linkage",

--- a/third-party/rust/.gitignore
+++ b/third-party/rust/.gitignore
@@ -3,3 +3,4 @@ target/
 .cargo
 
 !vendor/ring-0.16.20
+!vendor/cxx-1.0.52

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -1,5 +1,188 @@
+# @generated
 load("//antlir/bzl:oss_shim.bzl", "buck_genrule", "cpp_library", "export_file", "rust_library")
-load(":defs.bzl", "archive", "third_party_rust_binary", "third_party_rust_library")
+load(":defs.bzl", "archive", "third_party_rust_binary", "third_party_rust_library")  # @unused
+
+# This BUCK file serves as the preamble of the full generated BUCK file, and
+# includes explicit definitions for targets that are difficult to automatically
+# transform. The generated rules are appended to the contents of this file and
+# written out to ../BUCK to be shipped in the OSS repo.
+# This file is intentionally named 'BUCK' so that syntax highlighting and
+# auto-formatting work as expected.
+
+export_file(
+    name = "starlark-rust/starlark/src/syntax/grammar.lalrpop",
+)
+
+buck_genrule(
+    name = "starlark-grammar",
+    out = ".",
+    cmd = """
+        cd $TMP
+        mkdir syntax
+        cp $(location :starlark-rust/starlark/src/syntax/grammar.lalrpop) ./syntax/
+        $(exe :lalrpop-lalrpop) --out-dir $OUT ./syntax/grammar.lalrpop
+    """,
+)
+
+rust_library(
+    name = "starlark",
+    srcs = glob(["starlark-rust/starlark/src/**/*.rs"]),
+    env = {
+        "OUT_DIR": "$(location :starlark-grammar)",
+    },
+    rustc_flags = [
+        "-Aunused_braces",
+        "-Wbare_trait_objects",
+        "-Wellipsis_inclusive_range_patterns",
+        "-Dnon_fmt_panic",
+        "-Dunconditional_recursion",
+    ],
+    unittests = False,
+    deps = [
+        ":annotate-snippets",
+        ":anyhow",
+        ":bumpalo",
+        ":derivative",
+        ":either",
+        ":gazebo",
+        ":hashbrown",
+        ":indexmap",
+        ":itertools",
+        ":lalrpop-util",
+        ":logos",
+        ":maplit",
+        ":once_cell",
+        ":paste",
+        ":regex",
+        ":rustyline",
+        ":serde",
+        ":starlark_module",
+        ":static_assertions",
+        ":textwrap",
+        ":thiserror",
+    ],
+)
+
+rust_library(
+    name = "starlark_module",
+    srcs = glob(["starlark-rust/starlark_module/src/**/*.rs"]),
+    proc_macro = True,
+    rustc_flags = [
+        "-Aunused_braces",
+        "-Wbare_trait_objects",
+        "-Wellipsis_inclusive_range_patterns",
+        "-Dnon_fmt_panic",
+        "-Dunconditional_recursion",
+    ],
+    unittests = False,
+    deps = [
+        ":gazebo",
+        ":proc-macro2",
+        ":quote",
+        ":syn",
+    ],
+)
+
+rust_library(
+    name = "gazebo",
+    srcs = glob(
+        ["gazebo/gazebo/src/**/*.rs"],
+    ),
+    edition = "2018",
+    features = ["str_pattern_extensions"],
+    test_srcs = ["gazebo/gazebo/src/test.rs"],
+    deps = [
+        ":gazebo_derive",
+    ],
+)
+
+rust_library(
+    name = "gazebo_derive",
+    srcs = glob(
+        ["gazebo/gazebo_derive/src/**/*.rs"],
+    ),
+    edition = "2018",
+    proc_macro = True,
+    unittests = False,
+    deps = [
+        ":proc-macro2",
+        ":quote",
+        ":syn",
+    ],
+)
+
+cpp_library(
+    name = "cxx-core",
+    srcs = ["vendor/cxx-1.0.52/src/cxx.cc"],
+    headers = [],
+    header_namespace = "rust",
+    exported_headers = {
+        "cxx.h": "vendor/cxx-1.0.52/include/cxx.h",
+    },
+    preferred_linkage = "static",
+    visibility = ["PUBLIC"],
+)
+
+cpp_library(
+    name = "ring-0.16.20-ring-c-asm-elf",
+    srcs = [
+        "vendor/ring-0.16.20/crypto/constant_time_test.c",
+        "vendor/ring-0.16.20/crypto/cpu-intel.c",
+        "vendor/ring-0.16.20/crypto/crypto.c",
+        "vendor/ring-0.16.20/crypto/curve25519/curve25519.c",
+        "vendor/ring-0.16.20/crypto/fipsmodule/aes/aes_nohw.c",
+        "vendor/ring-0.16.20/crypto/fipsmodule/bn/montgomery.c",
+        "vendor/ring-0.16.20/crypto/fipsmodule/bn/montgomery_inv.c",
+        "vendor/ring-0.16.20/crypto/fipsmodule/ec/ecp_nistz.c",
+        "vendor/ring-0.16.20/crypto/fipsmodule/ec/ecp_nistz256.c",
+        "vendor/ring-0.16.20/crypto/fipsmodule/ec/gfp_p256.c",
+        "vendor/ring-0.16.20/crypto/fipsmodule/ec/gfp_p384.c",
+        "vendor/ring-0.16.20/crypto/limbs/limbs.c",
+        "vendor/ring-0.16.20/crypto/mem.c",
+        "vendor/ring-0.16.20/crypto/poly1305/poly1305.c",
+        "vendor/ring-0.16.20/crypto/poly1305/poly1305_arm.c",
+        "vendor/ring-0.16.20/crypto/poly1305/poly1305_vec.c",
+        "vendor/ring-0.16.20/pregenerated/aesni-gcm-x86_64-elf.S",
+        "vendor/ring-0.16.20/pregenerated/aesni-x86_64-elf.S",
+        "vendor/ring-0.16.20/pregenerated/chacha-x86_64-elf.S",
+        "vendor/ring-0.16.20/pregenerated/chacha20_poly1305_x86_64-elf.S",
+        "vendor/ring-0.16.20/pregenerated/ghash-x86_64-elf.S",
+        "vendor/ring-0.16.20/pregenerated/p256-x86_64-asm-elf.S",
+        "vendor/ring-0.16.20/pregenerated/sha256-x86_64-elf.S",
+        "vendor/ring-0.16.20/pregenerated/sha512-x86_64-elf.S",
+        "vendor/ring-0.16.20/pregenerated/vpaes-x86_64-elf.S",
+        "vendor/ring-0.16.20/pregenerated/x86_64-mont-elf.S",
+        "vendor/ring-0.16.20/pregenerated/x86_64-mont5-elf.S",
+    ],
+    headers = [
+        "vendor/ring-0.16.20/crypto/curve25519/curve25519_tables.h",
+        "vendor/ring-0.16.20/crypto/curve25519/internal.h",
+        "vendor/ring-0.16.20/crypto/fipsmodule/bn/internal.h",
+        "vendor/ring-0.16.20/crypto/fipsmodule/ec/ecp_nistz.h",
+        "vendor/ring-0.16.20/crypto/fipsmodule/ec/ecp_nistz256.h",
+        "vendor/ring-0.16.20/crypto/fipsmodule/ec/ecp_nistz256_table.inl",
+        "vendor/ring-0.16.20/crypto/fipsmodule/ec/ecp_nistz384.h",
+        "vendor/ring-0.16.20/crypto/fipsmodule/ec/ecp_nistz384.inl",
+        "vendor/ring-0.16.20/crypto/internal.h",
+        "vendor/ring-0.16.20/crypto/limbs/limbs.h",
+        "vendor/ring-0.16.20/crypto/limbs/limbs.inl",
+        "vendor/ring-0.16.20/crypto/poly1305/internal.h",
+        "vendor/ring-0.16.20/include/GFp/aes.h",
+        "vendor/ring-0.16.20/include/GFp/arm_arch.h",
+        "vendor/ring-0.16.20/include/GFp/base.h",
+        "vendor/ring-0.16.20/include/GFp/check.h",
+        "vendor/ring-0.16.20/include/GFp/cpu.h",
+        "vendor/ring-0.16.20/include/GFp/mem.h",
+        "vendor/ring-0.16.20/include/GFp/poly1305.h",
+        "vendor/ring-0.16.20/include/GFp/type_check.h",
+        "vendor/ring-0.16.20/third_party/fiat/curve25519_32.h",
+        "vendor/ring-0.16.20/third_party/fiat/curve25519_64.h",
+    ],
+    compiler_flags = ["-Wno-error"],
+    include_directories = ["vendor/ring-0.16.20/include"],
+    preferred_linkage = "static",
+    visibility = [],
+)
 
 archive(
     name = "addr2line-0.13.0--archive",
@@ -44,6 +227,12 @@ archive(
 )
 
 archive(
+    name = "argv-0.1.2--archive",
+    sha256 = "87b48bbc752e97f1b6d7f237c0fd50056f19417e30b10121d4065d1459270e1d",
+    url = "https://static.crates.io/crates/argv/argv-0.1.2.crate",
+)
+
+archive(
     name = "ascii-canvas-2.0.0--archive",
     sha256 = "ff8eb72df928aafb99fe5d37b383f2fe25bd2a765e3e5f7c365916b6f2463a29",
     url = "https://static.crates.io/crates/ascii-canvas/ascii-canvas-2.0.0.crate",
@@ -77,6 +266,12 @@ archive(
     name = "backtrace-0.3.51--archive",
     sha256 = "ec1931848a574faa8f7c71a12ea00453ff5effbb5f51afe7f77d7a48cace6ac1",
     url = "https://static.crates.io/crates/backtrace/backtrace-0.3.51.crate",
+)
+
+archive(
+    name = "base64-0.11.0--archive",
+    sha256 = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7",
+    url = "https://static.crates.io/crates/base64/base64-0.11.0.crate",
 )
 
 archive(
@@ -140,6 +335,12 @@ archive(
 )
 
 archive(
+    name = "bufsize-1.0.0--archive",
+    sha256 = "47989b37d1323184a2e6cab5a76bcdafe984a57259f77b3f1edeb169a8ec8cd6",
+    url = "https://static.crates.io/crates/bufsize/bufsize-1.0.0.crate",
+)
+
+archive(
     name = "bumpalo-3.4.0--archive",
     sha256 = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820",
     url = "https://static.crates.io/crates/bumpalo/bumpalo-3.4.0.crate",
@@ -194,6 +395,18 @@ archive(
 )
 
 archive(
+    name = "codespan-reporting-0.11.0--archive",
+    sha256 = "c6ce42b8998a383572e0a802d859b1f00c79b7b7474e62fff88ee5c2845d9c13",
+    url = "https://static.crates.io/crates/codespan-reporting/codespan-reporting-0.11.0.crate",
+)
+
+archive(
+    name = "const-cstr-0.3.0--archive",
+    sha256 = "ed3d0b5ff30645a68f35ece8cea4556ca14ef8a1651455f789a099a0513532a6",
+    url = "https://static.crates.io/crates/const-cstr/const-cstr-0.3.0.crate",
+)
+
+archive(
     name = "const_fn-0.4.2--archive",
     sha256 = "ce90df4c658c62f12d78f7508cf92f9173e5184a539c10bfe54a3107b3ffd0f2",
     url = "https://static.crates.io/crates/const_fn/const_fn-0.4.2.crate",
@@ -245,6 +458,24 @@ archive(
     name = "ct-logs-0.8.0--archive",
     sha256 = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8",
     url = "https://static.crates.io/crates/ct-logs/ct-logs-0.8.0.crate",
+)
+
+archive(
+    name = "cxx-1.0.52--archive",
+    sha256 = "1466c2983a24f17f1138b375127b44127e96fbf55dd292e071817a5edcf40c9a",
+    url = "https://static.crates.io/crates/cxx/cxx-1.0.52.crate",
+)
+
+archive(
+    name = "cxxbridge-cmd-1.0.52--archive",
+    sha256 = "164ad53dd137c29d83a377b8c61473b9b5b90f50b729d241d3ec5fcbc89c5525",
+    url = "https://static.crates.io/crates/cxxbridge-cmd/cxxbridge-cmd-1.0.52.crate",
+)
+
+archive(
+    name = "cxxbridge-macro-1.0.52--archive",
+    sha256 = "0d75224fc5397490a22abac11c6ee28815263e3f4418a85ae37f93895c86b100",
+    url = "https://static.crates.io/crates/cxxbridge-macro/cxxbridge-macro-1.0.52.crate",
 )
 
 archive(
@@ -362,6 +593,12 @@ archive(
 )
 
 archive(
+    name = "env_logger-0.7.1--archive",
+    sha256 = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36",
+    url = "https://static.crates.io/crates/env_logger/env_logger-0.7.1.crate",
+)
+
+archive(
     name = "erased-serde-0.3.12--archive",
     sha256 = "6ca8b296792113e1500fd935ae487be6e00ce318952a6880555554824d6ebf38",
     url = "https://static.crates.io/crates/erased-serde/erased-serde-0.3.12.crate",
@@ -389,6 +626,12 @@ archive(
     name = "fallible-iterator-0.2.0--archive",
     sha256 = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7",
     url = "https://static.crates.io/crates/fallible-iterator/fallible-iterator-0.2.0.crate",
+)
+
+archive(
+    name = "filetime-0.2.12--archive",
+    sha256 = "3ed85775dcc68644b5c950ac06a2b23768d3bc9390464151aaf27136998dcf9e",
+    url = "https://static.crates.io/crates/filetime/filetime-0.2.12.crate",
 )
 
 archive(
@@ -500,6 +743,12 @@ archive(
 )
 
 archive(
+    name = "ghost-0.1.2--archive",
+    sha256 = "1a5bcf1bbeab73aa4cf2fde60a846858dc036163c7c33bec309f8d17de785479",
+    url = "https://static.crates.io/crates/ghost/ghost-0.1.2.crate",
+)
+
+archive(
     name = "gimli-0.22.0--archive",
     sha256 = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724",
     url = "https://static.crates.io/crates/gimli/gimli-0.22.0.crate",
@@ -578,6 +827,12 @@ archive(
 )
 
 archive(
+    name = "humantime-1.3.0--archive",
+    sha256 = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f",
+    url = "https://static.crates.io/crates/humantime/humantime-1.3.0.crate",
+)
+
+archive(
     name = "hyper-0.14.7--archive",
     sha256 = "1e5f105c494081baa3bf9e200b279e27ec1623895cd504c7dbef8d0b080fcf54",
     url = "https://static.crates.io/crates/hyper/hyper-0.14.7.crate",
@@ -617,6 +872,12 @@ archive(
     name = "instant-0.1.7--archive",
     sha256 = "63312a18f7ea8760cdd0a7c5aac1a619752a246b833545e3e36d1f81f7cd9e66",
     url = "https://static.crates.io/crates/instant/instant-0.1.7.crate",
+)
+
+archive(
+    name = "iovec-0.1.4--archive",
+    sha256 = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e",
+    url = "https://static.crates.io/crates/iovec/iovec-0.1.4.crate",
 )
 
 archive(
@@ -671,6 +932,12 @@ archive(
     name = "libm-0.2.1--archive",
     sha256 = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a",
     url = "https://static.crates.io/crates/libm/libm-0.2.1.crate",
+)
+
+archive(
+    name = "link-cplusplus-1.0.3--archive",
+    sha256 = "372d61b8ffdc79aa85d5f679e16c9e34da2357796186e877001f21998ece1f99",
+    url = "https://static.crates.io/crates/link-cplusplus/link-cplusplus-1.0.3.crate",
 )
 
 archive(
@@ -734,9 +1001,9 @@ archive(
 )
 
 archive(
-    name = "memchr-2.4.0--archive",
-    sha256 = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc",
-    url = "https://static.crates.io/crates/memchr/memchr-2.4.0.crate",
+    name = "memchr-2.4.1--archive",
+    sha256 = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a",
+    url = "https://static.crates.io/crates/memchr/memchr-2.4.1.crate",
 )
 
 archive(
@@ -764,15 +1031,33 @@ archive(
 )
 
 archive(
+    name = "mio-0.6.23--archive",
+    sha256 = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4",
+    url = "https://static.crates.io/crates/mio/mio-0.6.23.crate",
+)
+
+archive(
     name = "mio-0.7.7--archive",
     sha256 = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7",
     url = "https://static.crates.io/crates/mio/mio-0.7.7.crate",
 )
 
 archive(
+    name = "mio-uds-0.6.8--archive",
+    sha256 = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0",
+    url = "https://static.crates.io/crates/mio-uds/mio-uds-0.6.8.crate",
+)
+
+archive(
     name = "multipart-0.17.0--archive",
     sha256 = "8209c33c951f07387a8497841122fc6f712165e3f9bda3e6be4645b58188f676",
     url = "https://static.crates.io/crates/multipart/multipart-0.17.0.crate",
+)
+
+archive(
+    name = "net2-0.2.37--archive",
+    sha256 = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae",
+    url = "https://static.crates.io/crates/net2/net2-0.2.37.crate",
 )
 
 archive(
@@ -791,6 +1076,12 @@ archive(
     name = "nix-0.20.0--archive",
     sha256 = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a",
     url = "https://static.crates.io/crates/nix/nix-0.20.0.crate",
+)
+
+archive(
+    name = "num-derive-0.3.2--archive",
+    sha256 = "6f09b9841adb6b5e1f89ef7087ea636e0fd94b2851f887c1e3eb5d5f8228fab3",
+    url = "https://static.crates.io/crates/num-derive/num-derive-0.3.2.crate",
 )
 
 archive(
@@ -839,6 +1130,12 @@ archive(
     name = "openssl-probe-0.1.2--archive",
     sha256 = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de",
     url = "https://static.crates.io/crates/openssl-probe/openssl-probe-0.1.2.crate",
+)
+
+archive(
+    name = "ordered-float-1.1.1--archive",
+    sha256 = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7",
+    url = "https://static.crates.io/crates/ordered-float/ordered-float-1.1.1.crate",
 )
 
 archive(
@@ -926,6 +1223,12 @@ archive(
 )
 
 archive(
+    name = "pin-project-lite-0.1.11--archive",
+    sha256 = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b",
+    url = "https://static.crates.io/crates/pin-project-lite/pin-project-lite-0.1.11.crate",
+)
+
+archive(
     name = "pin-project-lite-0.2.6--archive",
     sha256 = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905",
     url = "https://static.crates.io/crates/pin-project-lite/pin-project-lite-0.2.6.crate",
@@ -995,6 +1298,12 @@ archive(
     name = "quick-error-2.0.0--archive",
     sha256 = "3ac73b1112776fc109b2e61909bc46c7e1bf0d7f690ffb1676553acce16d5cda",
     url = "https://static.crates.io/crates/quick-error/quick-error-2.0.0.crate",
+)
+
+archive(
+    name = "quickcheck-0.9.2--archive",
+    sha256 = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f",
+    url = "https://static.crates.io/crates/quickcheck/quickcheck-0.9.2.crate",
 )
 
 archive(
@@ -1115,6 +1424,18 @@ archive(
     name = "rayon-core-1.9.0--archive",
     sha256 = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a",
     url = "https://static.crates.io/crates/rayon-core/rayon-core-1.9.0.crate",
+)
+
+archive(
+    name = "ref-cast-1.0.6--archive",
+    sha256 = "300f2a835d808734ee295d45007adacb9ebb29dd3ae2424acfa17930cae541da",
+    url = "https://static.crates.io/crates/ref-cast/ref-cast-1.0.6.crate",
+)
+
+archive(
+    name = "ref-cast-impl-1.0.6--archive",
+    sha256 = "4c38e3aecd2b21cb3959637b883bb3714bc7e43f0268b9a29d3743ee3e55cdd2",
+    url = "https://static.crates.io/crates/ref-cast-impl/ref-cast-impl-1.0.6.crate",
 )
 
 archive(
@@ -1358,9 +1679,9 @@ archive(
 )
 
 archive(
-    name = "syn-1.0.73--archive",
-    sha256 = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7",
-    url = "https://static.crates.io/crates/syn/syn-1.0.73.crate",
+    name = "syn-1.0.75--archive",
+    sha256 = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7",
+    url = "https://static.crates.io/crates/syn/syn-1.0.75.crate",
 )
 
 archive(
@@ -1373,6 +1694,12 @@ archive(
     name = "take_mut-0.2.2--archive",
     sha256 = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60",
     url = "https://static.crates.io/crates/take_mut/take_mut-0.2.2.crate",
+)
+
+archive(
+    name = "tar-0.4.30--archive",
+    sha256 = "489997b7557e9a43e192c527face4feacc78bfbe6eed67fd55c4c9e381cba290",
+    url = "https://static.crates.io/crates/tar/tar-0.4.30.crate",
 )
 
 archive(
@@ -1397,6 +1724,12 @@ archive(
     name = "term_size-0.3.2--archive",
     sha256 = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9",
     url = "https://static.crates.io/crates/term_size/term_size-0.3.2.crate",
+)
+
+archive(
+    name = "termcolor-1.1.2--archive",
+    sha256 = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4",
+    url = "https://static.crates.io/crates/termcolor/termcolor-1.1.2.crate",
 )
 
 archive(
@@ -1436,9 +1769,21 @@ archive(
 )
 
 archive(
+    name = "tokio-0.2.25--archive",
+    sha256 = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092",
+    url = "https://static.crates.io/crates/tokio/tokio-0.2.25.crate",
+)
+
+archive(
     name = "tokio-1.7.1--archive",
     sha256 = "5fb2ed024293bb19f7a5dc54fe83bf86532a44c12a2bb8ba40d64a4509395ca2",
     url = "https://static.crates.io/crates/tokio/tokio-1.7.1.crate",
+)
+
+archive(
+    name = "tokio-macros-0.2.6--archive",
+    sha256 = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a",
+    url = "https://static.crates.io/crates/tokio-macros/tokio-macros-0.2.6.crate",
 )
 
 archive(
@@ -1658,6 +2003,12 @@ archive(
 )
 
 archive(
+    name = "xattr-0.2.2--archive",
+    sha256 = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c",
+    url = "https://static.crates.io/crates/xattr/xattr-0.2.2.crate",
+)
+
+archive(
     name = "zstd-0.8.0+zstd.1.4.9--archive",
     sha256 = "afab5e288c9e10bcd910b16ad82cb8028b74b09eccaa5ecd90621f99d3380735",
     url = "https://static.crates.io/crates/zstd/zstd-0.8.0+zstd.1.4.9.crate",
@@ -1720,7 +2071,7 @@ third_party_rust_library(
 )
 
 third_party_rust_library(
-    name = "ahash-0.7.4",
+    name = "ahash",
     srcs = [
         "ahash-0.7.4/src/aes_hash.rs",
         "ahash-0.7.4/src/convert.rs",
@@ -1740,7 +2091,9 @@ third_party_rust_library(
     env = {
     },
     features = [
+        "default",
         "runtime-rng",
+        "std",
         "specialize",
     ],
     mapped_srcs = {
@@ -1796,7 +2149,7 @@ third_party_rust_library(
     },
     proc_macro = False,
     rustc_flags = ["--cap-lints=allow"],
-    deps = [":memchr-2.4.0"],
+    deps = [":memchr-2.4.1"],
 )
 
 third_party_rust_library(
@@ -1889,6 +2242,25 @@ third_party_rust_library(
         "--cap-lints=allow",
         "--cfg=backtrace",
     ],
+    deps = [],
+)
+
+third_party_rust_library(
+    name = "argv",
+    srcs = ["argv-0.1.2/src/lib.rs"],
+    archive = ":argv-0.1.2--archive",
+    crate = "argv",
+    crate_root = "argv-0.1.2/src/lib.rs",
+    edition = "2018",
+    env = {
+    },
+    features = [],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = False,
+    rustc_flags = ["--cap-lints=allow"],
     deps = [],
 )
 
@@ -2093,6 +2465,39 @@ third_party_rust_library(
         ":object-0.20.0",
         ":rustc-demangle",
     ],
+)
+
+third_party_rust_library(
+    name = "base64",
+    srcs = [
+        "base64-0.11.0/src/chunked_encoder.rs",
+        "base64-0.11.0/src/decode.rs",
+        "base64-0.11.0/src/display.rs",
+        "base64-0.11.0/src/encode.rs",
+        "base64-0.11.0/src/lib.rs",
+        "base64-0.11.0/src/tables.rs",
+        "base64-0.11.0/src/tests.rs",
+        "base64-0.11.0/src/write/encoder.rs",
+        "base64-0.11.0/src/write/encoder_tests.rs",
+        "base64-0.11.0/src/write/mod.rs",
+    ],
+    archive = ":base64-0.11.0--archive",
+    crate = "base64",
+    crate_root = "base64-0.11.0/src/lib.rs",
+    edition = "2018",
+    env = {
+    },
+    features = [
+        "default",
+        "std",
+    ],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = False,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [],
 )
 
 third_party_rust_library(
@@ -2375,9 +2780,28 @@ third_party_rust_library(
     proc_macro = False,
     rustc_flags = ["--cap-lints=allow"],
     deps = [
-        ":memchr-2.4.0",
+        ":memchr-2.4.1",
         ":safemem-0.3.3",
     ],
+)
+
+third_party_rust_library(
+    name = "bufsize",
+    srcs = ["bufsize-1.0.0/src/lib.rs"],
+    archive = ":bufsize-1.0.0--archive",
+    crate = "bufsize",
+    crate_root = "bufsize-1.0.0/src/lib.rs",
+    edition = "2018",
+    env = {
+    },
+    features = [],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = False,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [":bytes"],
 )
 
 third_party_rust_library(
@@ -2750,6 +3174,55 @@ third_party_rust_library(
         ":unicode-width",
         ":vec_map",
     ],
+)
+
+third_party_rust_library(
+    name = "codespan-reporting-0.11.0",
+    srcs = [
+        "codespan-reporting-0.11.0/src/diagnostic.rs",
+        "codespan-reporting-0.11.0/src/files.rs",
+        "codespan-reporting-0.11.0/src/lib.rs",
+        "codespan-reporting-0.11.0/src/term.rs",
+        "codespan-reporting-0.11.0/src/term/config.rs",
+        "codespan-reporting-0.11.0/src/term/renderer.rs",
+        "codespan-reporting-0.11.0/src/term/views.rs",
+    ],
+    archive = ":codespan-reporting-0.11.0--archive",
+    crate = "codespan_reporting",
+    crate_root = "codespan-reporting-0.11.0/src/lib.rs",
+    edition = "2018",
+    env = {
+    },
+    features = [],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = False,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [
+        ":termcolor",
+        ":unicode-width",
+    ],
+)
+
+third_party_rust_library(
+    name = "const-cstr",
+    srcs = ["const-cstr-0.3.0/src/lib.rs"],
+    archive = ":const-cstr-0.3.0--archive",
+    crate = "const_cstr",
+    crate_root = "const-cstr-0.3.0/src/lib.rs",
+    edition = "2015",
+    env = {
+    },
+    features = [],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = False,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [],
 )
 
 third_party_rust_library(
@@ -3145,6 +3618,221 @@ third_party_rust_library(
     proc_macro = False,
     rustc_flags = ["--cap-lints=allow"],
     deps = [":sct-0.6.0"],
+)
+
+third_party_rust_library(
+    name = "cxx",
+    srcs = [
+        "cxx-1.0.52/src/cxx_string.rs",
+        "cxx-1.0.52/src/cxx_vector.rs",
+        "cxx-1.0.52/src/exception.rs",
+        "cxx-1.0.52/src/extern_type.rs",
+        "cxx-1.0.52/src/fmt.rs",
+        "cxx-1.0.52/src/function.rs",
+        "cxx-1.0.52/src/lib.rs",
+        "cxx-1.0.52/src/macros/assert.rs",
+        "cxx-1.0.52/src/macros/concat.rs",
+        "cxx-1.0.52/src/macros/mod.rs",
+        "cxx-1.0.52/src/memory.rs",
+        "cxx-1.0.52/src/opaque.rs",
+        "cxx-1.0.52/src/result.rs",
+        "cxx-1.0.52/src/rust_slice.rs",
+        "cxx-1.0.52/src/rust_str.rs",
+        "cxx-1.0.52/src/rust_string.rs",
+        "cxx-1.0.52/src/rust_type.rs",
+        "cxx-1.0.52/src/rust_vec.rs",
+        "cxx-1.0.52/src/shared_ptr.rs",
+        "cxx-1.0.52/src/symbols/exception.rs",
+        "cxx-1.0.52/src/symbols/mod.rs",
+        "cxx-1.0.52/src/symbols/rust_slice.rs",
+        "cxx-1.0.52/src/symbols/rust_str.rs",
+        "cxx-1.0.52/src/symbols/rust_string.rs",
+        "cxx-1.0.52/src/symbols/rust_vec.rs",
+        "cxx-1.0.52/src/type_id.rs",
+        "cxx-1.0.52/src/unique_ptr.rs",
+        "cxx-1.0.52/src/unwind.rs",
+        "cxx-1.0.52/src/vector.rs",
+        "cxx-1.0.52/src/weak_ptr.rs",
+    ],
+    archive = ":cxx-1.0.52--archive",
+    crate = "cxx",
+    crate_root = "cxx-1.0.52/src/lib.rs",
+    edition = "2018",
+    env = {
+    },
+    features = ["default"],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = False,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [
+        ":cxx-core",
+        ":cxxbridge-macro-1.0.52",
+        ":link-cplusplus-1.0.3",
+    ],
+)
+
+third_party_rust_library(
+    name = "cxxbridge-cmd",
+    srcs = ["cxxbridge-cmd-1.0.52/src/lib.rs"],
+    archive = ":cxxbridge-cmd-1.0.52--archive",
+    crate = "cxxbridge_cmd",
+    crate_root = "cxxbridge-cmd-1.0.52/src/lib.rs",
+    edition = "2018",
+    env = {
+        "CARGO_PKG_AUTHORS": "",
+    },
+    features = [],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = False,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [
+        ":clap",
+        ":codespan-reporting-0.11.0",
+        ":proc-macro2",
+        ":quote",
+        ":syn",
+    ],
+)
+
+third_party_rust_binary(
+    name = "cxxbridge-cmd-cxxbridge",
+    srcs = [
+        "cxxbridge-cmd-1.0.52/src/app.rs",
+        "cxxbridge-cmd-1.0.52/src/gen/block.rs",
+        "cxxbridge-cmd-1.0.52/src/gen/builtin.rs",
+        "cxxbridge-cmd-1.0.52/src/gen/check.rs",
+        "cxxbridge-cmd-1.0.52/src/gen/error.rs",
+        "cxxbridge-cmd-1.0.52/src/gen/file.rs",
+        "cxxbridge-cmd-1.0.52/src/gen/fs.rs",
+        "cxxbridge-cmd-1.0.52/src/gen/ifndef.rs",
+        "cxxbridge-cmd-1.0.52/src/gen/include.rs",
+        "cxxbridge-cmd-1.0.52/src/gen/include/cxx.h",
+        "cxxbridge-cmd-1.0.52/src/gen/mod.rs",
+        "cxxbridge-cmd-1.0.52/src/gen/namespace.rs",
+        "cxxbridge-cmd-1.0.52/src/gen/nested.rs",
+        "cxxbridge-cmd-1.0.52/src/gen/out.rs",
+        "cxxbridge-cmd-1.0.52/src/gen/write.rs",
+        "cxxbridge-cmd-1.0.52/src/main.rs",
+        "cxxbridge-cmd-1.0.52/src/output.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/atom.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/attrs.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/check.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/derive.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/discriminant.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/doc.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/error.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/file.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/ident.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/impls.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/improper.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/instantiate.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/mangle.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/map.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/mod.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/names.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/namespace.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/parse.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/pod.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/qualified.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/report.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/resolve.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/set.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/symbol.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/tokens.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/toposort.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/trivial.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/types.rs",
+        "cxxbridge-cmd-1.0.52/src/syntax/visit.rs",
+        "cxxbridge-cmd-1.0.52/src/test.rs",
+    ],
+    archive = ":cxxbridge-cmd-1.0.52--archive",
+    crate = "cxxbridge",
+    crate_root = "cxxbridge-cmd-1.0.52/src/main.rs",
+    edition = "2018",
+    env = {
+        "CARGO_PKG_AUTHORS": "",
+    },
+    features = [],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = False,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [
+        ":clap",
+        ":codespan-reporting-0.11.0",
+        ":cxxbridge-cmd",
+        ":proc-macro2",
+        ":quote",
+        ":syn",
+    ],
+)
+
+third_party_rust_library(
+    name = "cxxbridge-macro-1.0.52",
+    srcs = [
+        "cxxbridge-macro-1.0.52/src/clang.rs",
+        "cxxbridge-macro-1.0.52/src/derive.rs",
+        "cxxbridge-macro-1.0.52/src/expand.rs",
+        "cxxbridge-macro-1.0.52/src/generics.rs",
+        "cxxbridge-macro-1.0.52/src/lib.rs",
+        "cxxbridge-macro-1.0.52/src/load.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/atom.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/attrs.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/check.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/derive.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/discriminant.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/doc.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/error.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/file.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/ident.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/impls.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/improper.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/instantiate.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/mangle.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/map.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/mod.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/names.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/namespace.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/parse.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/pod.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/qualified.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/report.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/resolve.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/set.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/symbol.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/tokens.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/toposort.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/trivial.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/types.rs",
+        "cxxbridge-macro-1.0.52/src/syntax/visit.rs",
+        "cxxbridge-macro-1.0.52/src/type_id.rs",
+    ],
+    archive = ":cxxbridge-macro-1.0.52--archive",
+    crate = "cxxbridge_macro",
+    crate_root = "cxxbridge-macro-1.0.52/src/lib.rs",
+    edition = "2018",
+    env = {
+    },
+    features = [],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = True,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [
+        ":proc-macro2",
+        ":quote",
+        ":syn",
+    ],
 )
 
 third_party_rust_library(
@@ -3723,6 +4411,51 @@ third_party_rust_library(
 )
 
 third_party_rust_library(
+    name = "env_logger",
+    srcs = [
+        "env_logger-0.7.1/src/filter/mod.rs",
+        "env_logger-0.7.1/src/filter/regex.rs",
+        "env_logger-0.7.1/src/filter/string.rs",
+        "env_logger-0.7.1/src/fmt/humantime/extern_impl.rs",
+        "env_logger-0.7.1/src/fmt/humantime/mod.rs",
+        "env_logger-0.7.1/src/fmt/humantime/shim_impl.rs",
+        "env_logger-0.7.1/src/fmt/mod.rs",
+        "env_logger-0.7.1/src/fmt/writer/atty.rs",
+        "env_logger-0.7.1/src/fmt/writer/mod.rs",
+        "env_logger-0.7.1/src/fmt/writer/termcolor/extern_impl.rs",
+        "env_logger-0.7.1/src/fmt/writer/termcolor/mod.rs",
+        "env_logger-0.7.1/src/fmt/writer/termcolor/shim_impl.rs",
+        "env_logger-0.7.1/src/lib.rs",
+    ],
+    archive = ":env_logger-0.7.1--archive",
+    crate = "env_logger",
+    crate_root = "env_logger-0.7.1/src/lib.rs",
+    edition = "2018",
+    env = {
+    },
+    features = [
+        "atty",
+        "default",
+        "humantime",
+        "regex",
+        "termcolor",
+    ],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = False,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [
+        ":atty",
+        ":humantime",
+        ":log",
+        ":regex",
+        ":termcolor",
+    ],
+)
+
+third_party_rust_library(
     name = "erased-serde",
     srcs = [
         "erased-serde-0.3.12/src/any.rs",
@@ -3930,6 +4663,39 @@ third_party_rust_library(
     proc_macro = False,
     rustc_flags = ["--cap-lints=allow"],
     deps = [],
+)
+
+third_party_rust_library(
+    name = "filetime",
+    srcs = [
+        "filetime-0.2.12/src/lib.rs",
+        "filetime-0.2.12/src/redox.rs",
+        "filetime-0.2.12/src/unix/android.rs",
+        "filetime-0.2.12/src/unix/linux.rs",
+        "filetime-0.2.12/src/unix/macos.rs",
+        "filetime-0.2.12/src/unix/mod.rs",
+        "filetime-0.2.12/src/unix/utimensat.rs",
+        "filetime-0.2.12/src/unix/utimes.rs",
+        "filetime-0.2.12/src/wasm.rs",
+        "filetime-0.2.12/src/windows.rs",
+    ],
+    archive = ":filetime-0.2.12--archive",
+    crate = "filetime",
+    crate_root = "filetime-0.2.12/src/lib.rs",
+    edition = "2018",
+    env = {
+    },
+    features = [],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = False,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [
+        ":cfg-if",
+        ":libc",
+    ],
 )
 
 third_party_rust_library(
@@ -4593,7 +5359,7 @@ third_party_rust_library(
         ":futures-macro-0.3.13",
         ":futures-sink",
         ":futures-task-0.3.13",
-        ":memchr-2.4.0",
+        ":memchr-2.4.1",
         ":pin-project-lite-0.2.6",
         ":pin-utils-0.1.0",
         ":proc-macro-hack",
@@ -4825,6 +5591,36 @@ third_party_rust_binary(
     proc_macro = False,
     rustc_flags = ["--cap-lints=allow"],
     deps = [],
+)
+
+third_party_rust_library(
+    name = "ghost",
+    srcs = [
+        "ghost-0.1.2/src/args.rs",
+        "ghost-0.1.2/src/derive.rs",
+        "ghost-0.1.2/src/lib.rs",
+        "ghost-0.1.2/src/parse.rs",
+        "ghost-0.1.2/src/variance.rs",
+        "ghost-0.1.2/src/visibility.rs",
+    ],
+    archive = ":ghost-0.1.2--archive",
+    crate = "ghost",
+    crate_root = "ghost-0.1.2/src/lib.rs",
+    edition = "2018",
+    env = {
+    },
+    features = [],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = True,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [
+        ":proc-macro2",
+        ":quote",
+        ":syn",
+    ],
 )
 
 third_party_rust_library(
@@ -5098,7 +5894,7 @@ third_party_rust_library(
     crate_root = "handlebars-3.5.4/src/lib.rs",
     edition = "2018",
     env = {
-        "CARGO_MANIFEST_DIR": "third-party/rust/handlebars-3.5.4",
+        "CARGO_MANIFEST_DIR": "$(location :handlebars-3.5.4--archive)/handlebars-3.5.4",
         "CARGO_PKG_NAME": "handlebars",
         "CARGO_PKG_VERSION": "3.5.4",
         "CARGO_PKG_VERSION_MAJOR": "3",
@@ -5113,12 +5909,12 @@ third_party_rust_library(
     proc_macro = False,
     rustc_flags = ["--cap-lints=allow"],
     deps = [
-        "//third-party/rust:log",
-        "//third-party/rust:pest",
-        "//third-party/rust:pest_derive",
-        "//third-party/rust:quick-error-2.0.0",
-        "//third-party/rust:serde",
-        "//third-party/rust:serde_json",
+        ":log",
+        ":pest",
+        ":pest_derive",
+        ":quick-error-2.0.0",
+        ":serde",
+        ":serde_json",
     ],
 )
 
@@ -5149,7 +5945,7 @@ third_party_rust_library(
     crate_root = "hashbrown-0.11.2/src/lib.rs",
     edition = "2018",
     env = {
-        "CARGO_MANIFEST_DIR": "third-party/rust/hashbrown-0.11.2",
+        "CARGO_MANIFEST_DIR": "$(location :hashbrown-0.11.2--archive)/hashbrown-0.11.2",
         "CARGO_PKG_NAME": "hashbrown",
         "CARGO_PKG_VERSION": "0.11.2",
         "CARGO_PKG_VERSION_MAJOR": "0",
@@ -5170,7 +5966,7 @@ third_party_rust_library(
     proc_macro = False,
     rustc_flags = ["--cap-lints=allow"],
     deps = [
-        ":ahash-0.7.4",
+        ":ahash",
         ":serde",
     ],
 )
@@ -5513,6 +6309,30 @@ third_party_rust_library(
 )
 
 third_party_rust_library(
+    name = "humantime",
+    srcs = [
+        "humantime-1.3.0/src/date.rs",
+        "humantime-1.3.0/src/duration.rs",
+        "humantime-1.3.0/src/lib.rs",
+        "humantime-1.3.0/src/wrapper.rs",
+    ],
+    archive = ":humantime-1.3.0--archive",
+    crate = "humantime",
+    crate_root = "humantime-1.3.0/src/lib.rs",
+    edition = "2015",
+    env = {
+    },
+    features = [],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = False,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [":quick-error-1.2.3"],
+)
+
+third_party_rust_library(
     name = "hyper",
     srcs = [
         "hyper-0.14.7/src/body/aggregate.rs",
@@ -5798,6 +6618,33 @@ third_party_rust_library(
     proc_macro = False,
     rustc_flags = ["--cap-lints=allow"],
     deps = [":cfg-if"],
+)
+
+third_party_rust_library(
+    name = "iovec-0.1.4",
+    srcs = [
+        "iovec-0.1.4/src/lib.rs",
+        "iovec-0.1.4/src/sys/mod.rs",
+        "iovec-0.1.4/src/sys/unix.rs",
+        "iovec-0.1.4/src/sys/unknown.rs",
+        "iovec-0.1.4/src/sys/windows.rs",
+        "iovec-0.1.4/src/unix.rs",
+        "iovec-0.1.4/src/windows.rs",
+    ],
+    archive = ":iovec-0.1.4--archive",
+    crate = "iovec",
+    crate_root = "iovec-0.1.4/src/lib.rs",
+    edition = "2015",
+    env = {
+    },
+    features = [],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = False,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [":libc"],
 )
 
 third_party_rust_library(
@@ -6098,7 +6945,7 @@ third_party_rust_library(
     crate_root = "lalrpop-0.19.1/src/lib.rs",
     edition = "2015",
     env = {
-        "CARGO_MANIFEST_DIR": "third-party/rust/lalrpop-0.19.1",
+        "CARGO_MANIFEST_DIR": "$(location :lalrpop-0.19.1--archive)/lalrpop-0.19.1",
         "CARGO_PKG_NAME": "lalrpop",
         "CARGO_PKG_VERSION": "0.19.1",
         "CARGO_PKG_VERSION_MAJOR": "0",
@@ -6252,7 +7099,7 @@ third_party_rust_binary(
     crate_root = "lalrpop-0.19.1/src/main.rs",
     edition = "2015",
     env = {
-        "CARGO_MANIFEST_DIR": "third-party/rust/lalrpop-0.19.1",
+        "CARGO_MANIFEST_DIR": "$(location :lalrpop-0.19.1--archive)/lalrpop-0.19.1",
         "CARGO_PKG_NAME": "lalrpop",
         "CARGO_PKG_VERSION": "0.19.1",
         "CARGO_PKG_VERSION_MAJOR": "0",
@@ -6884,6 +7731,25 @@ third_party_rust_library(
 )
 
 third_party_rust_library(
+    name = "link-cplusplus-1.0.3",
+    srcs = ["link-cplusplus-1.0.3/src/lib.rs"],
+    archive = ":link-cplusplus-1.0.3--archive",
+    crate = "link_cplusplus",
+    crate_root = "link-cplusplus-1.0.3/src/lib.rs",
+    edition = "2018",
+    env = {
+    },
+    features = ["default"],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = False,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [],
+)
+
+third_party_rust_library(
     name = "linked-hash-map",
     srcs = [
         "linked-hash-map-0.5.3/src/heapsize.rs",
@@ -7130,6 +7996,38 @@ third_party_rust_library(
 )
 
 third_party_rust_library(
+    name = "macros",
+    srcs = [
+        "shed/fbinit/macros/expand.rs",
+        "shed/fbinit/macros/lib.rs",
+    ],
+    archive = None,
+    crate = None,
+    crate_root = "shed/fbinit/macros/lib.rs",
+    edition = None,
+    env = {
+    },
+    features = [],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = True,
+    rustc_flags = [
+        "-Aunused_braces",
+        "-Wbare_trait_objects",
+        "-Wellipsis_inclusive_range_patterns",
+        "-Dnon_fmt_panic",
+        "-Dunconditional_recursion",
+    ],
+    deps = [
+        ":proc-macro2",
+        ":quote",
+        ":syn",
+    ],
+)
+
+third_party_rust_library(
     name = "maplit",
     srcs = ["maplit-1.0.2/src/lib.rs"],
     archive = ":maplit-1.0.2--archive",
@@ -7242,45 +8140,45 @@ third_party_rust_binary(
 )
 
 third_party_rust_library(
-    name = "memchr-2.4.0",
+    name = "memchr-2.4.1",
     srcs = [
-        "memchr-2.4.0/src/cow.rs",
-        "memchr-2.4.0/src/lib.rs",
-        "memchr-2.4.0/src/memchr/c.rs",
-        "memchr-2.4.0/src/memchr/fallback.rs",
-        "memchr-2.4.0/src/memchr/iter.rs",
-        "memchr-2.4.0/src/memchr/mod.rs",
-        "memchr-2.4.0/src/memchr/naive.rs",
-        "memchr-2.4.0/src/memchr/x86/avx.rs",
-        "memchr-2.4.0/src/memchr/x86/mod.rs",
-        "memchr-2.4.0/src/memchr/x86/sse2.rs",
-        "memchr-2.4.0/src/memmem/byte_frequencies.rs",
-        "memchr-2.4.0/src/memmem/genericsimd.rs",
-        "memchr-2.4.0/src/memmem/mod.rs",
-        "memchr-2.4.0/src/memmem/prefilter/fallback.rs",
-        "memchr-2.4.0/src/memmem/prefilter/genericsimd.rs",
-        "memchr-2.4.0/src/memmem/prefilter/mod.rs",
-        "memchr-2.4.0/src/memmem/prefilter/x86/avx.rs",
-        "memchr-2.4.0/src/memmem/prefilter/x86/mod.rs",
-        "memchr-2.4.0/src/memmem/prefilter/x86/sse.rs",
-        "memchr-2.4.0/src/memmem/rabinkarp.rs",
-        "memchr-2.4.0/src/memmem/rarebytes.rs",
-        "memchr-2.4.0/src/memmem/twoway.rs",
-        "memchr-2.4.0/src/memmem/util.rs",
-        "memchr-2.4.0/src/memmem/vector.rs",
-        "memchr-2.4.0/src/memmem/x86/avx.rs",
-        "memchr-2.4.0/src/memmem/x86/mod.rs",
-        "memchr-2.4.0/src/memmem/x86/sse.rs",
-        "memchr-2.4.0/src/tests/memchr/iter.rs",
-        "memchr-2.4.0/src/tests/memchr/memchr.rs",
-        "memchr-2.4.0/src/tests/memchr/mod.rs",
-        "memchr-2.4.0/src/tests/memchr/simple.rs",
-        "memchr-2.4.0/src/tests/memchr/testdata.rs",
-        "memchr-2.4.0/src/tests/mod.rs",
+        "memchr-2.4.1/src/cow.rs",
+        "memchr-2.4.1/src/lib.rs",
+        "memchr-2.4.1/src/memchr/c.rs",
+        "memchr-2.4.1/src/memchr/fallback.rs",
+        "memchr-2.4.1/src/memchr/iter.rs",
+        "memchr-2.4.1/src/memchr/mod.rs",
+        "memchr-2.4.1/src/memchr/naive.rs",
+        "memchr-2.4.1/src/memchr/x86/avx.rs",
+        "memchr-2.4.1/src/memchr/x86/mod.rs",
+        "memchr-2.4.1/src/memchr/x86/sse2.rs",
+        "memchr-2.4.1/src/memmem/byte_frequencies.rs",
+        "memchr-2.4.1/src/memmem/genericsimd.rs",
+        "memchr-2.4.1/src/memmem/mod.rs",
+        "memchr-2.4.1/src/memmem/prefilter/fallback.rs",
+        "memchr-2.4.1/src/memmem/prefilter/genericsimd.rs",
+        "memchr-2.4.1/src/memmem/prefilter/mod.rs",
+        "memchr-2.4.1/src/memmem/prefilter/x86/avx.rs",
+        "memchr-2.4.1/src/memmem/prefilter/x86/mod.rs",
+        "memchr-2.4.1/src/memmem/prefilter/x86/sse.rs",
+        "memchr-2.4.1/src/memmem/rabinkarp.rs",
+        "memchr-2.4.1/src/memmem/rarebytes.rs",
+        "memchr-2.4.1/src/memmem/twoway.rs",
+        "memchr-2.4.1/src/memmem/util.rs",
+        "memchr-2.4.1/src/memmem/vector.rs",
+        "memchr-2.4.1/src/memmem/x86/avx.rs",
+        "memchr-2.4.1/src/memmem/x86/mod.rs",
+        "memchr-2.4.1/src/memmem/x86/sse.rs",
+        "memchr-2.4.1/src/tests/memchr/iter.rs",
+        "memchr-2.4.1/src/tests/memchr/memchr.rs",
+        "memchr-2.4.1/src/tests/memchr/mod.rs",
+        "memchr-2.4.1/src/tests/memchr/simple.rs",
+        "memchr-2.4.1/src/tests/memchr/testdata.rs",
+        "memchr-2.4.1/src/tests/mod.rs",
     ],
-    archive = ":memchr-2.4.0--archive",
+    archive = ":memchr-2.4.1--archive",
     crate = "memchr",
-    crate_root = "memchr-2.4.0/src/lib.rs",
+    crate_root = "memchr-2.4.1/src/lib.rs",
     edition = "2018",
     env = {
     },
@@ -7296,17 +8194,17 @@ third_party_rust_library(
     proc_macro = False,
     rustc_flags = [
         "--cap-lints=allow",
-        "@$(location :memchr-2.4.0-build-script-build-args)",
+        "@$(location :memchr-2.4.1-build-script-build-args)",
     ],
     deps = [],
 )
 
 third_party_rust_binary(
-    name = "memchr-2.4.0-build-script-build",
-    srcs = ["memchr-2.4.0/build.rs"],
-    archive = ":memchr-2.4.0--archive",
+    name = "memchr-2.4.1-build-script-build",
+    srcs = ["memchr-2.4.1/build.rs"],
+    archive = ":memchr-2.4.1--archive",
     crate = "build_script_build",
-    crate_root = "memchr-2.4.0/build.rs",
+    crate_root = "memchr-2.4.1/build.rs",
     edition = "2018",
     env = {
     },
@@ -7578,6 +8476,110 @@ third_party_rust_library(
 )
 
 third_party_rust_library(
+    name = "mio-06",
+    srcs = [
+        "mio-0.6.23/src/channel.rs",
+        "mio-0.6.23/src/deprecated/event_loop.rs",
+        "mio-0.6.23/src/deprecated/handler.rs",
+        "mio-0.6.23/src/deprecated/io.rs",
+        "mio-0.6.23/src/deprecated/mod.rs",
+        "mio-0.6.23/src/deprecated/notify.rs",
+        "mio-0.6.23/src/deprecated/unix.rs",
+        "mio-0.6.23/src/event_imp.rs",
+        "mio-0.6.23/src/io.rs",
+        "mio-0.6.23/src/lazycell.rs",
+        "mio-0.6.23/src/lib.rs",
+        "mio-0.6.23/src/net/mod.rs",
+        "mio-0.6.23/src/net/tcp.rs",
+        "mio-0.6.23/src/net/udp.rs",
+        "mio-0.6.23/src/poll.rs",
+        "mio-0.6.23/src/sys/fuchsia/awakener.rs",
+        "mio-0.6.23/src/sys/fuchsia/eventedfd.rs",
+        "mio-0.6.23/src/sys/fuchsia/handles.rs",
+        "mio-0.6.23/src/sys/fuchsia/mod.rs",
+        "mio-0.6.23/src/sys/fuchsia/net.rs",
+        "mio-0.6.23/src/sys/fuchsia/ready.rs",
+        "mio-0.6.23/src/sys/fuchsia/selector.rs",
+        "mio-0.6.23/src/sys/mod.rs",
+        "mio-0.6.23/src/sys/unix/awakener.rs",
+        "mio-0.6.23/src/sys/unix/dlsym.rs",
+        "mio-0.6.23/src/sys/unix/epoll.rs",
+        "mio-0.6.23/src/sys/unix/eventedfd.rs",
+        "mio-0.6.23/src/sys/unix/io.rs",
+        "mio-0.6.23/src/sys/unix/kqueue.rs",
+        "mio-0.6.23/src/sys/unix/mod.rs",
+        "mio-0.6.23/src/sys/unix/ready.rs",
+        "mio-0.6.23/src/sys/unix/tcp.rs",
+        "mio-0.6.23/src/sys/unix/udp.rs",
+        "mio-0.6.23/src/sys/unix/uds.rs",
+        "mio-0.6.23/src/sys/unix/uio.rs",
+        "mio-0.6.23/src/sys/windows/awakener.rs",
+        "mio-0.6.23/src/sys/windows/buffer_pool.rs",
+        "mio-0.6.23/src/sys/windows/from_raw_arc.rs",
+        "mio-0.6.23/src/sys/windows/mod.rs",
+        "mio-0.6.23/src/sys/windows/selector.rs",
+        "mio-0.6.23/src/sys/windows/tcp.rs",
+        "mio-0.6.23/src/sys/windows/udp.rs",
+        "mio-0.6.23/src/timer.rs",
+        "mio-0.6.23/src/token.rs",
+        "mio-0.6.23/src/udp.rs",
+    ],
+    archive = ":mio-0.6.23--archive",
+    crate = "mio",
+    crate_root = "mio-0.6.23/src/lib.rs",
+    edition = "2015",
+    env = {
+    },
+    features = [
+        "default",
+        "with-deprecated",
+    ],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = False,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [
+        ":cfg-if",
+        ":iovec-0.1.4",
+        ":libc",
+        ":log",
+        ":net2-0.2.37",
+        ":slab-0.4.2",
+    ],
+)
+
+third_party_rust_library(
+    name = "mio-uds-0.6.8",
+    srcs = [
+        "mio-uds-0.6.8/src/datagram.rs",
+        "mio-uds-0.6.8/src/lib.rs",
+        "mio-uds-0.6.8/src/listener.rs",
+        "mio-uds-0.6.8/src/socket.rs",
+        "mio-uds-0.6.8/src/stream.rs",
+    ],
+    archive = ":mio-uds-0.6.8--archive",
+    crate = "mio_uds",
+    crate_root = "mio-uds-0.6.8/src/lib.rs",
+    edition = "2015",
+    env = {
+    },
+    features = [],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = False,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [
+        ":iovec-0.1.4",
+        ":libc",
+        ":mio-06",
+    ],
+)
+
+third_party_rust_library(
     name = "multipart-0.17.0",
     srcs = [
         "multipart-0.17.0/src/bin/form_test.rs",
@@ -7629,6 +8631,47 @@ third_party_rust_library(
         ":safemem-0.3.3",
         ":tempfile",
         ":twoway-0.1.8",
+    ],
+)
+
+third_party_rust_library(
+    name = "net2-0.2.37",
+    srcs = [
+        "net2-0.2.37/src/ext.rs",
+        "net2-0.2.37/src/lib.rs",
+        "net2-0.2.37/src/socket.rs",
+        "net2-0.2.37/src/sys/redox/impls.rs",
+        "net2-0.2.37/src/sys/redox/mod.rs",
+        "net2-0.2.37/src/sys/unix/impls.rs",
+        "net2-0.2.37/src/sys/unix/mod.rs",
+        "net2-0.2.37/src/sys/wasi/impls.rs",
+        "net2-0.2.37/src/sys/wasi/mod.rs",
+        "net2-0.2.37/src/sys/windows/impls.rs",
+        "net2-0.2.37/src/sys/windows/mod.rs",
+        "net2-0.2.37/src/tcp.rs",
+        "net2-0.2.37/src/udp.rs",
+        "net2-0.2.37/src/unix.rs",
+        "net2-0.2.37/src/utils.rs",
+    ],
+    archive = ":net2-0.2.37--archive",
+    crate = "net2",
+    crate_root = "net2-0.2.37/src/lib.rs",
+    edition = "2015",
+    env = {
+    },
+    features = [
+        "default",
+        "duration",
+    ],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = False,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [
+        ":cfg-if",
+        ":libc",
     ],
 )
 
@@ -7803,6 +8846,32 @@ third_party_rust_library(
         ":bitflags",
         ":cfg-if-1.0.0",
         ":libc",
+    ],
+)
+
+third_party_rust_library(
+    name = "num-derive",
+    srcs = [
+        "num-derive-0.3.2/src/lib.rs",
+        "num-derive-0.3.2/src/test.rs",
+    ],
+    archive = ":num-derive-0.3.2--archive",
+    crate = "num_derive",
+    crate_root = "num-derive-0.3.2/src/lib.rs",
+    edition = "2018",
+    env = {
+    },
+    features = ["full-syntax"],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = True,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [
+        ":proc-macro2",
+        ":quote",
+        ":syn",
     ],
 )
 
@@ -8136,6 +9205,32 @@ third_party_rust_library(
 )
 
 third_party_rust_library(
+    name = "ordered-float",
+    srcs = ["ordered-float-1.1.1/src/lib.rs"],
+    archive = ":ordered-float-1.1.1--archive",
+    crate = "ordered_float",
+    crate_root = "ordered-float-1.1.1/src/lib.rs",
+    edition = "2015",
+    env = {
+    },
+    features = [
+        "default",
+        "serde",
+        "std",
+    ],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = False,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [
+        ":num-traits",
+        ":serde",
+    ],
+)
+
+third_party_rust_library(
     name = "parking_lot-0.11.0",
     srcs = [
         "parking_lot-0.11.0/src/condvar.rs",
@@ -8293,7 +9388,7 @@ third_party_rust_library(
     },
     proc_macro = False,
     rustc_flags = ["--cap-lints=allow"],
-    deps = ["//third-party/rust:ucd-trie-0.1.3"],
+    deps = [":ucd-trie-0.1.3"],
 )
 
 third_party_rust_library(
@@ -8313,8 +9408,8 @@ third_party_rust_library(
     proc_macro = True,
     rustc_flags = ["--cap-lints=allow"],
     deps = [
-        "//third-party/rust:pest",
-        "//third-party/rust:pest_generator-2.1.3",
+        ":pest",
+        ":pest_generator-2.1.3",
     ],
 )
 
@@ -8339,11 +9434,11 @@ third_party_rust_library(
     proc_macro = False,
     rustc_flags = ["--cap-lints=allow"],
     deps = [
-        "//third-party/rust:pest",
-        "//third-party/rust:pest_meta-2.1.3",
-        "//third-party/rust:proc-macro2",
-        "//third-party/rust:quote",
-        "//third-party/rust:syn",
+        ":pest",
+        ":pest_meta-2.1.3",
+        ":proc-macro2",
+        ":quote",
+        ":syn",
     ],
 )
 
@@ -8377,8 +9472,8 @@ third_party_rust_library(
     proc_macro = False,
     rustc_flags = ["--cap-lints=allow"],
     deps = [
-        "//third-party/rust:maplit",
-        "//third-party/rust:pest",
+        ":maplit",
+        ":pest",
     ],
 )
 
@@ -8586,6 +9681,25 @@ third_party_rust_library(
         ":quote",
         ":syn",
     ],
+)
+
+third_party_rust_library(
+    name = "pin-project-lite-0.1.11",
+    srcs = ["pin-project-lite-0.1.11/src/lib.rs"],
+    archive = ":pin-project-lite-0.1.11--archive",
+    crate = "pin_project_lite",
+    crate_root = "pin-project-lite-0.1.11/src/lib.rs",
+    edition = "2018",
+    env = {
+    },
+    features = [],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = False,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [],
 )
 
 third_party_rust_library(
@@ -8970,6 +10084,41 @@ third_party_rust_library(
     proc_macro = False,
     rustc_flags = ["--cap-lints=allow"],
     deps = [],
+)
+
+third_party_rust_library(
+    name = "quickcheck",
+    srcs = [
+        "quickcheck-0.9.2/src/arbitrary.rs",
+        "quickcheck-0.9.2/src/lib.rs",
+        "quickcheck-0.9.2/src/tester.rs",
+        "quickcheck-0.9.2/src/tests.rs",
+    ],
+    archive = ":quickcheck-0.9.2--archive",
+    crate = "quickcheck",
+    crate_root = "quickcheck-0.9.2/src/lib.rs",
+    edition = "2018",
+    env = {
+    },
+    features = [
+        "default",
+        "env_logger",
+        "log",
+        "regex",
+        "use_logging",
+    ],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = False,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [
+        ":env_logger",
+        ":log",
+        ":rand",
+        ":rand_core",
+    ],
 )
 
 third_party_rust_library(
@@ -9893,6 +11042,74 @@ third_party_rust_library(
 )
 
 third_party_rust_library(
+    name = "ref-cast",
+    srcs = [
+        "ref-cast-1.0.6/src/layout.rs",
+        "ref-cast-1.0.6/src/lib.rs",
+        "ref-cast-1.0.6/src/trivial.rs",
+    ],
+    archive = ":ref-cast-1.0.6--archive",
+    crate = "ref_cast",
+    crate_root = "ref-cast-1.0.6/src/lib.rs",
+    edition = "2018",
+    env = {
+    },
+    features = [],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = False,
+    rustc_flags = [
+        "--cap-lints=allow",
+        "@$(location :ref-cast-1.0.6-build-script-build-args)",
+    ],
+    deps = [":ref-cast-impl-1.0.6"],
+)
+
+third_party_rust_binary(
+    name = "ref-cast-1.0.6-build-script-build",
+    srcs = ["ref-cast-1.0.6/build.rs"],
+    archive = ":ref-cast-1.0.6--archive",
+    crate = "build_script_build",
+    crate_root = "ref-cast-1.0.6/build.rs",
+    edition = "2018",
+    env = {
+    },
+    features = [],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = False,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [],
+)
+
+third_party_rust_library(
+    name = "ref-cast-impl-1.0.6",
+    srcs = ["ref-cast-impl-1.0.6/src/lib.rs"],
+    archive = ":ref-cast-impl-1.0.6--archive",
+    crate = "ref_cast_impl",
+    crate_root = "ref-cast-impl-1.0.6/src/lib.rs",
+    edition = "2018",
+    env = {
+    },
+    features = [],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = True,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [
+        ":proc-macro2",
+        ":quote",
+        ":syn",
+    ],
+)
+
+third_party_rust_library(
     name = "regex",
     srcs = [
         "regex-1.4.2/src/backtrack.rs",
@@ -9953,7 +11170,7 @@ third_party_rust_library(
     rustc_flags = ["--cap-lints=allow"],
     deps = [
         ":aho-corasick",
-        ":memchr-2.4.0",
+        ":memchr-2.4.1",
         ":regex-syntax-0.6.21",
         ":thread_local-1.0.1",
     ],
@@ -10412,7 +11629,7 @@ third_party_rust_library(
         ":fs2",
         ":libc",
         ":log",
-        ":memchr-2.4.0",
+        ":memchr-2.4.1",
         ":nix-0.19.1",
         ":unicode-segmentation",
         ":unicode-width",
@@ -11553,61 +12770,61 @@ third_party_rust_library(
 third_party_rust_library(
     name = "syn",
     srcs = [
-        "syn-1.0.73/src/attr.rs",
-        "syn-1.0.73/src/await.rs",
-        "syn-1.0.73/src/bigint.rs",
-        "syn-1.0.73/src/buffer.rs",
-        "syn-1.0.73/src/custom_keyword.rs",
-        "syn-1.0.73/src/custom_punctuation.rs",
-        "syn-1.0.73/src/data.rs",
-        "syn-1.0.73/src/derive.rs",
-        "syn-1.0.73/src/discouraged.rs",
-        "syn-1.0.73/src/error.rs",
-        "syn-1.0.73/src/export.rs",
-        "syn-1.0.73/src/expr.rs",
-        "syn-1.0.73/src/ext.rs",
-        "syn-1.0.73/src/file.rs",
-        "syn-1.0.73/src/gen/clone.rs",
-        "syn-1.0.73/src/gen/debug.rs",
-        "syn-1.0.73/src/gen/eq.rs",
-        "syn-1.0.73/src/gen/fold.rs",
-        "syn-1.0.73/src/gen/hash.rs",
-        "syn-1.0.73/src/gen/visit.rs",
-        "syn-1.0.73/src/gen/visit_mut.rs",
-        "syn-1.0.73/src/gen_helper.rs",
-        "syn-1.0.73/src/generics.rs",
-        "syn-1.0.73/src/group.rs",
-        "syn-1.0.73/src/ident.rs",
-        "syn-1.0.73/src/item.rs",
-        "syn-1.0.73/src/lib.rs",
-        "syn-1.0.73/src/lifetime.rs",
-        "syn-1.0.73/src/lit.rs",
-        "syn-1.0.73/src/lookahead.rs",
-        "syn-1.0.73/src/mac.rs",
-        "syn-1.0.73/src/macros.rs",
-        "syn-1.0.73/src/op.rs",
-        "syn-1.0.73/src/parse.rs",
-        "syn-1.0.73/src/parse_macro_input.rs",
-        "syn-1.0.73/src/parse_quote.rs",
-        "syn-1.0.73/src/pat.rs",
-        "syn-1.0.73/src/path.rs",
-        "syn-1.0.73/src/print.rs",
-        "syn-1.0.73/src/punctuated.rs",
-        "syn-1.0.73/src/reserved.rs",
-        "syn-1.0.73/src/sealed.rs",
-        "syn-1.0.73/src/span.rs",
-        "syn-1.0.73/src/spanned.rs",
-        "syn-1.0.73/src/stmt.rs",
-        "syn-1.0.73/src/thread.rs",
-        "syn-1.0.73/src/token.rs",
-        "syn-1.0.73/src/tt.rs",
-        "syn-1.0.73/src/ty.rs",
-        "syn-1.0.73/src/verbatim.rs",
-        "syn-1.0.73/src/whitespace.rs",
+        "syn-1.0.75/src/attr.rs",
+        "syn-1.0.75/src/await.rs",
+        "syn-1.0.75/src/bigint.rs",
+        "syn-1.0.75/src/buffer.rs",
+        "syn-1.0.75/src/custom_keyword.rs",
+        "syn-1.0.75/src/custom_punctuation.rs",
+        "syn-1.0.75/src/data.rs",
+        "syn-1.0.75/src/derive.rs",
+        "syn-1.0.75/src/discouraged.rs",
+        "syn-1.0.75/src/error.rs",
+        "syn-1.0.75/src/export.rs",
+        "syn-1.0.75/src/expr.rs",
+        "syn-1.0.75/src/ext.rs",
+        "syn-1.0.75/src/file.rs",
+        "syn-1.0.75/src/gen/clone.rs",
+        "syn-1.0.75/src/gen/debug.rs",
+        "syn-1.0.75/src/gen/eq.rs",
+        "syn-1.0.75/src/gen/fold.rs",
+        "syn-1.0.75/src/gen/hash.rs",
+        "syn-1.0.75/src/gen/visit.rs",
+        "syn-1.0.75/src/gen/visit_mut.rs",
+        "syn-1.0.75/src/gen_helper.rs",
+        "syn-1.0.75/src/generics.rs",
+        "syn-1.0.75/src/group.rs",
+        "syn-1.0.75/src/ident.rs",
+        "syn-1.0.75/src/item.rs",
+        "syn-1.0.75/src/lib.rs",
+        "syn-1.0.75/src/lifetime.rs",
+        "syn-1.0.75/src/lit.rs",
+        "syn-1.0.75/src/lookahead.rs",
+        "syn-1.0.75/src/mac.rs",
+        "syn-1.0.75/src/macros.rs",
+        "syn-1.0.75/src/op.rs",
+        "syn-1.0.75/src/parse.rs",
+        "syn-1.0.75/src/parse_macro_input.rs",
+        "syn-1.0.75/src/parse_quote.rs",
+        "syn-1.0.75/src/pat.rs",
+        "syn-1.0.75/src/path.rs",
+        "syn-1.0.75/src/print.rs",
+        "syn-1.0.75/src/punctuated.rs",
+        "syn-1.0.75/src/reserved.rs",
+        "syn-1.0.75/src/sealed.rs",
+        "syn-1.0.75/src/span.rs",
+        "syn-1.0.75/src/spanned.rs",
+        "syn-1.0.75/src/stmt.rs",
+        "syn-1.0.75/src/thread.rs",
+        "syn-1.0.75/src/token.rs",
+        "syn-1.0.75/src/tt.rs",
+        "syn-1.0.75/src/ty.rs",
+        "syn-1.0.75/src/verbatim.rs",
+        "syn-1.0.75/src/whitespace.rs",
     ],
-    archive = ":syn-1.0.73--archive",
+    archive = ":syn-1.0.75--archive",
     crate = "syn",
-    crate_root = "syn-1.0.73/src/lib.rs",
+    crate_root = "syn-1.0.75/src/lib.rs",
     edition = "2018",
     env = {
     },
@@ -11632,7 +12849,7 @@ third_party_rust_library(
     proc_macro = False,
     rustc_flags = [
         "--cap-lints=allow",
-        "@$(location :syn-1.0.73-build-script-build-args)",
+        "@$(location :syn-1.0.75-build-script-build-args)",
     ],
     deps = [
         ":proc-macro2",
@@ -11642,11 +12859,11 @@ third_party_rust_library(
 )
 
 third_party_rust_binary(
-    name = "syn-1.0.73-build-script-build",
-    srcs = ["syn-1.0.73/build.rs"],
-    archive = ":syn-1.0.73--archive",
+    name = "syn-1.0.75-build-script-build",
+    srcs = ["syn-1.0.75/build.rs"],
+    archive = ":syn-1.0.75--archive",
     crate = "build_script_build",
-    crate_root = "syn-1.0.73/build.rs",
+    crate_root = "syn-1.0.75/build.rs",
     edition = "2018",
     env = {
     },
@@ -11723,6 +12940,41 @@ third_party_rust_library(
     proc_macro = False,
     rustc_flags = ["--cap-lints=allow"],
     deps = [],
+)
+
+third_party_rust_library(
+    name = "tar",
+    srcs = [
+        "tar-0.4.30/src/archive.rs",
+        "tar-0.4.30/src/builder.rs",
+        "tar-0.4.30/src/entry.rs",
+        "tar-0.4.30/src/entry_type.rs",
+        "tar-0.4.30/src/error.rs",
+        "tar-0.4.30/src/header.rs",
+        "tar-0.4.30/src/lib.rs",
+        "tar-0.4.30/src/pax.rs",
+    ],
+    archive = ":tar-0.4.30--archive",
+    crate = "tar",
+    crate_root = "tar-0.4.30/src/lib.rs",
+    edition = "2018",
+    env = {
+    },
+    features = [
+        "default",
+        "xattr",
+    ],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = False,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [
+        ":filetime",
+        ":libc",
+        ":xattr",
+    ],
 )
 
 third_party_rust_library(
@@ -11840,6 +13092,25 @@ third_party_rust_library(
     proc_macro = False,
     rustc_flags = ["--cap-lints=allow"],
     deps = [":libc"],
+)
+
+third_party_rust_library(
+    name = "termcolor",
+    srcs = ["termcolor-1.1.2/src/lib.rs"],
+    archive = ":termcolor-1.1.2--archive",
+    crate = "termcolor",
+    crate_root = "termcolor-1.1.2/src/lib.rs",
+    edition = "2018",
+    env = {
+    },
+    features = [],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = False,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [],
 )
 
 third_party_rust_library(
@@ -12308,7 +13579,7 @@ third_party_rust_library(
     deps = [
         ":bytes",
         ":libc",
-        ":memchr-2.4.0",
+        ":memchr-2.4.1",
         ":mio",
         ":num_cpus",
         ":once_cell",
@@ -12316,6 +13587,394 @@ third_party_rust_library(
         ":pin-project-lite-0.2.6",
         ":signal-hook-registry-1.4.0",
         ":tokio-macros-1.1.0",
+    ],
+)
+
+third_party_rust_library(
+    name = "tokio-02",
+    srcs = [
+        "tokio-0.2.25/src/coop.rs",
+        "tokio-0.2.25/src/fs/canonicalize.rs",
+        "tokio-0.2.25/src/fs/copy.rs",
+        "tokio-0.2.25/src/fs/create_dir.rs",
+        "tokio-0.2.25/src/fs/create_dir_all.rs",
+        "tokio-0.2.25/src/fs/dir_builder.rs",
+        "tokio-0.2.25/src/fs/file.rs",
+        "tokio-0.2.25/src/fs/hard_link.rs",
+        "tokio-0.2.25/src/fs/metadata.rs",
+        "tokio-0.2.25/src/fs/mod.rs",
+        "tokio-0.2.25/src/fs/open_options.rs",
+        "tokio-0.2.25/src/fs/os/mod.rs",
+        "tokio-0.2.25/src/fs/os/unix/dir_builder_ext.rs",
+        "tokio-0.2.25/src/fs/os/unix/mod.rs",
+        "tokio-0.2.25/src/fs/os/unix/open_options_ext.rs",
+        "tokio-0.2.25/src/fs/os/unix/symlink.rs",
+        "tokio-0.2.25/src/fs/os/windows/mod.rs",
+        "tokio-0.2.25/src/fs/os/windows/symlink_dir.rs",
+        "tokio-0.2.25/src/fs/os/windows/symlink_file.rs",
+        "tokio-0.2.25/src/fs/read.rs",
+        "tokio-0.2.25/src/fs/read_dir.rs",
+        "tokio-0.2.25/src/fs/read_link.rs",
+        "tokio-0.2.25/src/fs/read_to_string.rs",
+        "tokio-0.2.25/src/fs/remove_dir.rs",
+        "tokio-0.2.25/src/fs/remove_dir_all.rs",
+        "tokio-0.2.25/src/fs/remove_file.rs",
+        "tokio-0.2.25/src/fs/rename.rs",
+        "tokio-0.2.25/src/fs/set_permissions.rs",
+        "tokio-0.2.25/src/fs/symlink_metadata.rs",
+        "tokio-0.2.25/src/fs/write.rs",
+        "tokio-0.2.25/src/future/maybe_done.rs",
+        "tokio-0.2.25/src/future/mod.rs",
+        "tokio-0.2.25/src/future/pending.rs",
+        "tokio-0.2.25/src/future/poll_fn.rs",
+        "tokio-0.2.25/src/future/ready.rs",
+        "tokio-0.2.25/src/future/try_join.rs",
+        "tokio-0.2.25/src/io/async_buf_read.rs",
+        "tokio-0.2.25/src/io/async_read.rs",
+        "tokio-0.2.25/src/io/async_seek.rs",
+        "tokio-0.2.25/src/io/async_write.rs",
+        "tokio-0.2.25/src/io/blocking.rs",
+        "tokio-0.2.25/src/io/driver/mod.rs",
+        "tokio-0.2.25/src/io/driver/platform.rs",
+        "tokio-0.2.25/src/io/driver/scheduled_io.rs",
+        "tokio-0.2.25/src/io/mod.rs",
+        "tokio-0.2.25/src/io/poll_evented.rs",
+        "tokio-0.2.25/src/io/registration.rs",
+        "tokio-0.2.25/src/io/seek.rs",
+        "tokio-0.2.25/src/io/split.rs",
+        "tokio-0.2.25/src/io/stderr.rs",
+        "tokio-0.2.25/src/io/stdin.rs",
+        "tokio-0.2.25/src/io/stdout.rs",
+        "tokio-0.2.25/src/io/util/async_buf_read_ext.rs",
+        "tokio-0.2.25/src/io/util/async_read_ext.rs",
+        "tokio-0.2.25/src/io/util/async_seek_ext.rs",
+        "tokio-0.2.25/src/io/util/async_write_ext.rs",
+        "tokio-0.2.25/src/io/util/buf_reader.rs",
+        "tokio-0.2.25/src/io/util/buf_stream.rs",
+        "tokio-0.2.25/src/io/util/buf_writer.rs",
+        "tokio-0.2.25/src/io/util/chain.rs",
+        "tokio-0.2.25/src/io/util/copy.rs",
+        "tokio-0.2.25/src/io/util/empty.rs",
+        "tokio-0.2.25/src/io/util/flush.rs",
+        "tokio-0.2.25/src/io/util/lines.rs",
+        "tokio-0.2.25/src/io/util/mem.rs",
+        "tokio-0.2.25/src/io/util/mod.rs",
+        "tokio-0.2.25/src/io/util/read.rs",
+        "tokio-0.2.25/src/io/util/read_buf.rs",
+        "tokio-0.2.25/src/io/util/read_exact.rs",
+        "tokio-0.2.25/src/io/util/read_int.rs",
+        "tokio-0.2.25/src/io/util/read_line.rs",
+        "tokio-0.2.25/src/io/util/read_to_end.rs",
+        "tokio-0.2.25/src/io/util/read_to_string.rs",
+        "tokio-0.2.25/src/io/util/read_until.rs",
+        "tokio-0.2.25/src/io/util/reader_stream.rs",
+        "tokio-0.2.25/src/io/util/repeat.rs",
+        "tokio-0.2.25/src/io/util/shutdown.rs",
+        "tokio-0.2.25/src/io/util/sink.rs",
+        "tokio-0.2.25/src/io/util/split.rs",
+        "tokio-0.2.25/src/io/util/stream_reader.rs",
+        "tokio-0.2.25/src/io/util/take.rs",
+        "tokio-0.2.25/src/io/util/write.rs",
+        "tokio-0.2.25/src/io/util/write_all.rs",
+        "tokio-0.2.25/src/io/util/write_buf.rs",
+        "tokio-0.2.25/src/io/util/write_int.rs",
+        "tokio-0.2.25/src/lib.rs",
+        "tokio-0.2.25/src/loom/mocked.rs",
+        "tokio-0.2.25/src/loom/mod.rs",
+        "tokio-0.2.25/src/loom/std/atomic_ptr.rs",
+        "tokio-0.2.25/src/loom/std/atomic_u16.rs",
+        "tokio-0.2.25/src/loom/std/atomic_u32.rs",
+        "tokio-0.2.25/src/loom/std/atomic_u64.rs",
+        "tokio-0.2.25/src/loom/std/atomic_u8.rs",
+        "tokio-0.2.25/src/loom/std/atomic_usize.rs",
+        "tokio-0.2.25/src/loom/std/mod.rs",
+        "tokio-0.2.25/src/loom/std/parking_lot.rs",
+        "tokio-0.2.25/src/loom/std/unsafe_cell.rs",
+        "tokio-0.2.25/src/macros/cfg.rs",
+        "tokio-0.2.25/src/macros/join.rs",
+        "tokio-0.2.25/src/macros/loom.rs",
+        "tokio-0.2.25/src/macros/mod.rs",
+        "tokio-0.2.25/src/macros/pin.rs",
+        "tokio-0.2.25/src/macros/ready.rs",
+        "tokio-0.2.25/src/macros/scoped_tls.rs",
+        "tokio-0.2.25/src/macros/select.rs",
+        "tokio-0.2.25/src/macros/support.rs",
+        "tokio-0.2.25/src/macros/thread_local.rs",
+        "tokio-0.2.25/src/macros/try_join.rs",
+        "tokio-0.2.25/src/net/addr.rs",
+        "tokio-0.2.25/src/net/lookup_host.rs",
+        "tokio-0.2.25/src/net/mod.rs",
+        "tokio-0.2.25/src/net/tcp/incoming.rs",
+        "tokio-0.2.25/src/net/tcp/listener.rs",
+        "tokio-0.2.25/src/net/tcp/mod.rs",
+        "tokio-0.2.25/src/net/tcp/split.rs",
+        "tokio-0.2.25/src/net/tcp/split_owned.rs",
+        "tokio-0.2.25/src/net/tcp/stream.rs",
+        "tokio-0.2.25/src/net/udp/mod.rs",
+        "tokio-0.2.25/src/net/udp/socket.rs",
+        "tokio-0.2.25/src/net/udp/split.rs",
+        "tokio-0.2.25/src/net/unix/datagram/mod.rs",
+        "tokio-0.2.25/src/net/unix/datagram/socket.rs",
+        "tokio-0.2.25/src/net/unix/datagram/split.rs",
+        "tokio-0.2.25/src/net/unix/datagram/split_owned.rs",
+        "tokio-0.2.25/src/net/unix/incoming.rs",
+        "tokio-0.2.25/src/net/unix/listener.rs",
+        "tokio-0.2.25/src/net/unix/mod.rs",
+        "tokio-0.2.25/src/net/unix/split.rs",
+        "tokio-0.2.25/src/net/unix/split_owned.rs",
+        "tokio-0.2.25/src/net/unix/stream.rs",
+        "tokio-0.2.25/src/net/unix/ucred.rs",
+        "tokio-0.2.25/src/park/either.rs",
+        "tokio-0.2.25/src/park/mod.rs",
+        "tokio-0.2.25/src/park/thread.rs",
+        "tokio-0.2.25/src/prelude.rs",
+        "tokio-0.2.25/src/process/kill.rs",
+        "tokio-0.2.25/src/process/mod.rs",
+        "tokio-0.2.25/src/process/unix/mod.rs",
+        "tokio-0.2.25/src/process/unix/orphan.rs",
+        "tokio-0.2.25/src/process/unix/reap.rs",
+        "tokio-0.2.25/src/process/windows.rs",
+        "tokio-0.2.25/src/runtime/basic_scheduler.rs",
+        "tokio-0.2.25/src/runtime/blocking/mod.rs",
+        "tokio-0.2.25/src/runtime/blocking/pool.rs",
+        "tokio-0.2.25/src/runtime/blocking/schedule.rs",
+        "tokio-0.2.25/src/runtime/blocking/shutdown.rs",
+        "tokio-0.2.25/src/runtime/blocking/task.rs",
+        "tokio-0.2.25/src/runtime/builder.rs",
+        "tokio-0.2.25/src/runtime/context.rs",
+        "tokio-0.2.25/src/runtime/enter.rs",
+        "tokio-0.2.25/src/runtime/handle.rs",
+        "tokio-0.2.25/src/runtime/io.rs",
+        "tokio-0.2.25/src/runtime/mod.rs",
+        "tokio-0.2.25/src/runtime/park.rs",
+        "tokio-0.2.25/src/runtime/queue.rs",
+        "tokio-0.2.25/src/runtime/shell.rs",
+        "tokio-0.2.25/src/runtime/spawner.rs",
+        "tokio-0.2.25/src/runtime/task/core.rs",
+        "tokio-0.2.25/src/runtime/task/error.rs",
+        "tokio-0.2.25/src/runtime/task/harness.rs",
+        "tokio-0.2.25/src/runtime/task/join.rs",
+        "tokio-0.2.25/src/runtime/task/mod.rs",
+        "tokio-0.2.25/src/runtime/task/raw.rs",
+        "tokio-0.2.25/src/runtime/task/stack.rs",
+        "tokio-0.2.25/src/runtime/task/state.rs",
+        "tokio-0.2.25/src/runtime/task/waker.rs",
+        "tokio-0.2.25/src/runtime/tests/loom_blocking.rs",
+        "tokio-0.2.25/src/runtime/tests/loom_oneshot.rs",
+        "tokio-0.2.25/src/runtime/tests/loom_pool.rs",
+        "tokio-0.2.25/src/runtime/tests/loom_queue.rs",
+        "tokio-0.2.25/src/runtime/tests/mod.rs",
+        "tokio-0.2.25/src/runtime/tests/queue.rs",
+        "tokio-0.2.25/src/runtime/tests/task.rs",
+        "tokio-0.2.25/src/runtime/thread_pool/atomic_cell.rs",
+        "tokio-0.2.25/src/runtime/thread_pool/idle.rs",
+        "tokio-0.2.25/src/runtime/thread_pool/mod.rs",
+        "tokio-0.2.25/src/runtime/thread_pool/worker.rs",
+        "tokio-0.2.25/src/runtime/time.rs",
+        "tokio-0.2.25/src/signal/ctrl_c.rs",
+        "tokio-0.2.25/src/signal/mod.rs",
+        "tokio-0.2.25/src/signal/registry.rs",
+        "tokio-0.2.25/src/signal/unix.rs",
+        "tokio-0.2.25/src/signal/windows.rs",
+        "tokio-0.2.25/src/stream/all.rs",
+        "tokio-0.2.25/src/stream/any.rs",
+        "tokio-0.2.25/src/stream/chain.rs",
+        "tokio-0.2.25/src/stream/collect.rs",
+        "tokio-0.2.25/src/stream/empty.rs",
+        "tokio-0.2.25/src/stream/filter.rs",
+        "tokio-0.2.25/src/stream/filter_map.rs",
+        "tokio-0.2.25/src/stream/fold.rs",
+        "tokio-0.2.25/src/stream/fuse.rs",
+        "tokio-0.2.25/src/stream/iter.rs",
+        "tokio-0.2.25/src/stream/map.rs",
+        "tokio-0.2.25/src/stream/merge.rs",
+        "tokio-0.2.25/src/stream/mod.rs",
+        "tokio-0.2.25/src/stream/next.rs",
+        "tokio-0.2.25/src/stream/once.rs",
+        "tokio-0.2.25/src/stream/pending.rs",
+        "tokio-0.2.25/src/stream/skip.rs",
+        "tokio-0.2.25/src/stream/skip_while.rs",
+        "tokio-0.2.25/src/stream/stream_map.rs",
+        "tokio-0.2.25/src/stream/take.rs",
+        "tokio-0.2.25/src/stream/take_while.rs",
+        "tokio-0.2.25/src/stream/timeout.rs",
+        "tokio-0.2.25/src/stream/try_next.rs",
+        "tokio-0.2.25/src/sync/barrier.rs",
+        "tokio-0.2.25/src/sync/batch_semaphore.rs",
+        "tokio-0.2.25/src/sync/broadcast.rs",
+        "tokio-0.2.25/src/sync/cancellation_token.rs",
+        "tokio-0.2.25/src/sync/mod.rs",
+        "tokio-0.2.25/src/sync/mpsc/block.rs",
+        "tokio-0.2.25/src/sync/mpsc/bounded.rs",
+        "tokio-0.2.25/src/sync/mpsc/chan.rs",
+        "tokio-0.2.25/src/sync/mpsc/error.rs",
+        "tokio-0.2.25/src/sync/mpsc/list.rs",
+        "tokio-0.2.25/src/sync/mpsc/mod.rs",
+        "tokio-0.2.25/src/sync/mpsc/unbounded.rs",
+        "tokio-0.2.25/src/sync/mutex.rs",
+        "tokio-0.2.25/src/sync/notify.rs",
+        "tokio-0.2.25/src/sync/oneshot.rs",
+        "tokio-0.2.25/src/sync/rwlock.rs",
+        "tokio-0.2.25/src/sync/semaphore.rs",
+        "tokio-0.2.25/src/sync/semaphore_ll.rs",
+        "tokio-0.2.25/src/sync/task/atomic_waker.rs",
+        "tokio-0.2.25/src/sync/task/mod.rs",
+        "tokio-0.2.25/src/sync/tests/atomic_waker.rs",
+        "tokio-0.2.25/src/sync/tests/loom_atomic_waker.rs",
+        "tokio-0.2.25/src/sync/tests/loom_broadcast.rs",
+        "tokio-0.2.25/src/sync/tests/loom_cancellation_token.rs",
+        "tokio-0.2.25/src/sync/tests/loom_list.rs",
+        "tokio-0.2.25/src/sync/tests/loom_mpsc.rs",
+        "tokio-0.2.25/src/sync/tests/loom_notify.rs",
+        "tokio-0.2.25/src/sync/tests/loom_oneshot.rs",
+        "tokio-0.2.25/src/sync/tests/loom_rwlock.rs",
+        "tokio-0.2.25/src/sync/tests/loom_semaphore_batch.rs",
+        "tokio-0.2.25/src/sync/tests/loom_semaphore_ll.rs",
+        "tokio-0.2.25/src/sync/tests/mod.rs",
+        "tokio-0.2.25/src/sync/tests/semaphore_batch.rs",
+        "tokio-0.2.25/src/sync/tests/semaphore_ll.rs",
+        "tokio-0.2.25/src/sync/watch.rs",
+        "tokio-0.2.25/src/task/blocking.rs",
+        "tokio-0.2.25/src/task/local.rs",
+        "tokio-0.2.25/src/task/mod.rs",
+        "tokio-0.2.25/src/task/spawn.rs",
+        "tokio-0.2.25/src/task/task_local.rs",
+        "tokio-0.2.25/src/task/yield_now.rs",
+        "tokio-0.2.25/src/time/clock.rs",
+        "tokio-0.2.25/src/time/delay.rs",
+        "tokio-0.2.25/src/time/delay_queue.rs",
+        "tokio-0.2.25/src/time/driver/atomic_stack.rs",
+        "tokio-0.2.25/src/time/driver/entry.rs",
+        "tokio-0.2.25/src/time/driver/handle.rs",
+        "tokio-0.2.25/src/time/driver/mod.rs",
+        "tokio-0.2.25/src/time/driver/registration.rs",
+        "tokio-0.2.25/src/time/driver/stack.rs",
+        "tokio-0.2.25/src/time/driver/tests/mod.rs",
+        "tokio-0.2.25/src/time/error.rs",
+        "tokio-0.2.25/src/time/instant.rs",
+        "tokio-0.2.25/src/time/interval.rs",
+        "tokio-0.2.25/src/time/mod.rs",
+        "tokio-0.2.25/src/time/tests/mod.rs",
+        "tokio-0.2.25/src/time/tests/test_delay.rs",
+        "tokio-0.2.25/src/time/throttle.rs",
+        "tokio-0.2.25/src/time/timeout.rs",
+        "tokio-0.2.25/src/time/wheel/level.rs",
+        "tokio-0.2.25/src/time/wheel/mod.rs",
+        "tokio-0.2.25/src/time/wheel/stack.rs",
+        "tokio-0.2.25/src/util/bit.rs",
+        "tokio-0.2.25/src/util/intrusive_double_linked_list.rs",
+        "tokio-0.2.25/src/util/linked_list.rs",
+        "tokio-0.2.25/src/util/mod.rs",
+        "tokio-0.2.25/src/util/pad.rs",
+        "tokio-0.2.25/src/util/rand.rs",
+        "tokio-0.2.25/src/util/slab/addr.rs",
+        "tokio-0.2.25/src/util/slab/entry.rs",
+        "tokio-0.2.25/src/util/slab/generation.rs",
+        "tokio-0.2.25/src/util/slab/mod.rs",
+        "tokio-0.2.25/src/util/slab/page.rs",
+        "tokio-0.2.25/src/util/slab/shard.rs",
+        "tokio-0.2.25/src/util/slab/slot.rs",
+        "tokio-0.2.25/src/util/slab/stack.rs",
+        "tokio-0.2.25/src/util/slab/tests/loom_slab.rs",
+        "tokio-0.2.25/src/util/slab/tests/loom_stack.rs",
+        "tokio-0.2.25/src/util/slab/tests/mod.rs",
+        "tokio-0.2.25/src/util/trace.rs",
+        "tokio-0.2.25/src/util/try_lock.rs",
+        "tokio-0.2.25/src/util/wake.rs",
+    ],
+    archive = ":tokio-0.2.25--archive",
+    crate = "tokio",
+    crate_root = "tokio-0.2.25/src/lib.rs",
+    edition = "2018",
+    env = {
+    },
+    features = [
+        "blocking",
+        "default",
+        "dns",
+        "fnv",
+        "fs",
+        "full",
+        "futures-core",
+        "io-driver",
+        "io-std",
+        "io-util",
+        "iovec",
+        "lazy_static",
+        "libc",
+        "macros",
+        "memchr",
+        "mio",
+        "mio-named-pipes",
+        "mio-uds",
+        "net",
+        "num_cpus",
+        "process",
+        "rt-core",
+        "rt-threaded",
+        "rt-util",
+        "signal",
+        "signal-hook-registry",
+        "slab",
+        "stream",
+        "sync",
+        "tcp",
+        "test-util",
+        "time",
+        "tokio-macros",
+        "tokio_track_caller",
+        "udp",
+        "uds",
+        "winapi",
+    ],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = False,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [
+        ":bytes-05",
+        ":fnv",
+        ":futures-core",
+        ":iovec-0.1.4",
+        ":lazy_static",
+        ":libc",
+        ":memchr-2.4.1",
+        ":mio-06",
+        ":mio-uds-0.6.8",
+        ":num_cpus",
+        ":pin-project-lite-0.1.11",
+        ":signal-hook-registry-1.4.0",
+        ":slab-0.4.2",
+        ":tokio-macros",
+    ],
+)
+
+third_party_rust_library(
+    name = "tokio-macros",
+    srcs = [
+        "tokio-macros-0.2.6/src/entry.rs",
+        "tokio-macros-0.2.6/src/lib.rs",
+        "tokio-macros-0.2.6/src/select.rs",
+    ],
+    archive = ":tokio-macros-0.2.6--archive",
+    crate = "tokio_macros",
+    crate_root = "tokio-macros-0.2.6/src/lib.rs",
+    edition = "2018",
+    env = {
+    },
+    features = [],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = True,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [
+        ":proc-macro2",
+        ":quote",
+        ":syn",
     ],
 )
 
@@ -12555,6 +14214,38 @@ third_party_rust_library(
         ":pin-project-lite-0.2.6",
         ":slab-0.4.2",
         ":tokio",
+    ],
+)
+
+third_party_rust_library(
+    name = "tokio_shim",
+    srcs = ["shed/tokio_shim/src/lib.rs"],
+    archive = None,
+    crate = None,
+    crate_root = "shed/tokio_shim/src/lib.rs",
+    edition = None,
+    env = {
+    },
+    features = [],
+    mapped_srcs = {
+    },
+    named_deps = {
+        "tokio_02": ":tokio-02",
+        "tokio_1x": ":tokio",
+        "tokio_1x_stream": ":tokio-stream",
+    },
+    proc_macro = False,
+    rustc_flags = [
+        "-Aunused_braces",
+        "-Wbare_trait_objects",
+        "-Wellipsis_inclusive_range_patterns",
+        "-Dnon_fmt_panic",
+        "-Dunconditional_recursion",
+    ],
+    deps = [
+        ":futures",
+        ":pin-project",
+        ":thiserror",
     ],
 )
 
@@ -13075,7 +14766,7 @@ third_party_rust_library(
     crate_root = "trust-dns-resolver-0.20.0/src/lib.rs",
     edition = "2018",
     env = {
-        "CARGO_MANIFEST_DIR": "third-party/rust/trust-dns-resolver-0.20.0",
+        "CARGO_MANIFEST_DIR": "$(location :trust-dns-resolver-0.20.0--archive)/trust-dns-resolver-0.20.0",
         "CARGO_PKG_NAME": "trust-dns-resolver",
         "CARGO_PKG_VERSION": "0.20.0",
         "CARGO_PKG_VERSION_MAJOR": "0",
@@ -13205,7 +14896,7 @@ third_party_rust_library(
     },
     proc_macro = False,
     rustc_flags = ["--cap-lints=allow"],
-    deps = [":memchr-2.4.0"],
+    deps = [":memchr-2.4.1"],
 )
 
 third_party_rust_library(
@@ -13814,6 +15505,38 @@ third_party_rust_library(
 )
 
 third_party_rust_library(
+    name = "xattr",
+    srcs = [
+        "xattr-0.2.2/src/error.rs",
+        "xattr-0.2.2/src/lib.rs",
+        "xattr-0.2.2/src/sys/bsd.rs",
+        "xattr-0.2.2/src/sys/linux_macos/linux.rs",
+        "xattr-0.2.2/src/sys/linux_macos/macos.rs",
+        "xattr-0.2.2/src/sys/linux_macos/mod.rs",
+        "xattr-0.2.2/src/sys/mod.rs",
+        "xattr-0.2.2/src/sys/unsupported.rs",
+        "xattr-0.2.2/src/util.rs",
+    ],
+    archive = ":xattr-0.2.2--archive",
+    crate = "xattr",
+    crate_root = "xattr-0.2.2/src/lib.rs",
+    edition = "2015",
+    env = {
+    },
+    features = [
+        "default",
+        "unsupported",
+    ],
+    mapped_srcs = {
+    },
+    named_deps = {
+    },
+    proc_macro = False,
+    rustc_flags = ["--cap-lints=allow"],
+    deps = [":libc"],
+)
+
+third_party_rust_library(
     name = "zstd",
     srcs = [
         "zstd-0.8.0+zstd.1.4.9/src/block/compressor.rs",
@@ -13944,127 +15667,4 @@ third_party_rust_library(
         "-lzstd",
     ],
     deps = [":libc"],
-)
-
-cpp_library(
-    name = "ring-0.16.20-ring-c-asm-elf",
-    srcs = [
-        "vendor/ring-0.16.20/crypto/constant_time_test.c",
-        "vendor/ring-0.16.20/crypto/cpu-intel.c",
-        "vendor/ring-0.16.20/crypto/crypto.c",
-        "vendor/ring-0.16.20/crypto/curve25519/curve25519.c",
-        "vendor/ring-0.16.20/crypto/fipsmodule/aes/aes_nohw.c",
-        "vendor/ring-0.16.20/crypto/fipsmodule/bn/montgomery.c",
-        "vendor/ring-0.16.20/crypto/fipsmodule/bn/montgomery_inv.c",
-        "vendor/ring-0.16.20/crypto/fipsmodule/ec/ecp_nistz.c",
-        "vendor/ring-0.16.20/crypto/fipsmodule/ec/ecp_nistz256.c",
-        "vendor/ring-0.16.20/crypto/fipsmodule/ec/gfp_p256.c",
-        "vendor/ring-0.16.20/crypto/fipsmodule/ec/gfp_p384.c",
-        "vendor/ring-0.16.20/crypto/limbs/limbs.c",
-        "vendor/ring-0.16.20/crypto/mem.c",
-        "vendor/ring-0.16.20/crypto/poly1305/poly1305.c",
-        "vendor/ring-0.16.20/crypto/poly1305/poly1305_arm.c",
-        "vendor/ring-0.16.20/crypto/poly1305/poly1305_vec.c",
-        "vendor/ring-0.16.20/pregenerated/aesni-gcm-x86_64-elf.S",
-        "vendor/ring-0.16.20/pregenerated/aesni-x86_64-elf.S",
-        "vendor/ring-0.16.20/pregenerated/chacha-x86_64-elf.S",
-        "vendor/ring-0.16.20/pregenerated/chacha20_poly1305_x86_64-elf.S",
-        "vendor/ring-0.16.20/pregenerated/ghash-x86_64-elf.S",
-        "vendor/ring-0.16.20/pregenerated/p256-x86_64-asm-elf.S",
-        "vendor/ring-0.16.20/pregenerated/sha256-x86_64-elf.S",
-        "vendor/ring-0.16.20/pregenerated/sha512-x86_64-elf.S",
-        "vendor/ring-0.16.20/pregenerated/vpaes-x86_64-elf.S",
-        "vendor/ring-0.16.20/pregenerated/x86_64-mont-elf.S",
-        "vendor/ring-0.16.20/pregenerated/x86_64-mont5-elf.S",
-    ],
-    headers = [
-        "vendor/ring-0.16.20/crypto/curve25519/curve25519_tables.h",
-        "vendor/ring-0.16.20/crypto/curve25519/internal.h",
-        "vendor/ring-0.16.20/crypto/fipsmodule/bn/internal.h",
-        "vendor/ring-0.16.20/crypto/fipsmodule/ec/ecp_nistz.h",
-        "vendor/ring-0.16.20/crypto/fipsmodule/ec/ecp_nistz256.h",
-        "vendor/ring-0.16.20/crypto/fipsmodule/ec/ecp_nistz256_table.inl",
-        "vendor/ring-0.16.20/crypto/fipsmodule/ec/ecp_nistz384.h",
-        "vendor/ring-0.16.20/crypto/fipsmodule/ec/ecp_nistz384.inl",
-        "vendor/ring-0.16.20/crypto/internal.h",
-        "vendor/ring-0.16.20/crypto/limbs/limbs.h",
-        "vendor/ring-0.16.20/crypto/limbs/limbs.inl",
-        "vendor/ring-0.16.20/crypto/poly1305/internal.h",
-        "vendor/ring-0.16.20/include/GFp/aes.h",
-        "vendor/ring-0.16.20/include/GFp/arm_arch.h",
-        "vendor/ring-0.16.20/include/GFp/base.h",
-        "vendor/ring-0.16.20/include/GFp/check.h",
-        "vendor/ring-0.16.20/include/GFp/cpu.h",
-        "vendor/ring-0.16.20/include/GFp/mem.h",
-        "vendor/ring-0.16.20/include/GFp/poly1305.h",
-        "vendor/ring-0.16.20/include/GFp/type_check.h",
-        "vendor/ring-0.16.20/third_party/fiat/curve25519_32.h",
-        "vendor/ring-0.16.20/third_party/fiat/curve25519_64.h",
-    ],
-    compiler_flags = ["-Wno-error"],
-    include_directories = ["vendor/ring-0.16.20/include"],
-    preferred_linkage = "static",
-    visibility = [],
-)
-
-rust_library(
-    name = "starlark",
-    srcs = glob(["starlark-rust/starlark/src/**/*.rs"]),
-    env = {
-        "OUT_DIR": "$(location :starlark-grammar)/src",
-    },
-    rustc_flags = [
-        "-Aunused_braces",
-        "-Wbare_trait_objects",
-        "-Wellipsis_inclusive_range_patterns",
-        "-Dnon_fmt_panic",
-        "-Dunconditional_recursion",
-    ],
-    deps = [
-        ":annotate-snippets",
-        ":anyhow",
-        ":bumpalo",
-        ":derivative",
-        ":either",
-        ":hashbrown",
-        ":indexmap",
-        ":itertools",
-        ":lalrpop-util",
-        ":logos",
-        ":maplit",
-        ":once_cell",
-        ":paste",
-        ":rustyline",
-        ":starlark_module",
-        ":static_assertions",
-        ":thiserror",
-    ],
-)
-
-export_file(
-    name = "starlark-rust/starlark/src/syntax/grammar.lalrpop",
-)
-
-buck_genrule(
-    name = "starlark-grammar",
-    out = ".",
-    cmd = "$(exe :lalrpop-lalrpop) --out-dir $OUT $(location :starlark-rust/starlark/src/syntax/grammar.lalrpop)",
-)
-
-rust_library(
-    name = "starlark_module",
-    srcs = glob(["starlark-rust/starlark_module/src/**/*.rs"]),
-    proc_macro = True,
-    rustc_flags = [
-        "-Aunused_braces",
-        "-Wbare_trait_objects",
-        "-Wellipsis_inclusive_range_patterns",
-        "-Dnon_fmt_panic",
-        "-Dunconditional_recursion",
-    ],
-    deps = [
-        ":proc-macro2",
-        ":quote",
-        ":syn",
-    ],
 )

--- a/third-party/rust/defs.bzl
+++ b/third-party/rust/defs.bzl
@@ -25,6 +25,7 @@ def _extract_file(archive, src):
     return ":" + name
 
 def third_party_rust_library(name, archive, srcs, mapped_srcs = None, **kwargs):
+    kwargs["unittests"] = False
     if archive:
         src_targets = {}
         for src in srcs:

--- a/third-party/rust/vendor/cxx-1.0.52/include/cxx.h
+++ b/third-party/rust/vendor/cxx-1.0.52/include/cxx.h
@@ -1,0 +1,1091 @@
+#pragma once
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <initializer_list>
+#include <iosfwd>
+#include <iterator>
+#include <new>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+#if defined(_WIN32)
+#include <basetsd.h>
+#else
+#include <sys/types.h>
+#endif
+
+namespace rust {
+inline namespace cxxbridge1 {
+
+struct unsafe_bitcopy_t;
+
+namespace {
+template <typename T>
+class impl;
+}
+
+#ifndef CXXBRIDGE1_RUST_STRING
+#define CXXBRIDGE1_RUST_STRING
+// https://cxx.rs/binding/string.html
+class String final {
+public:
+  String() noexcept;
+  String(const String &) noexcept;
+  String(String &&) noexcept;
+  ~String() noexcept;
+
+  String(const std::string &);
+  String(const char *);
+  String(const char *, std::size_t);
+  String(const char16_t *);
+  String(const char16_t *, std::size_t);
+
+  String &operator=(const String &) &noexcept;
+  String &operator=(String &&) &noexcept;
+
+  explicit operator std::string() const;
+
+  // Note: no null terminator.
+  const char *data() const noexcept;
+  std::size_t size() const noexcept;
+  std::size_t length() const noexcept;
+  bool empty() const noexcept;
+
+  const char *c_str() noexcept;
+
+  using iterator = char *;
+  iterator begin() noexcept;
+  iterator end() noexcept;
+
+  using const_iterator = const char *;
+  const_iterator begin() const noexcept;
+  const_iterator end() const noexcept;
+  const_iterator cbegin() const noexcept;
+  const_iterator cend() const noexcept;
+
+  bool operator==(const String &) const noexcept;
+  bool operator!=(const String &) const noexcept;
+  bool operator<(const String &) const noexcept;
+  bool operator<=(const String &) const noexcept;
+  bool operator>(const String &) const noexcept;
+  bool operator>=(const String &) const noexcept;
+
+  void swap(String &) noexcept;
+
+  // Internal API only intended for the cxxbridge code generator.
+  String(unsafe_bitcopy_t, const String &) noexcept;
+
+private:
+  friend void swap(String &lhs, String &rhs) noexcept { lhs.swap(rhs); }
+
+  // Size and alignment statically verified by rust_string.rs.
+  std::array<std::uintptr_t, 3> repr;
+};
+#endif // CXXBRIDGE1_RUST_STRING
+
+#ifndef CXXBRIDGE1_RUST_STR
+#define CXXBRIDGE1_RUST_STR
+// https://cxx.rs/binding/str.html
+class Str final {
+public:
+  Str() noexcept;
+  Str(const String &) noexcept;
+  Str(const std::string &);
+  Str(const char *);
+  Str(const char *, std::size_t);
+
+  Str &operator=(const Str &) &noexcept = default;
+
+  explicit operator std::string() const;
+
+  // Note: no null terminator.
+  const char *data() const noexcept;
+  std::size_t size() const noexcept;
+  std::size_t length() const noexcept;
+  bool empty() const noexcept;
+
+  // Important in order for System V ABI to pass in registers.
+  Str(const Str &) noexcept = default;
+  ~Str() noexcept = default;
+
+  using iterator = const char *;
+  using const_iterator = const char *;
+  const_iterator begin() const noexcept;
+  const_iterator end() const noexcept;
+  const_iterator cbegin() const noexcept;
+  const_iterator cend() const noexcept;
+
+  bool operator==(const Str &) const noexcept;
+  bool operator!=(const Str &) const noexcept;
+  bool operator<(const Str &) const noexcept;
+  bool operator<=(const Str &) const noexcept;
+  bool operator>(const Str &) const noexcept;
+  bool operator>=(const Str &) const noexcept;
+
+  void swap(Str &) noexcept;
+
+private:
+  class uninit;
+  Str(uninit) noexcept;
+  friend impl<Str>;
+
+  std::array<std::uintptr_t, 2> repr;
+};
+#endif // CXXBRIDGE1_RUST_STR
+
+#ifndef CXXBRIDGE1_RUST_SLICE
+namespace detail {
+template <bool>
+struct copy_assignable_if {};
+
+template <>
+struct copy_assignable_if<false> {
+  copy_assignable_if() noexcept = default;
+  copy_assignable_if(const copy_assignable_if &) noexcept = default;
+  copy_assignable_if &operator=(const copy_assignable_if &) &noexcept = delete;
+  copy_assignable_if &operator=(copy_assignable_if &&) &noexcept = default;
+};
+} // namespace detail
+
+// https://cxx.rs/binding/slice.html
+template <typename T>
+class Slice final
+    : private detail::copy_assignable_if<std::is_const<T>::value> {
+public:
+  using value_type = T;
+
+  Slice() noexcept;
+  Slice(T *, std::size_t count) noexcept;
+
+  Slice &operator=(const Slice<T> &) &noexcept = default;
+  Slice &operator=(Slice<T> &&) &noexcept = default;
+
+  T *data() const noexcept;
+  std::size_t size() const noexcept;
+  std::size_t length() const noexcept;
+  bool empty() const noexcept;
+
+  T &operator[](std::size_t n) const noexcept;
+  T &at(std::size_t n) const;
+  T &front() const noexcept;
+  T &back() const noexcept;
+
+  // Important in order for System V ABI to pass in registers.
+  Slice(const Slice<T> &) noexcept = default;
+  ~Slice() noexcept = default;
+
+  class iterator;
+  iterator begin() const noexcept;
+  iterator end() const noexcept;
+
+  void swap(Slice &) noexcept;
+
+private:
+  class uninit;
+  Slice(uninit) noexcept;
+  friend impl<Slice>;
+  friend void sliceInit(void *, const void *, std::size_t) noexcept;
+  friend void *slicePtr(const void *) noexcept;
+  friend std::size_t sliceLen(const void *) noexcept;
+
+  std::array<std::uintptr_t, 2> repr;
+};
+
+template <typename T>
+class Slice<T>::iterator final {
+public:
+  using iterator_category = std::random_access_iterator_tag;
+  using value_type = T;
+  using difference_type = std::ptrdiff_t;
+  using pointer = typename std::add_pointer<T>::type;
+  using reference = typename std::add_lvalue_reference<T>::type;
+
+  reference operator*() const noexcept;
+  pointer operator->() const noexcept;
+  reference operator[](difference_type) const noexcept;
+
+  iterator &operator++() noexcept;
+  iterator operator++(int) noexcept;
+  iterator &operator--() noexcept;
+  iterator operator--(int) noexcept;
+
+  iterator &operator+=(difference_type) noexcept;
+  iterator &operator-=(difference_type) noexcept;
+  iterator operator+(difference_type) const noexcept;
+  iterator operator-(difference_type) const noexcept;
+  difference_type operator-(const iterator &) const noexcept;
+
+  bool operator==(const iterator &) const noexcept;
+  bool operator!=(const iterator &) const noexcept;
+  bool operator<(const iterator &) const noexcept;
+  bool operator<=(const iterator &) const noexcept;
+  bool operator>(const iterator &) const noexcept;
+  bool operator>=(const iterator &) const noexcept;
+
+private:
+  friend class Slice;
+  void *pos;
+  std::size_t stride;
+};
+#endif // CXXBRIDGE1_RUST_SLICE
+
+#ifndef CXXBRIDGE1_RUST_BOX
+// https://cxx.rs/binding/box.html
+template <typename T>
+class Box final {
+public:
+  using element_type = T;
+  using const_pointer =
+      typename std::add_pointer<typename std::add_const<T>::type>::type;
+  using pointer = typename std::add_pointer<T>::type;
+
+  Box() = delete;
+  Box(Box &&) noexcept;
+  ~Box() noexcept;
+
+  explicit Box(const T &);
+  explicit Box(T &&);
+
+  Box &operator=(Box &&) &noexcept;
+
+  const T *operator->() const noexcept;
+  const T &operator*() const noexcept;
+  T *operator->() noexcept;
+  T &operator*() noexcept;
+
+  template <typename... Fields>
+  static Box in_place(Fields &&...);
+
+  void swap(Box &) noexcept;
+
+  // Important: requires that `raw` came from an into_raw call. Do not pass a
+  // pointer from `new` or any other source.
+  static Box from_raw(T *) noexcept;
+
+  T *into_raw() noexcept;
+
+  /* Deprecated */ using value_type = element_type;
+
+private:
+  class uninit;
+  class allocation;
+  Box(uninit) noexcept;
+  void drop() noexcept;
+
+  friend void swap(Box &lhs, Box &rhs) noexcept { lhs.swap(rhs); }
+
+  T *ptr;
+};
+#endif // CXXBRIDGE1_RUST_BOX
+
+#ifndef CXXBRIDGE1_RUST_VEC
+// https://cxx.rs/binding/vec.html
+template <typename T>
+class Vec final {
+public:
+  using value_type = T;
+
+  Vec() noexcept;
+  Vec(std::initializer_list<T>);
+  Vec(const Vec &);
+  Vec(Vec &&) noexcept;
+  ~Vec() noexcept;
+
+  Vec &operator=(Vec &&) &noexcept;
+  Vec &operator=(const Vec &) &;
+
+  std::size_t size() const noexcept;
+  bool empty() const noexcept;
+  const T *data() const noexcept;
+  T *data() noexcept;
+  std::size_t capacity() const noexcept;
+
+  const T &operator[](std::size_t n) const noexcept;
+  const T &at(std::size_t n) const;
+  const T &front() const noexcept;
+  const T &back() const noexcept;
+
+  T &operator[](std::size_t n) noexcept;
+  T &at(std::size_t n);
+  T &front() noexcept;
+  T &back() noexcept;
+
+  void reserve(std::size_t new_cap);
+  void push_back(const T &value);
+  void push_back(T &&value);
+  template <typename... Args>
+  void emplace_back(Args &&...args);
+
+  using iterator = typename Slice<T>::iterator;
+  iterator begin() noexcept;
+  iterator end() noexcept;
+
+  using const_iterator = typename Slice<const T>::iterator;
+  const_iterator begin() const noexcept;
+  const_iterator end() const noexcept;
+  const_iterator cbegin() const noexcept;
+  const_iterator cend() const noexcept;
+
+  void swap(Vec &) noexcept;
+
+  // Internal API only intended for the cxxbridge code generator.
+  Vec(unsafe_bitcopy_t, const Vec &) noexcept;
+
+private:
+  void reserve_total(std::size_t cap) noexcept;
+  void set_len(std::size_t len) noexcept;
+  void drop() noexcept;
+
+  friend void swap(Vec &lhs, Vec &rhs) noexcept { lhs.swap(rhs); }
+
+  // Size and alignment statically verified by rust_vec.rs.
+  std::array<std::uintptr_t, 3> repr;
+};
+#endif // CXXBRIDGE1_RUST_VEC
+
+#ifndef CXXBRIDGE1_RUST_FN
+// https://cxx.rs/binding/fn.html
+template <typename Signature>
+class Fn;
+
+template <typename Ret, typename... Args>
+class Fn<Ret(Args...)> final {
+public:
+  Ret operator()(Args... args) const noexcept;
+  Fn operator*() const noexcept;
+
+private:
+  Ret (*trampoline)(Args..., void *fn) noexcept;
+  void *fn;
+};
+#endif // CXXBRIDGE1_RUST_FN
+
+#ifndef CXXBRIDGE1_RUST_ERROR
+#define CXXBRIDGE1_RUST_ERROR
+// https://cxx.rs/binding/result.html
+class Error final : public std::exception {
+public:
+  Error(const Error &);
+  Error(Error &&) noexcept;
+  ~Error() noexcept override;
+
+  Error &operator=(const Error &) &;
+  Error &operator=(Error &&) &noexcept;
+
+  const char *what() const noexcept override;
+
+private:
+  Error() noexcept = default;
+  friend impl<Error>;
+  const char *msg;
+  std::size_t len;
+};
+#endif // CXXBRIDGE1_RUST_ERROR
+
+#ifndef CXXBRIDGE1_RUST_ISIZE
+#define CXXBRIDGE1_RUST_ISIZE
+#if defined(_WIN32)
+using isize = SSIZE_T;
+#else
+using isize = ssize_t;
+#endif
+#endif // CXXBRIDGE1_RUST_ISIZE
+
+std::ostream &operator<<(std::ostream &, const String &);
+std::ostream &operator<<(std::ostream &, const Str &);
+
+#ifndef CXXBRIDGE1_RUST_OPAQUE
+#define CXXBRIDGE1_RUST_OPAQUE
+// Base class of generated opaque Rust types.
+class Opaque {
+public:
+  Opaque() = delete;
+  Opaque(const Opaque &) = delete;
+  ~Opaque() = delete;
+};
+#endif // CXXBRIDGE1_RUST_OPAQUE
+
+template <typename T>
+std::size_t size_of();
+template <typename T>
+std::size_t align_of();
+
+// IsRelocatable<T> is used in assertions that a C++ type passed by value
+// between Rust and C++ is soundly relocatable by Rust.
+//
+// There may be legitimate reasons to opt out of the check for support of types
+// that the programmer knows are soundly Rust-movable despite not being
+// recognized as such by the C++ type system due to a move constructor or
+// destructor. To opt out of the relocatability check, do either of the
+// following things in any header used by `include!` in the bridge.
+//
+//      --- if you define the type:
+//      struct MyType {
+//        ...
+//    +   using IsRelocatable = std::true_type;
+//      };
+//
+//      --- otherwise:
+//    + template <>
+//    + struct rust::IsRelocatable<MyType> : std::true_type {};
+template <typename T>
+struct IsRelocatable;
+
+using u8 = std::uint8_t;
+using u16 = std::uint16_t;
+using u32 = std::uint32_t;
+using u64 = std::uint64_t;
+using usize = std::size_t; // see static asserts in cxx.cc
+using i8 = std::int8_t;
+using i16 = std::int16_t;
+using i32 = std::int32_t;
+using i64 = std::int64_t;
+using f32 = float;
+using f64 = double;
+
+// Snake case aliases for use in code that uses this style for type names.
+using string = String;
+using str = Str;
+template <typename T>
+using slice = Slice<T>;
+template <typename T>
+using box = Box<T>;
+template <typename T>
+using vec = Vec<T>;
+using error = Error;
+template <typename Signature>
+using fn = Fn<Signature>;
+template <typename T>
+using is_relocatable = IsRelocatable<T>;
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// end public API, begin implementation details
+
+#ifndef CXXBRIDGE1_PANIC
+#define CXXBRIDGE1_PANIC
+template <typename Exception>
+void panic [[noreturn]] (const char *msg);
+#endif // CXXBRIDGE1_PANIC
+
+#ifndef CXXBRIDGE1_RUST_FN
+#define CXXBRIDGE1_RUST_FN
+template <typename Ret, typename... Args>
+Ret Fn<Ret(Args...)>::operator()(Args... args) const noexcept {
+  return (*this->trampoline)(std::forward<Args>(args)..., this->fn);
+}
+
+template <typename Ret, typename... Args>
+Fn<Ret(Args...)> Fn<Ret(Args...)>::operator*() const noexcept {
+  return *this;
+}
+#endif // CXXBRIDGE1_RUST_FN
+
+#ifndef CXXBRIDGE1_RUST_BITCOPY_T
+#define CXXBRIDGE1_RUST_BITCOPY_T
+struct unsafe_bitcopy_t final {
+  explicit unsafe_bitcopy_t() = default;
+};
+#endif // CXXBRIDGE1_RUST_BITCOPY_T
+
+#ifndef CXXBRIDGE1_RUST_BITCOPY
+#define CXXBRIDGE1_RUST_BITCOPY
+constexpr unsafe_bitcopy_t unsafe_bitcopy{};
+#endif // CXXBRIDGE1_RUST_BITCOPY
+
+#ifndef CXXBRIDGE1_RUST_SLICE
+#define CXXBRIDGE1_RUST_SLICE
+template <typename T>
+Slice<T>::Slice() noexcept {
+  sliceInit(this, reinterpret_cast<void *>(align_of<T>()), 0);
+}
+
+template <typename T>
+Slice<T>::Slice(T *s, std::size_t count) noexcept {
+  assert(s != nullptr || count == 0);
+  sliceInit(this,
+            s == nullptr && count == 0
+                ? reinterpret_cast<void *>(align_of<T>())
+                : const_cast<typename std::remove_const<T>::type *>(s),
+            count);
+}
+
+template <typename T>
+T *Slice<T>::data() const noexcept {
+  return reinterpret_cast<T *>(slicePtr(this));
+}
+
+template <typename T>
+std::size_t Slice<T>::size() const noexcept {
+  return sliceLen(this);
+}
+
+template <typename T>
+std::size_t Slice<T>::length() const noexcept {
+  return this->size();
+}
+
+template <typename T>
+bool Slice<T>::empty() const noexcept {
+  return this->size() == 0;
+}
+
+template <typename T>
+T &Slice<T>::operator[](std::size_t n) const noexcept {
+  assert(n < this->size());
+  auto pos = static_cast<char *>(slicePtr(this)) + size_of<T>() * n;
+  return *reinterpret_cast<T *>(pos);
+}
+
+template <typename T>
+T &Slice<T>::at(std::size_t n) const {
+  if (n >= this->size()) {
+    panic<std::out_of_range>("rust::Slice index out of range");
+  }
+  return (*this)[n];
+}
+
+template <typename T>
+T &Slice<T>::front() const noexcept {
+  assert(!this->empty());
+  return (*this)[0];
+}
+
+template <typename T>
+T &Slice<T>::back() const noexcept {
+  assert(!this->empty());
+  return (*this)[this->size() - 1];
+}
+
+template <typename T>
+typename Slice<T>::iterator::reference
+Slice<T>::iterator::operator*() const noexcept {
+  return *static_cast<T *>(this->pos);
+}
+
+template <typename T>
+typename Slice<T>::iterator::pointer
+Slice<T>::iterator::operator->() const noexcept {
+  return static_cast<T *>(this->pos);
+}
+
+template <typename T>
+typename Slice<T>::iterator::reference Slice<T>::iterator::operator[](
+    typename Slice<T>::iterator::difference_type n) const noexcept {
+  auto pos = static_cast<char *>(this->pos) + this->stride * n;
+  return *reinterpret_cast<T *>(pos);
+}
+
+template <typename T>
+typename Slice<T>::iterator &Slice<T>::iterator::operator++() noexcept {
+  this->pos = static_cast<char *>(this->pos) + this->stride;
+  return *this;
+}
+
+template <typename T>
+typename Slice<T>::iterator Slice<T>::iterator::operator++(int) noexcept {
+  auto ret = iterator(*this);
+  this->pos = static_cast<char *>(this->pos) + this->stride;
+  return ret;
+}
+
+template <typename T>
+typename Slice<T>::iterator &Slice<T>::iterator::operator--() noexcept {
+  this->pos = static_cast<char *>(this->pos) - this->stride;
+  return *this;
+}
+
+template <typename T>
+typename Slice<T>::iterator Slice<T>::iterator::operator--(int) noexcept {
+  auto ret = iterator(*this);
+  this->pos = static_cast<char *>(this->pos) - this->stride;
+  return ret;
+}
+
+template <typename T>
+typename Slice<T>::iterator &Slice<T>::iterator::operator+=(
+    typename Slice<T>::iterator::difference_type n) noexcept {
+  this->pos = static_cast<char *>(this->pos) + this->stride * n;
+  return *this;
+}
+
+template <typename T>
+typename Slice<T>::iterator &Slice<T>::iterator::operator-=(
+    typename Slice<T>::iterator::difference_type n) noexcept {
+  this->pos = static_cast<char *>(this->pos) - this->stride * n;
+  return *this;
+}
+
+template <typename T>
+typename Slice<T>::iterator Slice<T>::iterator::operator+(
+    typename Slice<T>::iterator::difference_type n) const noexcept {
+  auto ret = iterator(*this);
+  ret.pos = static_cast<char *>(this->pos) + this->stride * n;
+  return ret;
+}
+
+template <typename T>
+typename Slice<T>::iterator Slice<T>::iterator::operator-(
+    typename Slice<T>::iterator::difference_type n) const noexcept {
+  auto ret = iterator(*this);
+  ret.pos = static_cast<char *>(this->pos) - this->stride * n;
+  return ret;
+}
+
+template <typename T>
+typename Slice<T>::iterator::difference_type
+Slice<T>::iterator::operator-(const iterator &other) const noexcept {
+  auto diff = std::distance(static_cast<char *>(other.pos),
+                            static_cast<char *>(this->pos));
+  return diff / this->stride;
+}
+
+template <typename T>
+bool Slice<T>::iterator::operator==(const iterator &other) const noexcept {
+  return this->pos == other.pos;
+}
+
+template <typename T>
+bool Slice<T>::iterator::operator!=(const iterator &other) const noexcept {
+  return this->pos != other.pos;
+}
+
+template <typename T>
+bool Slice<T>::iterator::operator<(const iterator &other) const noexcept {
+  return this->pos < other.pos;
+}
+
+template <typename T>
+bool Slice<T>::iterator::operator<=(const iterator &other) const noexcept {
+  return this->pos <= other.pos;
+}
+
+template <typename T>
+bool Slice<T>::iterator::operator>(const iterator &other) const noexcept {
+  return this->pos > other.pos;
+}
+
+template <typename T>
+bool Slice<T>::iterator::operator>=(const iterator &other) const noexcept {
+  return this->pos >= other.pos;
+}
+
+template <typename T>
+typename Slice<T>::iterator Slice<T>::begin() const noexcept {
+  iterator it;
+  it.pos = slicePtr(this);
+  it.stride = size_of<T>();
+  return it;
+}
+
+template <typename T>
+typename Slice<T>::iterator Slice<T>::end() const noexcept {
+  iterator it = this->begin();
+  it.pos = static_cast<char *>(it.pos) + it.stride * this->size();
+  return it;
+}
+
+template <typename T>
+void Slice<T>::swap(Slice &rhs) noexcept {
+  std::swap(*this, rhs);
+}
+#endif // CXXBRIDGE1_RUST_SLICE
+
+#ifndef CXXBRIDGE1_RUST_BOX
+#define CXXBRIDGE1_RUST_BOX
+template <typename T>
+class Box<T>::uninit {};
+
+template <typename T>
+class Box<T>::allocation {
+  static T *alloc() noexcept;
+  static void dealloc(T *) noexcept;
+
+public:
+  allocation() noexcept : ptr(alloc()) {}
+  ~allocation() noexcept {
+    if (this->ptr) {
+      dealloc(this->ptr);
+    }
+  }
+  T *ptr;
+};
+
+template <typename T>
+Box<T>::Box(Box &&other) noexcept : ptr(other.ptr) {
+  other.ptr = nullptr;
+}
+
+template <typename T>
+Box<T>::Box(const T &val) {
+  allocation alloc;
+  ::new (alloc.ptr) T(val);
+  this->ptr = alloc.ptr;
+  alloc.ptr = nullptr;
+}
+
+template <typename T>
+Box<T>::Box(T &&val) {
+  allocation alloc;
+  ::new (alloc.ptr) T(std::move(val));
+  this->ptr = alloc.ptr;
+  alloc.ptr = nullptr;
+}
+
+template <typename T>
+Box<T>::~Box() noexcept {
+  if (this->ptr) {
+    this->drop();
+  }
+}
+
+template <typename T>
+Box<T> &Box<T>::operator=(Box &&other) &noexcept {
+  if (this->ptr) {
+    this->drop();
+  }
+  this->ptr = other.ptr;
+  other.ptr = nullptr;
+  return *this;
+}
+
+template <typename T>
+const T *Box<T>::operator->() const noexcept {
+  return this->ptr;
+}
+
+template <typename T>
+const T &Box<T>::operator*() const noexcept {
+  return *this->ptr;
+}
+
+template <typename T>
+T *Box<T>::operator->() noexcept {
+  return this->ptr;
+}
+
+template <typename T>
+T &Box<T>::operator*() noexcept {
+  return *this->ptr;
+}
+
+template <typename T>
+template <typename... Fields>
+Box<T> Box<T>::in_place(Fields &&...fields) {
+  allocation alloc;
+  auto ptr = alloc.ptr;
+  ::new (ptr) T{std::forward<Fields>(fields)...};
+  alloc.ptr = nullptr;
+  return from_raw(ptr);
+}
+
+template <typename T>
+void Box<T>::swap(Box &rhs) noexcept {
+  using std::swap;
+  swap(this->ptr, rhs.ptr);
+}
+
+template <typename T>
+Box<T> Box<T>::from_raw(T *raw) noexcept {
+  Box box = uninit{};
+  box.ptr = raw;
+  return box;
+}
+
+template <typename T>
+T *Box<T>::into_raw() noexcept {
+  T *raw = this->ptr;
+  this->ptr = nullptr;
+  return raw;
+}
+
+template <typename T>
+Box<T>::Box(uninit) noexcept {}
+#endif // CXXBRIDGE1_RUST_BOX
+
+#ifndef CXXBRIDGE1_RUST_VEC
+#define CXXBRIDGE1_RUST_VEC
+template <typename T>
+Vec<T>::Vec(std::initializer_list<T> init) : Vec{} {
+  this->reserve_total(init.size());
+  std::move(init.begin(), init.end(), std::back_inserter(*this));
+}
+
+template <typename T>
+Vec<T>::Vec(const Vec &other) : Vec() {
+  this->reserve_total(other.size());
+  std::copy(other.begin(), other.end(), std::back_inserter(*this));
+}
+
+template <typename T>
+Vec<T>::Vec(Vec &&other) noexcept : repr(other.repr) {
+  new (&other) Vec();
+}
+
+template <typename T>
+Vec<T>::~Vec() noexcept {
+  this->drop();
+}
+
+template <typename T>
+Vec<T> &Vec<T>::operator=(Vec &&other) &noexcept {
+  this->drop();
+  this->repr = other.repr;
+  new (&other) Vec();
+  return *this;
+}
+
+template <typename T>
+Vec<T> &Vec<T>::operator=(const Vec &other) & {
+  if (this != &other) {
+    this->drop();
+    new (this) Vec(other);
+  }
+  return *this;
+}
+
+template <typename T>
+bool Vec<T>::empty() const noexcept {
+  return this->size() == 0;
+}
+
+template <typename T>
+T *Vec<T>::data() noexcept {
+  return const_cast<T *>(const_cast<const Vec<T> *>(this)->data());
+}
+
+template <typename T>
+const T &Vec<T>::operator[](std::size_t n) const noexcept {
+  assert(n < this->size());
+  auto data = reinterpret_cast<const char *>(this->data());
+  return *reinterpret_cast<const T *>(data + n * size_of<T>());
+}
+
+template <typename T>
+const T &Vec<T>::at(std::size_t n) const {
+  if (n >= this->size()) {
+    panic<std::out_of_range>("rust::Vec index out of range");
+  }
+  return (*this)[n];
+}
+
+template <typename T>
+const T &Vec<T>::front() const noexcept {
+  assert(!this->empty());
+  return (*this)[0];
+}
+
+template <typename T>
+const T &Vec<T>::back() const noexcept {
+  assert(!this->empty());
+  return (*this)[this->size() - 1];
+}
+
+template <typename T>
+T &Vec<T>::operator[](std::size_t n) noexcept {
+  assert(n < this->size());
+  auto data = reinterpret_cast<char *>(this->data());
+  return *reinterpret_cast<T *>(data + n * size_of<T>());
+}
+
+template <typename T>
+T &Vec<T>::at(std::size_t n) {
+  if (n >= this->size()) {
+    panic<std::out_of_range>("rust::Vec index out of range");
+  }
+  return (*this)[n];
+}
+
+template <typename T>
+T &Vec<T>::front() noexcept {
+  assert(!this->empty());
+  return (*this)[0];
+}
+
+template <typename T>
+T &Vec<T>::back() noexcept {
+  assert(!this->empty());
+  return (*this)[this->size() - 1];
+}
+
+template <typename T>
+void Vec<T>::reserve(std::size_t new_cap) {
+  this->reserve_total(new_cap);
+}
+
+template <typename T>
+void Vec<T>::push_back(const T &value) {
+  this->emplace_back(value);
+}
+
+template <typename T>
+void Vec<T>::push_back(T &&value) {
+  this->emplace_back(std::move(value));
+}
+
+template <typename T>
+template <typename... Args>
+void Vec<T>::emplace_back(Args &&...args) {
+  auto size = this->size();
+  this->reserve_total(size + 1);
+  ::new (reinterpret_cast<T *>(reinterpret_cast<char *>(this->data()) +
+                               size * size_of<T>()))
+      T(std::forward<Args>(args)...);
+  this->set_len(size + 1);
+}
+
+template <typename T>
+typename Vec<T>::iterator Vec<T>::begin() noexcept {
+  return Slice<T>(this->data(), this->size()).begin();
+}
+
+template <typename T>
+typename Vec<T>::iterator Vec<T>::end() noexcept {
+  return Slice<T>(this->data(), this->size()).end();
+}
+
+template <typename T>
+typename Vec<T>::const_iterator Vec<T>::begin() const noexcept {
+  return this->cbegin();
+}
+
+template <typename T>
+typename Vec<T>::const_iterator Vec<T>::end() const noexcept {
+  return this->cend();
+}
+
+template <typename T>
+typename Vec<T>::const_iterator Vec<T>::cbegin() const noexcept {
+  return Slice<const T>(this->data(), this->size()).begin();
+}
+
+template <typename T>
+typename Vec<T>::const_iterator Vec<T>::cend() const noexcept {
+  return Slice<const T>(this->data(), this->size()).end();
+}
+
+template <typename T>
+void Vec<T>::swap(Vec &rhs) noexcept {
+  using std::swap;
+  swap(this->repr, rhs.repr);
+}
+
+// Internal API only intended for the cxxbridge code generator.
+template <typename T>
+Vec<T>::Vec(unsafe_bitcopy_t, const Vec &bits) noexcept : repr(bits.repr) {}
+#endif // CXXBRIDGE1_RUST_VEC
+
+#ifndef CXXBRIDGE1_IS_COMPLETE
+#define CXXBRIDGE1_IS_COMPLETE
+namespace detail {
+namespace {
+template <typename T, typename = std::size_t>
+struct is_complete : std::false_type {};
+template <typename T>
+struct is_complete<T, decltype(sizeof(T))> : std::true_type {};
+} // namespace
+} // namespace detail
+#endif // CXXBRIDGE1_IS_COMPLETE
+
+#ifndef CXXBRIDGE1_LAYOUT
+#define CXXBRIDGE1_LAYOUT
+class layout {
+  template <typename T>
+  friend std::size_t size_of();
+  template <typename T>
+  friend std::size_t align_of();
+  template <typename T>
+  static typename std::enable_if<std::is_base_of<Opaque, T>::value,
+                                 std::size_t>::type
+  do_size_of() {
+    return T::layout::size();
+  }
+  template <typename T>
+  static typename std::enable_if<!std::is_base_of<Opaque, T>::value,
+                                 std::size_t>::type
+  do_size_of() {
+    return sizeof(T);
+  }
+  template <typename T>
+  static
+      typename std::enable_if<detail::is_complete<T>::value, std::size_t>::type
+      size_of() {
+    return do_size_of<T>();
+  }
+  template <typename T>
+  static typename std::enable_if<std::is_base_of<Opaque, T>::value,
+                                 std::size_t>::type
+  do_align_of() {
+    return T::layout::align();
+  }
+  template <typename T>
+  static typename std::enable_if<!std::is_base_of<Opaque, T>::value,
+                                 std::size_t>::type
+  do_align_of() {
+    return alignof(T);
+  }
+  template <typename T>
+  static
+      typename std::enable_if<detail::is_complete<T>::value, std::size_t>::type
+      align_of() {
+    return do_align_of<T>();
+  }
+};
+
+template <typename T>
+std::size_t size_of() {
+  return layout::size_of<T>();
+}
+
+template <typename T>
+std::size_t align_of() {
+  return layout::align_of<T>();
+}
+#endif // CXXBRIDGE1_LAYOUT
+
+#ifndef CXXBRIDGE1_RELOCATABLE
+#define CXXBRIDGE1_RELOCATABLE
+namespace detail {
+template <typename... Ts>
+struct make_void {
+  using type = void;
+};
+
+template <typename... Ts>
+using void_t = typename make_void<Ts...>::type;
+
+template <typename Void, template <typename...> class, typename...>
+struct detect : std::false_type {};
+template <template <typename...> class T, typename... A>
+struct detect<void_t<T<A...>>, T, A...> : std::true_type {};
+
+template <template <typename...> class T, typename... A>
+using is_detected = detect<void, T, A...>;
+
+template <typename T>
+using detect_IsRelocatable = typename T::IsRelocatable;
+
+template <typename T>
+struct get_IsRelocatable
+    : std::is_same<typename T::IsRelocatable, std::true_type> {};
+} // namespace detail
+
+template <typename T>
+struct IsRelocatable
+    : std::conditional<
+          detail::is_detected<detail::detect_IsRelocatable, T>::value,
+          detail::get_IsRelocatable<T>,
+          std::integral_constant<
+              bool, std::is_trivially_move_constructible<T>::value &&
+                        std::is_trivially_destructible<T>::value>>::type {};
+#endif // CXXBRIDGE1_RELOCATABLE
+
+} // namespace cxxbridge1
+} // namespace rust

--- a/third-party/rust/vendor/cxx-1.0.52/src/cxx.cc
+++ b/third-party/rust/vendor/cxx-1.0.52/src/cxx.cc
@@ -1,0 +1,688 @@
+#include "../include/cxx.h"
+#include <cstring>
+#include <iostream>
+#include <memory>
+
+extern "C" {
+void cxxbridge1$cxx_string$init(std::string *s, const std::uint8_t *ptr,
+                                std::size_t len) noexcept {
+  new (s) std::string(reinterpret_cast<const char *>(ptr), len);
+}
+
+void cxxbridge1$cxx_string$destroy(std::string *s) noexcept {
+  using std::string;
+  s->~string();
+}
+
+const char *cxxbridge1$cxx_string$data(const std::string &s) noexcept {
+  return s.data();
+}
+
+std::size_t cxxbridge1$cxx_string$length(const std::string &s) noexcept {
+  return s.length();
+}
+
+void cxxbridge1$cxx_string$clear(std::string &s) noexcept { s.clear(); }
+
+void cxxbridge1$cxx_string$push(std::string &s, const std::uint8_t *ptr,
+                                std::size_t len) noexcept {
+  s.append(reinterpret_cast<const char *>(ptr), len);
+}
+
+// rust::String
+void cxxbridge1$string$new(rust::String *self) noexcept;
+void cxxbridge1$string$clone(rust::String *self,
+                             const rust::String &other) noexcept;
+bool cxxbridge1$string$from_utf8(rust::String *self, const char *ptr,
+                                 std::size_t len) noexcept;
+bool cxxbridge1$string$from_utf16(rust::String *self, const char16_t *ptr,
+                                  std::size_t len) noexcept;
+void cxxbridge1$string$drop(rust::String *self) noexcept;
+const char *cxxbridge1$string$ptr(const rust::String *self) noexcept;
+std::size_t cxxbridge1$string$len(const rust::String *self) noexcept;
+void cxxbridge1$string$reserve_total(rust::String *self, size_t cap) noexcept;
+
+// rust::Str
+void cxxbridge1$str$new(rust::Str *self) noexcept;
+void cxxbridge1$str$ref(rust::Str *self, const rust::String *string) noexcept;
+bool cxxbridge1$str$from(rust::Str *self, const char *ptr,
+                         std::size_t len) noexcept;
+const char *cxxbridge1$str$ptr(const rust::Str *self) noexcept;
+std::size_t cxxbridge1$str$len(const rust::Str *self) noexcept;
+
+// rust::Slice
+void cxxbridge1$slice$new(void *self, const void *ptr,
+                          std::size_t len) noexcept;
+void *cxxbridge1$slice$ptr(const void *self) noexcept;
+std::size_t cxxbridge1$slice$len(const void *self) noexcept;
+} // extern "C"
+
+namespace rust {
+inline namespace cxxbridge1 {
+
+template <typename Exception>
+void panic [[noreturn]] (const char *msg) {
+#if defined(RUST_CXX_NO_EXCEPTIONS)
+  std::cerr << "Error: " << msg << ". Aborting." << std::endl;
+  std::terminate();
+#else
+  throw Exception(msg);
+#endif
+}
+
+template void panic<std::out_of_range> [[noreturn]] (const char *msg);
+
+String::String() noexcept { cxxbridge1$string$new(this); }
+
+String::String(const String &other) noexcept {
+  cxxbridge1$string$clone(this, other);
+}
+
+String::String(String &&other) noexcept : repr(other.repr) {
+  cxxbridge1$string$new(&other);
+}
+
+String::~String() noexcept { cxxbridge1$string$drop(this); }
+
+static void initString(String *self, const char *s, std::size_t len) {
+  if (!cxxbridge1$string$from_utf8(self, s, len)) {
+    panic<std::invalid_argument>("data for rust::String is not utf-8");
+  }
+}
+
+static void initString(String *self, const char16_t *s, std::size_t len) {
+  if (!cxxbridge1$string$from_utf16(self, s, len)) {
+    panic<std::invalid_argument>("data for rust::String is not utf-16");
+  }
+}
+
+String::String(const std::string &s) { initString(this, s.data(), s.length()); }
+
+String::String(const char *s) {
+  assert(s != nullptr);
+  initString(this, s, std::strlen(s));
+}
+
+String::String(const char *s, std::size_t len) {
+  assert(s != nullptr || len == 0);
+  initString(this,
+             s == nullptr && len == 0 ? reinterpret_cast<const char *>(1) : s,
+             len);
+}
+
+String::String(const char16_t *s) {
+  assert(s != nullptr);
+  initString(this, s, std::char_traits<char16_t>::length(s));
+}
+
+String::String(const char16_t *s, std::size_t len) {
+  assert(s != nullptr || len == 0);
+  initString(this,
+             s == nullptr && len == 0 ? reinterpret_cast<const char16_t *>(2)
+                                      : s,
+             len);
+}
+
+String &String::operator=(const String &other) &noexcept {
+  if (this != &other) {
+    cxxbridge1$string$drop(this);
+    cxxbridge1$string$clone(this, other);
+  }
+  return *this;
+}
+
+String &String::operator=(String &&other) &noexcept {
+  cxxbridge1$string$drop(this);
+  this->repr = other.repr;
+  cxxbridge1$string$new(&other);
+  return *this;
+}
+
+String::operator std::string() const {
+  return std::string(this->data(), this->size());
+}
+
+const char *String::data() const noexcept {
+  return cxxbridge1$string$ptr(this);
+}
+
+std::size_t String::size() const noexcept {
+  return cxxbridge1$string$len(this);
+}
+
+std::size_t String::length() const noexcept {
+  return cxxbridge1$string$len(this);
+}
+
+bool String::empty() const noexcept { return this->size() == 0; }
+
+const char *String::c_str() noexcept {
+  auto len = this->length();
+  cxxbridge1$string$reserve_total(this, len + 1);
+  auto ptr = this->data();
+  const_cast<char *>(ptr)[len] = '\0';
+  return ptr;
+}
+
+String::iterator String::begin() noexcept {
+  return const_cast<char *>(this->data());
+}
+
+String::iterator String::end() noexcept {
+  return const_cast<char *>(this->data()) + this->size();
+}
+
+String::const_iterator String::begin() const noexcept { return this->cbegin(); }
+
+String::const_iterator String::end() const noexcept { return this->cend(); }
+
+String::const_iterator String::cbegin() const noexcept { return this->data(); }
+
+String::const_iterator String::cend() const noexcept {
+  return this->data() + this->size();
+}
+
+bool String::operator==(const String &rhs) const noexcept {
+  return rust::Str(*this) == rust::Str(rhs);
+}
+
+bool String::operator!=(const String &rhs) const noexcept {
+  return rust::Str(*this) != rust::Str(rhs);
+}
+
+bool String::operator<(const String &rhs) const noexcept {
+  return rust::Str(*this) < rust::Str(rhs);
+}
+
+bool String::operator<=(const String &rhs) const noexcept {
+  return rust::Str(*this) <= rust::Str(rhs);
+}
+
+bool String::operator>(const String &rhs) const noexcept {
+  return rust::Str(*this) > rust::Str(rhs);
+}
+
+bool String::operator>=(const String &rhs) const noexcept {
+  return rust::Str(*this) >= rust::Str(rhs);
+}
+
+void String::swap(String &rhs) noexcept {
+  using std::swap;
+  swap(this->repr, rhs.repr);
+}
+
+String::String(unsafe_bitcopy_t, const String &bits) noexcept
+    : repr(bits.repr) {}
+
+std::ostream &operator<<(std::ostream &os, const String &s) {
+  os.write(s.data(), s.size());
+  return os;
+}
+
+Str::Str() noexcept { cxxbridge1$str$new(this); }
+
+Str::Str(const String &s) noexcept { cxxbridge1$str$ref(this, &s); }
+
+static void initStr(Str *self, const char *ptr, std::size_t len) {
+  if (!cxxbridge1$str$from(self, ptr, len)) {
+    panic<std::invalid_argument>("data for rust::Str is not utf-8");
+  }
+}
+
+Str::Str(const std::string &s) { initStr(this, s.data(), s.length()); }
+
+Str::Str(const char *s) {
+  assert(s != nullptr);
+  initStr(this, s, std::strlen(s));
+}
+
+Str::Str(const char *s, std::size_t len) {
+  assert(s != nullptr || len == 0);
+  initStr(this,
+          s == nullptr && len == 0 ? reinterpret_cast<const char *>(1) : s,
+          len);
+}
+
+Str::operator std::string() const {
+  return std::string(this->data(), this->size());
+}
+
+const char *Str::data() const noexcept { return cxxbridge1$str$ptr(this); }
+
+std::size_t Str::size() const noexcept { return cxxbridge1$str$len(this); }
+
+std::size_t Str::length() const noexcept { return this->size(); }
+
+bool Str::empty() const noexcept { return this->size() == 0; }
+
+Str::const_iterator Str::begin() const noexcept { return this->cbegin(); }
+
+Str::const_iterator Str::end() const noexcept { return this->cend(); }
+
+Str::const_iterator Str::cbegin() const noexcept { return this->data(); }
+
+Str::const_iterator Str::cend() const noexcept {
+  return this->data() + this->size();
+}
+
+bool Str::operator==(const Str &rhs) const noexcept {
+  return this->size() == rhs.size() &&
+         std::equal(this->begin(), this->end(), rhs.begin());
+}
+
+bool Str::operator!=(const Str &rhs) const noexcept { return !(*this == rhs); }
+
+bool Str::operator<(const Str &rhs) const noexcept {
+  return std::lexicographical_compare(this->begin(), this->end(), rhs.begin(),
+                                      rhs.end());
+}
+
+bool Str::operator<=(const Str &rhs) const noexcept {
+  // std::mismatch(this->begin(), this->end(), rhs.begin(), rhs.end()), except
+  // without Undefined Behavior on C++11 if rhs is shorter than *this.
+  const_iterator liter = this->begin(), lend = this->end(), riter = rhs.begin(),
+                 rend = rhs.end();
+  while (liter != lend && riter != rend && *liter == *riter) {
+    ++liter, ++riter;
+  }
+  if (liter == lend) {
+    return true; // equal or *this is a prefix of rhs
+  } else if (riter == rend) {
+    return false; // rhs is a prefix of *this
+  } else {
+    return *liter <= *riter;
+  }
+}
+
+bool Str::operator>(const Str &rhs) const noexcept { return rhs < *this; }
+
+bool Str::operator>=(const Str &rhs) const noexcept { return rhs <= *this; }
+
+void Str::swap(Str &rhs) noexcept {
+  using std::swap;
+  swap(this->repr, rhs.repr);
+}
+
+std::ostream &operator<<(std::ostream &os, const Str &s) {
+  os.write(s.data(), s.size());
+  return os;
+}
+
+void sliceInit(void *self, const void *ptr, std::size_t len) noexcept {
+  cxxbridge1$slice$new(self, ptr, len);
+}
+
+void *slicePtr(const void *self) noexcept { return cxxbridge1$slice$ptr(self); }
+
+std::size_t sliceLen(const void *self) noexcept {
+  return cxxbridge1$slice$len(self);
+}
+
+// Rust specifies that usize is ABI compatible with C's uintptr_t.
+// https://rust-lang.github.io/unsafe-code-guidelines/layout/scalars.html#isize-and-usize
+// However there is no direct Rust equivalent for size_t. C does not guarantee
+// that size_t and uintptr_t are compatible. In practice though, on all
+// platforms supported by Rust, they are identical for ABI purposes. See the
+// libc crate which unconditionally defines libc::size_t = usize. We expect the
+// same here and these assertions are just here to explicitly document that.
+// *Note that no assumption is made about C++ name mangling of signatures
+// containing these types, not here nor anywhere in CXX.*
+static_assert(sizeof(std::size_t) == sizeof(std::uintptr_t),
+              "unsupported size_t size");
+static_assert(alignof(std::size_t) == alignof(std::uintptr_t),
+              "unsupported size_t alignment");
+static_assert(sizeof(rust::isize) == sizeof(std::intptr_t),
+              "unsupported ssize_t size");
+static_assert(alignof(rust::isize) == alignof(std::intptr_t),
+              "unsupported ssize_t alignment");
+
+static_assert(std::is_trivially_copy_constructible<Str>::value,
+              "trivial Str(const Str &)");
+static_assert(std::is_trivially_copy_assignable<Str>::value,
+              "trivial operator=(const Str &)");
+static_assert(std::is_trivially_destructible<Str>::value, "trivial ~Str()");
+
+static_assert(
+    std::is_trivially_copy_constructible<Slice<const std::uint8_t>>::value,
+    "trivial Slice(const Slice &)");
+static_assert(
+    std::is_trivially_move_constructible<Slice<const std::uint8_t>>::value,
+    "trivial Slice(Slice &&)");
+static_assert(
+    std::is_trivially_copy_assignable<Slice<const std::uint8_t>>::value,
+    "trivial Slice::operator=(const Slice &) for const slices");
+static_assert(
+    std::is_trivially_move_assignable<Slice<const std::uint8_t>>::value,
+    "trivial Slice::operator=(Slice &&)");
+static_assert(std::is_trivially_destructible<Slice<const std::uint8_t>>::value,
+              "trivial ~Slice()");
+
+static_assert(std::is_trivially_copy_constructible<Slice<std::uint8_t>>::value,
+              "trivial Slice(const Slice &)");
+static_assert(std::is_trivially_move_constructible<Slice<std::uint8_t>>::value,
+              "trivial Slice(Slice &&)");
+static_assert(!std::is_copy_assignable<Slice<std::uint8_t>>::value,
+              "delete Slice::operator=(const Slice &) for mut slices");
+static_assert(std::is_trivially_move_assignable<Slice<std::uint8_t>>::value,
+              "trivial Slice::operator=(Slice &&)");
+static_assert(std::is_trivially_destructible<Slice<std::uint8_t>>::value,
+              "trivial ~Slice()");
+
+static_assert(std::is_same<Vec<std::uint8_t>::const_iterator,
+                           Vec<const std::uint8_t>::iterator>::value,
+              "Vec<T>::const_iterator == Vec<const T>::iterator");
+static_assert(std::is_same<Vec<const std::uint8_t>::const_iterator,
+                           Vec<const std::uint8_t>::iterator>::value,
+              "Vec<const T>::const_iterator == Vec<const T>::iterator");
+static_assert(!std::is_same<Vec<std::uint8_t>::const_iterator,
+                            Vec<std::uint8_t>::iterator>::value,
+              "Vec<T>::const_iterator != Vec<T>::iterator");
+
+static const char *errorCopy(const char *ptr, std::size_t len) {
+  char *copy = new char[len];
+  std::memcpy(copy, ptr, len);
+  return copy;
+}
+
+extern "C" {
+const char *cxxbridge1$error(const char *ptr, std::size_t len) noexcept {
+  return errorCopy(ptr, len);
+}
+} // extern "C"
+
+Error::Error(const Error &other)
+    : std::exception(other),
+      msg(other.msg ? errorCopy(other.msg, other.len) : nullptr),
+      len(other.len) {}
+
+Error::Error(Error &&other) noexcept
+    : std::exception(std::move(other)), msg(other.msg), len(other.len) {
+  other.msg = nullptr;
+  other.len = 0;
+}
+
+Error::~Error() noexcept { delete[] this->msg; }
+
+Error &Error::operator=(const Error &other) & {
+  if (this != &other) {
+    std::exception::operator=(other);
+    delete[] this->msg;
+    this->msg = nullptr;
+    if (other.msg) {
+      this->msg = errorCopy(other.msg, other.len);
+      this->len = other.len;
+    }
+  }
+  return *this;
+}
+
+Error &Error::operator=(Error &&other) &noexcept {
+  std::exception::operator=(std::move(other));
+  this->msg = other.msg;
+  this->len = other.len;
+  other.msg = nullptr;
+  other.len = 0;
+  return *this;
+}
+
+const char *Error::what() const noexcept { return this->msg; }
+
+namespace {
+template <typename T>
+union MaybeUninit {
+  T value;
+  MaybeUninit() {}
+  ~MaybeUninit() {}
+};
+} // namespace
+
+namespace detail {
+// On some platforms size_t is the same C++ type as one of the sized integer
+// types; on others it is a distinct type. Only in the latter case do we need to
+// define a specialized impl of rust::Vec<size_t>, because in the former case it
+// would collide with one of the other specializations.
+using usize_if_unique =
+    typename std::conditional<std::is_same<size_t, uint64_t>::value ||
+                                  std::is_same<size_t, uint32_t>::value,
+                              struct usize_ignore, size_t>::type;
+using isize_if_unique =
+    typename std::conditional<std::is_same<rust::isize, int64_t>::value ||
+                                  std::is_same<rust::isize, int32_t>::value,
+                              struct isize_ignore, rust::isize>::type;
+} // namespace detail
+
+} // namespace cxxbridge1
+} // namespace rust
+
+namespace {
+template <typename T>
+void destroy(T *ptr) {
+  ptr->~T();
+}
+} // namespace
+
+extern "C" {
+void cxxbridge1$unique_ptr$std$string$null(
+    std::unique_ptr<std::string> *ptr) noexcept {
+  new (ptr) std::unique_ptr<std::string>();
+}
+void cxxbridge1$unique_ptr$std$string$raw(std::unique_ptr<std::string> *ptr,
+                                          std::string *raw) noexcept {
+  new (ptr) std::unique_ptr<std::string>(raw);
+}
+const std::string *cxxbridge1$unique_ptr$std$string$get(
+    const std::unique_ptr<std::string> &ptr) noexcept {
+  return ptr.get();
+}
+std::string *cxxbridge1$unique_ptr$std$string$release(
+    std::unique_ptr<std::string> &ptr) noexcept {
+  return ptr.release();
+}
+void cxxbridge1$unique_ptr$std$string$drop(
+    std::unique_ptr<std::string> *ptr) noexcept {
+  ptr->~unique_ptr();
+}
+} // extern "C"
+
+namespace {
+const std::size_t kMaxExpectedWordsInString = 8;
+static_assert(alignof(std::string) <= alignof(void *),
+              "unexpectedly large std::string alignment");
+static_assert(sizeof(std::string) <= kMaxExpectedWordsInString * sizeof(void *),
+              "unexpectedly large std::string size");
+} // namespace
+
+#define STD_VECTOR_OPS(RUST_TYPE, CXX_TYPE)                                    \
+  std::size_t cxxbridge1$std$vector$##RUST_TYPE##$size(                        \
+      const std::vector<CXX_TYPE> &s) noexcept {                               \
+    return s.size();                                                           \
+  }                                                                            \
+  CXX_TYPE *cxxbridge1$std$vector$##RUST_TYPE##$get_unchecked(                 \
+      std::vector<CXX_TYPE> *s, std::size_t pos) noexcept {                    \
+    return &(*s)[pos];                                                         \
+  }                                                                            \
+  void cxxbridge1$unique_ptr$std$vector$##RUST_TYPE##$null(                    \
+      std::unique_ptr<std::vector<CXX_TYPE>> *ptr) noexcept {                  \
+    new (ptr) std::unique_ptr<std::vector<CXX_TYPE>>();                        \
+  }                                                                            \
+  void cxxbridge1$unique_ptr$std$vector$##RUST_TYPE##$raw(                     \
+      std::unique_ptr<std::vector<CXX_TYPE>> *ptr,                             \
+      std::vector<CXX_TYPE> *raw) noexcept {                                   \
+    new (ptr) std::unique_ptr<std::vector<CXX_TYPE>>(raw);                     \
+  }                                                                            \
+  const std::vector<CXX_TYPE>                                                  \
+      *cxxbridge1$unique_ptr$std$vector$##RUST_TYPE##$get(                     \
+          const std::unique_ptr<std::vector<CXX_TYPE>> &ptr) noexcept {        \
+    return ptr.get();                                                          \
+  }                                                                            \
+  std::vector<CXX_TYPE>                                                        \
+      *cxxbridge1$unique_ptr$std$vector$##RUST_TYPE##$release(                 \
+          std::unique_ptr<std::vector<CXX_TYPE>> &ptr) noexcept {              \
+    return ptr.release();                                                      \
+  }                                                                            \
+  void cxxbridge1$unique_ptr$std$vector$##RUST_TYPE##$drop(                    \
+      std::unique_ptr<std::vector<CXX_TYPE>> *ptr) noexcept {                  \
+    ptr->~unique_ptr();                                                        \
+  }
+
+#define STD_VECTOR_TRIVIAL_OPS(RUST_TYPE, CXX_TYPE)                            \
+  void cxxbridge1$std$vector$##RUST_TYPE##$push_back(                          \
+      std::vector<CXX_TYPE> *v, CXX_TYPE *value) noexcept {                    \
+    v->push_back(std::move(*value));                                           \
+    destroy(value);                                                            \
+  }                                                                            \
+  void cxxbridge1$std$vector$##RUST_TYPE##$pop_back(std::vector<CXX_TYPE> *v,  \
+                                                    CXX_TYPE *out) noexcept {  \
+    new (out) CXX_TYPE(std::move(v->back()));                                  \
+    v->pop_back();                                                             \
+  }
+
+#define RUST_VEC_EXTERNS(RUST_TYPE, CXX_TYPE)                                  \
+  void cxxbridge1$rust_vec$##RUST_TYPE##$new(                                  \
+      rust::Vec<CXX_TYPE> *ptr) noexcept;                                      \
+  void cxxbridge1$rust_vec$##RUST_TYPE##$drop(                                 \
+      rust::Vec<CXX_TYPE> *ptr) noexcept;                                      \
+  std::size_t cxxbridge1$rust_vec$##RUST_TYPE##$len(                           \
+      const rust::Vec<CXX_TYPE> *ptr) noexcept;                                \
+  std::size_t cxxbridge1$rust_vec$##RUST_TYPE##$capacity(                      \
+      const rust::Vec<CXX_TYPE> *ptr) noexcept;                                \
+  const CXX_TYPE *cxxbridge1$rust_vec$##RUST_TYPE##$data(                      \
+      const rust::Vec<CXX_TYPE> *ptr) noexcept;                                \
+  void cxxbridge1$rust_vec$##RUST_TYPE##$reserve_total(                        \
+      rust::Vec<CXX_TYPE> *ptr, std::size_t cap) noexcept;                     \
+  void cxxbridge1$rust_vec$##RUST_TYPE##$set_len(rust::Vec<CXX_TYPE> *ptr,     \
+                                                 std::size_t len) noexcept;
+
+#define RUST_VEC_OPS(RUST_TYPE, CXX_TYPE)                                      \
+  template <>                                                                  \
+  Vec<CXX_TYPE>::Vec() noexcept {                                              \
+    cxxbridge1$rust_vec$##RUST_TYPE##$new(this);                               \
+  }                                                                            \
+  template <>                                                                  \
+  void Vec<CXX_TYPE>::drop() noexcept {                                        \
+    return cxxbridge1$rust_vec$##RUST_TYPE##$drop(this);                       \
+  }                                                                            \
+  template <>                                                                  \
+  std::size_t Vec<CXX_TYPE>::size() const noexcept {                           \
+    return cxxbridge1$rust_vec$##RUST_TYPE##$len(this);                        \
+  }                                                                            \
+  template <>                                                                  \
+  std::size_t Vec<CXX_TYPE>::capacity() const noexcept {                       \
+    return cxxbridge1$rust_vec$##RUST_TYPE##$capacity(this);                   \
+  }                                                                            \
+  template <>                                                                  \
+  const CXX_TYPE *Vec<CXX_TYPE>::data() const noexcept {                       \
+    return cxxbridge1$rust_vec$##RUST_TYPE##$data(this);                       \
+  }                                                                            \
+  template <>                                                                  \
+  void Vec<CXX_TYPE>::reserve_total(std::size_t cap) noexcept {                \
+    cxxbridge1$rust_vec$##RUST_TYPE##$reserve_total(this, cap);                \
+  }                                                                            \
+  template <>                                                                  \
+  void Vec<CXX_TYPE>::set_len(std::size_t len) noexcept {                      \
+    cxxbridge1$rust_vec$##RUST_TYPE##$set_len(this, len);                      \
+  }
+
+#define SHARED_PTR_OPS(RUST_TYPE, CXX_TYPE)                                    \
+  static_assert(sizeof(std::shared_ptr<CXX_TYPE>) == 2 * sizeof(void *), "");  \
+  static_assert(alignof(std::shared_ptr<CXX_TYPE>) == alignof(void *), "");    \
+  void cxxbridge1$std$shared_ptr$##RUST_TYPE##$null(                           \
+      std::shared_ptr<CXX_TYPE> *ptr) noexcept {                               \
+    new (ptr) std::shared_ptr<CXX_TYPE>();                                     \
+  }                                                                            \
+  CXX_TYPE *cxxbridge1$std$shared_ptr$##RUST_TYPE##$uninit(                    \
+      std::shared_ptr<CXX_TYPE> *ptr) noexcept {                               \
+    CXX_TYPE *uninit =                                                         \
+        reinterpret_cast<CXX_TYPE *>(new rust::MaybeUninit<CXX_TYPE>);         \
+    new (ptr) std::shared_ptr<CXX_TYPE>(uninit);                               \
+    return uninit;                                                             \
+  }                                                                            \
+  void cxxbridge1$std$shared_ptr$##RUST_TYPE##$clone(                          \
+      const std::shared_ptr<CXX_TYPE> &self,                                   \
+      std::shared_ptr<CXX_TYPE> *ptr) noexcept {                               \
+    new (ptr) std::shared_ptr<CXX_TYPE>(self);                                 \
+  }                                                                            \
+  const CXX_TYPE *cxxbridge1$std$shared_ptr$##RUST_TYPE##$get(                 \
+      const std::shared_ptr<CXX_TYPE> &self) noexcept {                        \
+    return self.get();                                                         \
+  }                                                                            \
+  void cxxbridge1$std$shared_ptr$##RUST_TYPE##$drop(                           \
+      const std::shared_ptr<CXX_TYPE> *self) noexcept {                        \
+    self->~shared_ptr();                                                       \
+  }                                                                            \
+  static_assert(sizeof(std::weak_ptr<CXX_TYPE>) == 2 * sizeof(void *), "");    \
+  static_assert(alignof(std::weak_ptr<CXX_TYPE>) == alignof(void *), "");      \
+  void cxxbridge1$std$weak_ptr$##RUST_TYPE##$null(                             \
+      std::weak_ptr<CXX_TYPE> *ptr) noexcept {                                 \
+    new (ptr) std::weak_ptr<CXX_TYPE>();                                       \
+  }                                                                            \
+  void cxxbridge1$std$weak_ptr$##RUST_TYPE##$clone(                            \
+      const std::weak_ptr<CXX_TYPE> &self,                                     \
+      std::weak_ptr<CXX_TYPE> *ptr) noexcept {                                 \
+    new (ptr) std::weak_ptr<CXX_TYPE>(self);                                   \
+  }                                                                            \
+  void cxxbridge1$std$weak_ptr$##RUST_TYPE##$downgrade(                        \
+      const std::shared_ptr<CXX_TYPE> &shared,                                 \
+      std::weak_ptr<CXX_TYPE> *weak) noexcept {                                \
+    new (weak) std::weak_ptr<CXX_TYPE>(shared);                                \
+  }                                                                            \
+  void cxxbridge1$std$weak_ptr$##RUST_TYPE##$upgrade(                          \
+      const std::weak_ptr<CXX_TYPE> &weak,                                     \
+      std::shared_ptr<CXX_TYPE> *shared) noexcept {                            \
+    new (shared) std::shared_ptr<CXX_TYPE>(weak.lock());                       \
+  }                                                                            \
+  void cxxbridge1$std$weak_ptr$##RUST_TYPE##$drop(                             \
+      const std::weak_ptr<CXX_TYPE> *self) noexcept {                          \
+    self->~weak_ptr();                                                         \
+  }
+
+// Usize and isize are the same type as one of the below.
+#define FOR_EACH_NUMERIC(MACRO)                                                \
+  MACRO(u8, std::uint8_t)                                                      \
+  MACRO(u16, std::uint16_t)                                                    \
+  MACRO(u32, std::uint32_t)                                                    \
+  MACRO(u64, std::uint64_t)                                                    \
+  MACRO(i8, std::int8_t)                                                       \
+  MACRO(i16, std::int16_t)                                                     \
+  MACRO(i32, std::int32_t)                                                     \
+  MACRO(i64, std::int64_t)                                                     \
+  MACRO(f32, float)                                                            \
+  MACRO(f64, double)
+
+#define FOR_EACH_TRIVIAL_STD_VECTOR(MACRO)                                     \
+  FOR_EACH_NUMERIC(MACRO)                                                      \
+  MACRO(usize, std::size_t)                                                    \
+  MACRO(isize, rust::isize)
+
+#define FOR_EACH_STD_VECTOR(MACRO)                                             \
+  FOR_EACH_TRIVIAL_STD_VECTOR(MACRO)                                           \
+  MACRO(string, std::string)
+
+#define FOR_EACH_RUST_VEC(MACRO)                                               \
+  FOR_EACH_NUMERIC(MACRO)                                                      \
+  MACRO(bool, bool)                                                            \
+  MACRO(char, char)                                                            \
+  MACRO(usize, rust::detail::usize_if_unique)                                  \
+  MACRO(isize, rust::detail::isize_if_unique)                                  \
+  MACRO(string, rust::String)                                                  \
+  MACRO(str, rust::Str)
+
+#define FOR_EACH_SHARED_PTR(MACRO)                                             \
+  FOR_EACH_NUMERIC(MACRO)                                                      \
+  MACRO(bool, bool)                                                            \
+  MACRO(usize, std::size_t)                                                    \
+  MACRO(isize, rust::isize)                                                    \
+  MACRO(string, std::string)
+
+extern "C" {
+FOR_EACH_STD_VECTOR(STD_VECTOR_OPS)
+FOR_EACH_TRIVIAL_STD_VECTOR(STD_VECTOR_TRIVIAL_OPS)
+FOR_EACH_RUST_VEC(RUST_VEC_EXTERNS)
+FOR_EACH_SHARED_PTR(SHARED_PTR_OPS)
+} // extern "C"
+
+namespace rust {
+inline namespace cxxbridge1 {
+FOR_EACH_RUST_VEC(RUST_VEC_OPS)
+} // namespace cxxbridge1
+} // namespace rust

--- a/tools/build/BUCK
+++ b/tools/build/BUCK
@@ -1,14 +1,14 @@
 load("//antlir/bzl:oss_shim.bzl", "buck_command_alias")
 load(":rust.bzl", "rustc_toolchain")
 
+# The latest nightly and it's sha can be found in
+# https://static.rust-lang.org/dist/channel-rust-nightly.toml
 linux_x86_64_toolchain = rustc_toolchain(
     arch = "x86_64",
     channel = "nightly",
-    # The sha256 of the artifact is available via a URL of this form:
-    # https://static.rust-lang.org/dist/{version}/rust-{channel}-{arch}-{target}.tar.gz.sha256
-    sha256 = "89effca4bf6420446cd55ce46c384ad4f8496f7ad6e96108255fbad0d37f036b",
+    sha256 = "bf1b041c95324caa94bc3d02fe32cce0160e0a4a430cf1072614287d9e4dfcff",
     target = "unknown-linux-gnu",
-    version = "2021-04-20",
+    version = "2021-08-23",
 )
 
 buck_command_alias(


### PR DESCRIPTION
Summary:
I wrote this fancy tool and forgot to actually run it.
I also think that lots of this has been broken since I added starlark, so there
were lots of little things I needed to fix.

Short list:
- update to latest rust nightly (some features were stabilized between our
  previous rev and now)
- fix CARGO_MANIFEST_DIR that is read by some proc-macros
- targets for gazebo, add more deps for starlark crates

Differential Revision: D30432551

