### PR TITLE
Support cross-cell use of Antlir

### DIFF
--- a/antlir/bzl/constants.bzl
+++ b/antlir/bzl/constants.bzl
@@ -9,7 +9,7 @@
 # Note that there's no deep reason for this struct / non-struct split, so we
 # could easily move everything into the struct.
 #
-load("//antlir/bzl:oss_shim.bzl", "do_not_use_repo_cfg")
+load("//antlir/bzl:oss_shim.bzl", "config", "do_not_use_repo_cfg")
 load("//antlir/bzl:sha256.bzl", "sha256_b64")
 load("//antlir/bzl:shape.bzl", "shape")
 load(":snapshot_install_dir.bzl", "RPM_DEFAULT_SNAPSHOT_FOR_INSTALLER_DIR", "snapshot_install_dir")
@@ -258,6 +258,7 @@ repo_config_t = shape.shape(
     flavor_default = str,
     flavor_to_config = shape.dict(str, _flavor_config_t),
     antlir_linux_flavor = str,
+    antlir_cell_name = str,
 )
 
 REPO_CFG = shape.new(
@@ -300,4 +301,5 @@ REPO_CFG = shape.new(
     # including `image.layer` will use.  This would be fixable if Buck
     # supported providers like Bazel does.
     antlir_linux_flavor = _get_str_cfg("antlir_linux_flavor", allow_none = True),
+    antlir_cell_name = config.get_antlir_cell_name(),
 )

--- a/antlir/bzl/image/package/new.bzl
+++ b/antlir/bzl/image/package/new.bzl
@@ -14,6 +14,7 @@ load("//antlir/bzl:image_utils.bzl", "image_utils")
 load("//antlir/bzl:loopback_opts.bzl", "normalize_loopback_opts")
 load("//antlir/bzl:oss_shim.bzl", "buck_genrule")
 load("//antlir/bzl:shape.bzl", "shape")
+load("//antlir/bzl:target_helpers.bzl", "antlir_dep")
 
 _IMAGE_PACKAGE = "image_package"
 
@@ -53,7 +54,7 @@ def package_new(
         # This is very temporary to work around an FB-internal issue.
         cacheable = False,
         bash = image_utils.wrap_bash_build_in_common_boilerplate(
-            self_dependency = "//antlir/bzl/image/package:new",
+            self_dependency = antlir_dep("bzl/image/package:new"),
             # We don't need to hold any subvolume lock because we trust
             # that (a) Buck will keep our input JSON alive, and (b) the
             # existence of the JSON will keep the refcount above 1,
@@ -66,7 +67,7 @@ def package_new(
             # On the other hand, `exe` does not expand to a single file,
             # but rather to a shell snippet, so it's not always what one
             # wants either.
-            $(exe //antlir:package-image) \
+            $(exe {package_image}) \
               --subvolumes-dir "$subvolumes_dir" \
               --layer-path $(query_outputs {layer}) \
               --format {format} \
@@ -92,6 +93,7 @@ def package_new(
                 # This could replace `--subvolume-json`, though also
                 # specifying it would make `get_subvolume_on_disk_stack`
                 # more efficient.
+                package_image = antlir_dep(":package-image"),
             ),
             rule_type = _IMAGE_PACKAGE,
             target_name = name,

--- a/antlir/bzl/oss_shim.bzl
+++ b/antlir/bzl/oss_shim.bzl
@@ -149,6 +149,7 @@ http_archive = shim.http_archive
 kernel_get = shim.kernel_get
 do_not_use_repo_cfg = shim.do_not_use_repo_cfg
 rpm_vset = shim.rpm_vset
+repository_name = shim.repository_name
 rust_binary = shim.rust_binary
 rust_bindgen_library = shim.rust_bindgen_library
 rust_library = shim.rust_library

--- a/antlir/bzl/oss_shim_impl.bzl
+++ b/antlir/bzl/oss_shim_impl.bzl
@@ -52,7 +52,7 @@ def _assert_package():
     # implicit loads of native rules is disabled) for consistency. Everything
     # in the main cell except the above exception(s) are allowed to use
     # oss_shim.bzl
-    cell = native.repository_name()
+    cell = _repository_name()
 
     # TODO: if antlir is intended to _only_ be used as a Buck cell, the '@'
     # check should be disabled. This is not currently the way the project is
@@ -558,6 +558,9 @@ def _get_buck_out_path():
 
 ### END COPY-PASTA
 
+def _repository_name():
+    return "@"
+
 def _get_antlir_cell_name():
     return ""
 
@@ -605,6 +608,7 @@ shim = struct(
     python_binary = _python_binary,
     python_library = _python_library,
     python_unittest = _python_unittest,
+    repository_name = _repository_name,
     rust_binary = _rust_binary,
     rust_library = _rust_library,
     rust_unittest = _rust_unittest,

--- a/antlir/bzl/target_helpers.bzl
+++ b/antlir/bzl/target_helpers.bzl
@@ -3,22 +3,26 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-load(":oss_shim.bzl", "buck_genrule", "config", "target_utils")
+load(":oss_shim.bzl", "buck_genrule", "config", "repository_name", "target_utils")
 load(":sha256.bzl", "sha256_b64")
 
 def normalize_target(target):
+    if target.startswith("//"):
+        return repository_name()[1:] + target
+
     # Don't normalize if already normalized. This avoids the Buck error:
     #   Error in package_name: Top-level invocations of package_name are not
     #   allowed in .bzl files.  Wrap it in a macro and call it from a BUCK file.
     if "//" in target:
         return target
+
     parsed = target_utils.parse_target(
         target,
         # The repository name always starts with "@", which we do not want here.
         # default_repo will be empty for the main repository, which matches the
         # results from $(query_targets ...).
         # @lint-ignore BUCKLINT
-        default_repo = native.repository_name()[1:],
+        default_repo = repository_name()[1:],
         # @lint-ignore BUCKLINT
         default_base_path = native.package_name(),
     )

--- a/antlir/bzl/tests/test_image_unittest_repo_server.py
+++ b/antlir/bzl/tests/test_image_unittest_repo_server.py
@@ -8,6 +8,7 @@ import os
 import subprocess
 import unittest
 
+from antlir.config import antlir_dep
 from antlir.fs_utils import temp_dir
 from antlir.rpm.find_snapshot import snapshot_install_dir
 from antlir.tests.flavor_helpers import get_rpm_installers_supported
@@ -16,7 +17,7 @@ from antlir.tests.flavor_helpers import get_rpm_installers_supported
 class ImageUnittestTestRepoServer(unittest.TestCase):
     def test_install_rpm(self):
         snapshot_dir = snapshot_install_dir(
-            "//antlir/rpm:repo-snapshot-for-tests"
+            antlir_dep("rpm:repo-snapshot-for-tests")
         )
         for prog in get_rpm_installers_supported():
             with temp_dir() as td:

--- a/antlir/compiler/defs.bzl
+++ b/antlir/compiler/defs.bzl
@@ -5,10 +5,11 @@
 
 load("//antlir/bzl:constants.bzl", "REPO_CFG")
 load("//antlir/bzl:oss_shim.bzl", "python_unittest")
+load("//antlir/bzl:target_helpers.bzl", "antlir_dep")
 load("//antlir/bzl/image/feature:install.bzl", "TEST_ONLY_wrap_buck_runnable")
 load("//antlir/bzl/image/feature:new.bzl", "PRIVATE_DO_NOT_USE_feature_target_name")
 
-TEST_IMAGE_PREFIX = "//antlir/compiler/test_images:"
+TEST_IMAGE_PREFIX = antlir_dep("compiler/test_images:")
 
 def READ_MY_DOC_image_feature_target(name):
     """

--- a/antlir/compiler/items/mount.py
+++ b/antlir/compiler/items/mount.py
@@ -21,6 +21,7 @@ from antlir.compiler.requires_provides import (
     ProvidesDoNotAccess,
     RequireDirectory,
 )
+from antlir.config import antlir_dep
 from antlir.find_built_subvol import find_built_subvol
 from antlir.fs_utils import Path, temp_dir
 from antlir.subvol_utils import Subvol
@@ -116,7 +117,7 @@ class MountItem(ImageItem):
         kwargs["build_source"] = BuildSource(**cfg.pop("build_source"))
         if kwargs["build_source"].type == "host" and not (
             kwargs["from_target"] in layer_opts.allowed_host_mount_targets
-            or kwargs["from_target"].startswith("//antlir/compiler/test")
+            or kwargs["from_target"].startswith(antlir_dep("compiler/test"))
         ):
             raise AssertionError(
                 "Host mounts cause containers to be non-hermetic and "

--- a/antlir/compiler/items/tests/test_genrule_layer.py
+++ b/antlir/compiler/items/tests/test_genrule_layer.py
@@ -12,6 +12,7 @@ import unittest
 from contextlib import contextmanager
 from typing import AnyStr, Iterable
 
+from antlir.config import antlir_dep
 from antlir.fs_utils import Path
 from antlir.rpm.find_snapshot import snapshot_install_dir
 from antlir.subvol_utils import TempSubvolumes
@@ -78,7 +79,7 @@ class GenruleLayerItemTestCase(unittest.TestCase):
             self._check_protected_dir(subvol, "/__antlir__")
 
             snapshot_dir = snapshot_install_dir(
-                "//antlir/rpm:repo-snapshot-for-tests"
+                antlir_dep("rpm:repo-snapshot-for-tests")
             )
             GenruleLayerItem.get_phase_builder(
                 [

--- a/antlir/compiler/items/tests/test_mount.py
+++ b/antlir/compiler/items/tests/test_mount.py
@@ -17,6 +17,7 @@ from antlir.compiler.requires_provides import (
     RequireDirectory,
 )
 from antlir.compiler.subvolume_on_disk import SubvolumeOnDisk
+from antlir.config import antlir_dep
 from antlir.fs_utils import Path, temp_dir
 from antlir.subvol_utils import TempSubvolumes
 from antlir.tests.layer_resource import layer_resource_subvol
@@ -351,8 +352,7 @@ class MountItemTestCase(BaseItemTestCase):
             Mount(
                 build_source=BuildSource(
                     type="layer",
-                    source="//antlir/compiler/test_images:"
-                    + "hello_world_base",
+                    source=antlir_dep("compiler/test_images:hello_world_base"),
                 ),
                 is_directory=True,
                 mountpoint="meownt",

--- a/antlir/compiler/tests/sample_items.py
+++ b/antlir/compiler/tests/sample_items.py
@@ -21,6 +21,7 @@ from antlir.compiler.items.rpm_action import (
 from antlir.compiler.items.symlink import SymlinkToDirItem, SymlinkToFileItem
 from antlir.compiler.items.tarball import TarballItem
 from antlir.compiler.items.user import UserItem
+from antlir.config import antlir_dep
 from antlir.fs_utils import Path
 from antlir.rpm.find_snapshot import mangle_target
 
@@ -42,7 +43,7 @@ _NONPORTABLE_ARTIFACTS = int(
     os.environ.get("test_image_feature_built_artifacts_require_repo")
 )
 
-T_BASE = "//antlir/compiler/test_images"
+T_BASE = antlir_dep("compiler/test_images")
 # Use the "debug", human-readable forms of the `feature`s targets here,
 # since that's what we are testing.
 T_DIRS = f"{T_BASE}:feature_dirs"

--- a/antlir/compiler/tests/test_image_layer.py
+++ b/antlir/compiler/tests/test_image_layer.py
@@ -15,7 +15,7 @@ from antlir.btrfs_diff.tests.demo_sendstreams_expected import (
     render_demo_subvols,
 )
 from antlir.compiler.items.mount import mounts_from_meta
-from antlir.config import repo_config
+from antlir.config import repo_config, antlir_dep
 from antlir.find_built_subvol import find_built_subvol
 from antlir.fs_utils import Path
 from antlir.tests.flavor_helpers import (
@@ -65,7 +65,7 @@ class ImageLayerTestCase(unittest.TestCase):
                 "is_directory": True,
                 "build_source": {
                     "type": "layer",
-                    "source": "//antlir/compiler/test_images:" + target,
+                    "source": antlir_dep("compiler/test_images:" + target),
                 },
             }
             if mount_config:
@@ -209,7 +209,7 @@ class ImageLayerTestCase(unittest.TestCase):
                 {
                     "build_source": {
                         "type": "layer",
-                        "source": "//antlir/compiler/test_images:create_ops",
+                        "source": antlir_dep("compiler/test_images:create_ops"),
                     }
                 },
             ),

--- a/antlir/nspawn_in_subvol/cmd.py
+++ b/antlir/nspawn_in_subvol/cmd.py
@@ -31,6 +31,10 @@ from .args import PopenArgs, _NspawnOpts
 from .common import find_cgroup2_mountpoint, parse_cgroup2_path
 
 
+# For test mocking
+_load_repo_config = repo_config
+
+
 def _colon_quote_path(path: AnyStr) -> Path:
     return Path(re.sub(b"[\\\\:]", lambda m: b"\\" + m.group(0), Path(path)))
 
@@ -252,13 +256,13 @@ def _extra_nspawn_args_and_env(
             bind_args(
                 # Buck seems to operate with `realpath` when it resolves
                 # `$(location)` macros, so this is what we should mount.
-                os.path.realpath(repo_config().repo_root)
+                os.path.realpath(_load_repo_config().repo_root)
             )
         )
 
         # insert additional host mounts that are always required when
         # using repository artifacts.
-        for mount in repo_config().host_mounts_for_repo_artifacts:
+        for mount in _load_repo_config().host_mounts_for_repo_artifacts:
             extra_nspawn_args.extend(bind_args(mount))
 
         # Future: we **may** also need to mount the scratch directory

--- a/antlir/nspawn_in_subvol/plugins/tests/rpm_base.py
+++ b/antlir/nspawn_in_subvol/plugins/tests/rpm_base.py
@@ -8,13 +8,16 @@ import shlex
 import tempfile
 import textwrap
 
+from antlir.config import antlir_dep
 from antlir.nspawn_in_subvol.tests.base import NspawnTestBase
 from antlir.rpm.find_snapshot import snapshot_install_dir
 
 
 class RpmNspawnTestBase(NspawnTestBase):
 
-    _SNAPSHOT_DIR = snapshot_install_dir("//antlir/rpm:repo-snapshot-for-tests")
+    _SNAPSHOT_DIR = snapshot_install_dir(
+        antlir_dep("rpm:repo-snapshot-for-tests")
+    )
 
     def _yum_or_dnf_install(
         self,

--- a/antlir/nspawn_in_subvol/plugins/tests/test_rpm_installer_shadow_paths.py
+++ b/antlir/nspawn_in_subvol/plugins/tests/test_rpm_installer_shadow_paths.py
@@ -6,6 +6,7 @@
 
 import functools
 
+from antlir.config import antlir_dep
 from antlir.rpm.find_snapshot import snapshot_install_dir
 from antlir.subvol_utils import with_temp_subvols
 from antlir.tests.layer_resource import layer_resource_subvol
@@ -18,7 +19,7 @@ class TestImpl:
     _SHADOW_BA_PAIR = (__package__, "shadow-build-appliance")
 
     _NONDEFAULT_SNAPSHOT_DIR = snapshot_install_dir(
-        "//antlir/rpm:non-default-repo-snapshot-for-tests"
+        antlir_dep("rpm:non-default-repo-snapshot-for-tests")
     )
 
     def test_install_via_default_shadowed_installer(self):

--- a/antlir/rpm/replay/tests/test_extract_nested_features.py
+++ b/antlir/rpm/replay/tests/test_extract_nested_features.py
@@ -7,6 +7,7 @@
 import os
 import unittest
 
+from antlir.config import antlir_dep
 from antlir.rpm.replay.tests.test_utils import (
     build_env_map,
     extract_features_from_env_map,
@@ -85,7 +86,7 @@ class ExtractNestedFeaturesTestCase(unittest.TestCase):
         self.assertEqual(set(), ef.features_needing_custom_image)
 
         def feature_target(layer_name):
-            return f"//antlir/rpm/replay/tests:{layer_name}__layer-feature"
+            return antlir_dep(f"rpm/replay/tests:{layer_name}__layer-feature")
 
         self.assertEqual(
             {

--- a/antlir/rpm/replay/tests/test_rpm_replay.py
+++ b/antlir/rpm/replay/tests/test_rpm_replay.py
@@ -7,7 +7,7 @@ import os
 import unittest
 
 from antlir.compiler.items_for_features import ItemFactory
-from antlir.config import repo_config
+from antlir.config import repo_config, antlir_dep
 from antlir.rpm.find_snapshot import snapshot_install_dir
 from antlir.rpm.yum_dnf_conf import YumDnf
 from antlir.tests.layer_resource import layer_resource_subvol
@@ -49,7 +49,7 @@ class RpmReplayTestCase(unittest.TestCase):
                 repo_config().flavor_to_config["antlir_test"].rpm_installer
             ),
             rpm_repo_snapshot=snapshot_install_dir(
-                "//antlir/rpm:rpm-replay-repo-snapshot-for-tests"
+                antlir_dep("rpm:rpm-replay-repo-snapshot-for-tests")
             ),
         )
 

--- a/antlir/rpm/replay/tests/test_subvol_rpm_compare.py
+++ b/antlir/rpm/replay/tests/test_subvol_rpm_compare.py
@@ -5,6 +5,7 @@
 
 import unittest
 
+from antlir.config import antlir_dep
 from antlir.rpm.find_snapshot import snapshot_install_dir
 from antlir.rpm.yum_dnf_conf import YumDnf
 from antlir.subvol_utils import Subvol
@@ -32,7 +33,7 @@ class SubvolRpmCompareTestImpl:
             leaf=leaf,
             rpm_installer=self._YUM_DNF,
             rpm_repo_snapshot=snapshot_install_dir(
-                "//antlir/rpm:rpm-replay-repo-snapshot-for-tests"
+                antlir_dep("rpm:rpm-replay-repo-snapshot-for-tests")
             ),
         )
 

--- a/antlir/rpm/tests/test_yum_dnf_from_snapshot.py
+++ b/antlir/rpm/tests/test_yum_dnf_from_snapshot.py
@@ -11,6 +11,7 @@ import uuid
 from contextlib import contextmanager
 from unittest import mock
 
+from antlir.config import antlir_dep
 from antlir.fs_utils import META_DIR, Path, create_ro, temp_dir
 from antlir.rpm.find_snapshot import snapshot_install_dir
 from antlir.rpm.yum_dnf_conf import YumDnf
@@ -25,7 +26,7 @@ from antlir.tests.subvol_helpers import (
 from .. import yum_dnf_from_snapshot
 
 _INSTALL_ARGS = ["install", "--assumeyes", "rpm-test-carrot", "rpm-test-milk"]
-_SNAPSHOT_DIR = snapshot_install_dir("//antlir/rpm:repo-snapshot-for-tests")
+_SNAPSHOT_DIR = snapshot_install_dir(antlir_dep("rpm:repo-snapshot-for-tests"))
 
 
 def _temp_subvol(name: str):

--- a/antlir/tests/test_config.py
+++ b/antlir/tests/test_config.py
@@ -9,6 +9,7 @@ import unittest.mock
 
 from antlir.artifacts_dir import find_repo_root
 from antlir.config import (
+    antlir_dep,
     base_repo_config_t,
     repo_config,
     repo_config_t,
@@ -31,6 +32,7 @@ class RepoConfigTestCase(unittest.TestCase):
             "flavor_available": ["no_vset", "with_vset"],
             "flavor_default": "no_vset",
             "antlir_linux_flavor": "no_vset",
+            "antlir_cell_name": "test",
             "flavor_to_config": {
                 "no_vset": {
                     "name": "no_vset",
@@ -114,3 +116,17 @@ class RepoConfigTestCase(unittest.TestCase):
                 mock_backing_dir,
                 _unmemoized_repo_config().host_mounts_for_repo_artifacts,
             )
+
+    def test_antlir_dep(self):
+        with self.assertRaisesRegex(RuntimeError, "Antlir deps should be "):
+            antlir_dep("//bad/antlir/dep")
+
+        self.assertEqual(
+            f"{repo_config().antlir_cell_name}//antlir:some-target",
+            antlir_dep(":some-target"),
+        )
+
+        self.assertEqual(
+            f"{repo_config().antlir_cell_name}//antlir/another:target",
+            antlir_dep("another:target"),
+        )


### PR DESCRIPTION
Summary:
This diff is the final step in enabling Antlir to be useable cross-cell.  It makes the following changes to support this:

- Adds the `antlir_cell_name` to the `repo_config` so that it can be usable in python/other code.
- Adds an `antlir_dep` helper in python that mirrors the one in `bzl/target_helpers.bzl`
- Adds a `repository_name` shim so that we can retrieve the current "cell" being used from .bzl code.  Unfortunately, `native.repository_name` does not work the way it should.
- Fixes up the places where an `antlir_dep` is needed (ie: anywhere a naked `//antlir/...` is used)

Differential Revision: D31852138

