### PR TITLE
shape: rust and python client libs for thrift shapes

### DIFF
--- a/antlir/bzl/shape/BUCK
+++ b/antlir/bzl/shape/BUCK
@@ -1,0 +1,27 @@
+load("//antlir/bzl:oss_shim.bzl", "rust_binary", "third_party")
+
+rust_binary(
+    name = "bzl-codegen",
+    srcs = [
+        "gen.rs",
+        "ir.rs",
+        "main.rs",
+        "parse.rs",
+        "templates/enum.bzl.handlebars",
+        "templates/preamble.bzl.handlebars",
+        "templates/struct.bzl.handlebars",
+        "templates/union.bzl.handlebars",
+    ],
+    deps = third_party.libraries(
+        [
+            "anyhow",
+            "handlebars",
+            "itertools",
+            "serde",
+            "serde_json",
+        ],
+        platform = "rust",
+    ) + [
+        "//common/rust/shed/serde_starlark:serde_starlark",
+    ],
+)

--- a/antlir/bzl/shape/BUCK
+++ b/antlir/bzl/shape/BUCK
@@ -17,6 +17,7 @@ rust_binary(
             "anyhow",
             "handlebars",
             "itertools",
+            "md-5",
             "serde",
             "serde_json",
             "structopt",

--- a/antlir/bzl/shape/BUCK
+++ b/antlir/bzl/shape/BUCK
@@ -1,4 +1,4 @@
-load("//antlir/bzl:oss_shim.bzl", "buck_sh_binary", "rust_binary", "third_party")
+load("//antlir/bzl:oss_shim.bzl", "buck_sh_binary", "export_file", "rust_binary", "third_party")
 
 rust_binary(
     name = "bzl-codegen",
@@ -8,13 +8,18 @@ rust_binary(
         "main.rs",
         "parse.rs",
         "templates/enum.bzl.handlebars",
+        "templates/enum.rs.handlebars",
         "templates/preamble.bzl.handlebars",
+        "templates/preamble.rs.handlebars",
         "templates/struct.bzl.handlebars",
+        "templates/struct.rs.handlebars",
         "templates/union.bzl.handlebars",
+        "templates/union.rs.handlebars",
     ],
     deps = third_party.libraries(
         [
             "anyhow",
+            "derive_more",
             "handlebars",
             "itertools",
             "md-5",
@@ -31,4 +36,12 @@ rust_binary(
 buck_sh_binary(
     name = "test-up-to-date",
     main = "test-up-to-date.sh",
+)
+
+export_file(
+    name = "shape.rs",
+)
+
+export_file(
+    name = "shape_py.rs",
 )

--- a/antlir/bzl/shape/BUCK
+++ b/antlir/bzl/shape/BUCK
@@ -1,4 +1,4 @@
-load("//antlir/bzl:oss_shim.bzl", "rust_binary", "third_party")
+load("//antlir/bzl:oss_shim.bzl", "buck_sh_binary", "rust_binary", "third_party")
 
 rust_binary(
     name = "bzl-codegen",
@@ -19,9 +19,15 @@ rust_binary(
             "itertools",
             "serde",
             "serde_json",
+            "structopt",
         ],
         platform = "rust",
     ) + [
         "//common/rust/shed/serde_starlark:serde_starlark",
     ],
+)
+
+buck_sh_binary(
+    name = "test-up-to-date",
+    main = "test-up-to-date.sh",
 )

--- a/antlir/bzl/shape/defs.bzl
+++ b/antlir/bzl/shape/defs.bzl
@@ -1,0 +1,23 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+load("@bazel_skylib//lib:types.bzl", "types")
+
+def fail_with_context(msg, context):
+    if types.is_none(context):
+        fail(msg)
+    elif types.is_string(context):
+        fail("{}{}".format(context + ":" if context else "", msg))
+    elif types.is_list(context):
+        stack = [msg] + context[::-1] if context else [msg]
+        fail("\n When: ".join(stack))
+    else:
+        fail("Provided invalid context {} when trying to render error: {}".format(context, msg))
+
+def add_context(msg, context = None):
+    if msg == None:
+        return context
+    context = context or []
+    return context + [msg]

--- a/antlir/bzl/shape/gen.rs
+++ b/antlir/bzl/shape/gen.rs
@@ -1,0 +1,595 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use anyhow::{anyhow, Context, Result};
+use handlebars::{no_escape, Handlebars};
+use itertools::{join, Itertools};
+use serde::Serialize;
+use serde_json::Value as JsonValue;
+use std::collections::HashMap;
+use std::convert::{TryFrom, TryInto};
+
+use crate::ir::{
+    AllTypes, ComplexType, DocString, Enum, Field, FieldName, Primitive, Struct, Type, TypeName,
+    Union,
+};
+
+static INDENT: &str = "    ";
+
+pub trait Render {
+    fn setup_handlebars(hb: Handlebars<'static>) -> Result<Handlebars<'static>>;
+
+    fn render(&self, hb: &Handlebars<'static>) -> Result<String>;
+}
+
+pub trait RenderLiteral {
+    fn render_literal(&self, value: JsonValue) -> Result<String>;
+}
+
+pub trait RenderChecker {
+    fn render_typecheck(&self, name: &str, context_name: &str, indent: usize) -> Result<String>;
+}
+
+pub(crate) fn render(types: &AllTypes) -> Result<String> {
+    let hb = setup_handlebars().context("When setting up handlebars")?;
+    types.render(&hb)
+}
+
+fn setup_handlebars() -> Result<Handlebars<'static>> {
+    let mut handlebars = Handlebars::new();
+    handlebars.set_strict_mode(true);
+    handlebars.register_escape_fn(no_escape);
+
+    let handlebars = AllTypes::setup_handlebars(handlebars)
+        .context("When setting up handlebars for AllTypes")?;
+    let handlebars = ComplexType::setup_handlebars(handlebars)
+        .context("When setting up handlebars for ComplexType")?;
+    let handlebars =
+        Enum::setup_handlebars(handlebars).context("When setting up handlebars for Enum")?;
+    let handlebars =
+        Struct::setup_handlebars(handlebars).context("When setting up handlebars for Struct")?;
+    let handlebars =
+        Union::setup_handlebars(handlebars).context("When setting up handlebars for Union")?;
+    Ok(handlebars)
+}
+
+static PREAMBLE_TYPES: &[&str] = &["bool", "int", "string", "dict", "list"];
+
+impl Render for AllTypes {
+    fn setup_handlebars(mut hb: Handlebars<'static>) -> Result<Handlebars<'static>> {
+        hb.register_template_string(
+            "preamble",
+            include_str!("templates/preamble.bzl.handlebars"),
+        )
+        .context("Trying to register preamble template")?;
+        Ok(hb)
+    }
+
+    fn render(&self, hb: &Handlebars<'static>) -> Result<String> {
+        let mut output = String::new();
+
+        output.push_str(
+            &hb.render("preamble", &PREAMBLE_TYPES)
+                .context("Failed to render the preamble")?,
+        );
+
+        output.push('\n');
+
+        for (name, typ) in self.into_iter().sorted_by_key(|(t, _)| &t.0) {
+            output.push_str(
+                &*typ
+                    .render(hb)
+                    .context(format!("Attempting to render {}", name.0))?,
+            );
+            output.push('\n');
+        }
+        Ok(output)
+    }
+}
+
+impl Render for ComplexType {
+    fn setup_handlebars(hb: Handlebars<'static>) -> Result<Handlebars<'static>> {
+        Ok(hb)
+    }
+
+    fn render(&self, hb: &Handlebars<'static>) -> Result<String> {
+        match self {
+            Self::Enum(e) => e.render(hb),
+            Self::Struct(s) => s.render(hb),
+            Self::Union(u) => u.render(hb),
+        }
+    }
+}
+
+impl Render for Enum {
+    fn setup_handlebars(mut hb: Handlebars<'static>) -> Result<Handlebars<'static>> {
+        hb.register_template_string("enum", include_str!("templates/enum.bzl.handlebars"))
+            .context("Trying to register enum template")?;
+        Ok(hb)
+    }
+
+    fn render(&self, hb: &Handlebars<'static>) -> Result<String> {
+        hb.render("enum", self)
+            .context(format!("When rendering template for {}", self.name.0))
+    }
+}
+
+impl RenderLiteral for Enum {
+    fn render_literal(&self, value: JsonValue) -> Result<String> {
+        let value_str = match &value {
+            JsonValue::String(s) => serde_starlark::to_string(&value).context(format!(
+                "When trying to render string ('{}') for enum {}",
+                s, self.name.0
+            ))?,
+            JsonValue::Number(n) => serde_starlark::to_string(&value).context(format!(
+                "When trying to render number ({}) for enum {}",
+                n, self.name.0
+            ))?,
+            other => {
+                return Err(anyhow!(
+                    "Expected either String or Number when rendering literal for enum '{}' found: {}",
+                    self.name.0,
+                    value_type_name(other)
+                ));
+            }
+        };
+
+        Ok(format!("{}({})", self.name.0, value_str))
+    }
+}
+
+impl RenderChecker for Field {
+    fn render_typecheck(&self, name: &str, context_name: &str, indent: usize) -> Result<String> {
+        if self.required {
+            Ok(format!(
+                "{indent}if {name} == None:\n\
+                {next_indent}_fail_with_context(\"{name}: required but is None\", context={context_name})\n\
+                {indent}else:\n\
+                {field_validate}\
+                ",
+                indent = INDENT.repeat(indent),
+                next_indent = INDENT.repeat(indent + 1),
+                context_name = context_name,
+                name = name,
+                field_validate = self.typ.render_typecheck(name, context_name, indent + 1)?,
+            ))
+        } else {
+            Ok(format!(
+                "{indent}if {name} != None:\n\
+                {field_validate}\
+                ",
+                indent = INDENT.repeat(indent),
+                name = name,
+                field_validate = self.typ.render_typecheck(name, context_name, indent + 1)?,
+            ))
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct FieldContext {
+    name: FieldName,
+    // An already rendered default value. This is expected to be something
+    // that could be stored in a dictionary key like: {"foo": {{default_value}}}
+    default_value: Option<String>,
+
+    // An already rendered call to check the type. This should be a valid line
+    // of code that can be placed inside a function. A variable with the same name
+    // as the field you are validating will be in the scope for you to use as well as
+    // any of the check_<type> functions defined in the preemable template. You can
+    // also assume that globals like fail, None etc are available but beyond this you
+    // should not assume anything else about the environment this code runs in (eg
+    // don't depend on any other field names or types).
+    type_check: String,
+    required: bool,
+}
+
+impl FieldContext {
+    fn try_from_field(f: &Field, indent: usize) -> Result<Self> {
+        Ok(Self {
+            name: f.name.clone(),
+            required: f.required,
+            // It is safe to ignore the fact that this might be a union
+            // which isn't allowed a default value here because when we go
+            // to render that union it will error out there which is a much
+            // better error location than trying to do it here.
+            default_value: match &f.default_value {
+                Some(default_value) => Some(
+                    f.typ
+                        .render_literal(default_value.clone())
+                        .context("While trying to render default value")?,
+                ),
+                None => None,
+            },
+            type_check: f
+                .render_typecheck(&f.name.0, "err_context", indent)
+                .context(format!(
+                    "While trying to render typecheck for field {}",
+                    f.name.0
+                ))?,
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct StructOrUnionContext {
+    name: TypeName,
+    fields: Vec<FieldContext>,
+    docstring: Option<DocString>,
+}
+
+impl TryFrom<&Struct> for StructOrUnionContext {
+    type Error = anyhow::Error;
+
+    fn try_from(s: &Struct) -> Result<Self> {
+        let mut fields = Vec::new();
+        for field in s.fields.values().sorted_by_key(|f| &f.name.0) {
+            fields.push(FieldContext::try_from_field(field, 1).context(format!(
+                "When converting {} to renderable format",
+                field.name.0
+            ))?);
+        }
+
+        Ok(Self {
+            name: s.name.clone(),
+            fields,
+            docstring: s.docstring.clone(),
+        })
+    }
+}
+
+impl TryFrom<&Union> for StructOrUnionContext {
+    type Error = anyhow::Error;
+
+    fn try_from(u: &Union) -> Result<Self> {
+        let mut fields = Vec::new();
+        for field in u.fields.values().sorted_by_key(|f| &f.name.0) {
+            if field.default_value.is_some() {
+                return Err(anyhow!(
+                    "'{}.{}' has a default value which isn't allowed for union",
+                    u.name.0,
+                    field.name.0,
+                ));
+            }
+            fields.push(FieldContext::try_from_field(field, 2).context(format!(
+                "When converting {} to renderable format",
+                field.name.0
+            ))?);
+        }
+
+        Ok(Self {
+            name: u.name.clone(),
+            fields,
+            docstring: u.docstring.clone(),
+        })
+    }
+}
+
+impl Render for Struct {
+    fn setup_handlebars(mut hb: Handlebars<'static>) -> Result<Handlebars<'static>> {
+        hb.register_template_string("struct", include_str!("templates/struct.bzl.handlebars"))
+            .context("Trying to register struct template")?;
+        Ok(hb)
+    }
+
+    fn render(&self, hb: &Handlebars<'static>) -> Result<String> {
+        let ctx: StructOrUnionContext = self
+            .try_into()
+            .context("When trying to build context for struct template")?;
+
+        hb.render("struct", &ctx)
+            .context(format!("When rendering template for {}", self.name.0))
+    }
+}
+
+impl Render for Union {
+    fn setup_handlebars(mut hb: Handlebars<'static>) -> Result<Handlebars<'static>> {
+        hb.register_template_string("union", include_str!("templates/union.bzl.handlebars"))
+            .context("Trying to register union template")?;
+        Ok(hb)
+    }
+
+    fn render(&self, hb: &Handlebars<'static>) -> Result<String> {
+        let ctx: StructOrUnionContext = self
+            .try_into()
+            .context("When trying to build context for union template")?;
+
+        hb.render("union", &ctx)
+            .context(format!("When rendering template for {}", self.name.0))
+    }
+}
+
+impl RenderLiteral for Type {
+    fn render_literal(&self, value: JsonValue) -> Result<String> {
+        match self {
+            Self::Primitive(p) => p.render_literal(value),
+            Self::Complex(c) => c.render_literal(value),
+            Self::List { inner_type } => match value {
+                JsonValue::Array(values) => {
+                    let mut out = Vec::new();
+                    for (i, value) in values.into_iter().enumerate() {
+                        out.push(
+                            inner_type
+                                .render_literal(value)
+                                .context(format!("While rendering element {} of list", i))?,
+                        );
+                    }
+                    Ok(format!("[{}]", join(out, ",")))
+                }
+                other => Err(anyhow!(
+                    "Expected List but found: {}",
+                    value_type_name(&other)
+                )),
+            },
+            Self::Map {
+                key_type,
+                value_type,
+            } => match value {
+                JsonValue::Object(object) => {
+                    let mut out = Vec::new();
+                    for (key, value) in object.into_iter() {
+                        let key: JsonValue = serde_json::from_str(&key)
+                            .context("Failed to convert key from string back to serde value")?;
+                        let key_str = key_type
+                            .render_literal(key.clone())
+                            .context(format!("While rendering key {}", key))?;
+
+                        let value_str = value_type
+                            .render_literal(value)
+                            .context(format!("While rendering value for key {}", key))?;
+
+                        out.push(format!("{}: {}", key_str, value_str));
+                    }
+                    Ok(format!("{{{}}}", join(out, ", ")))
+                }
+                other => Err(anyhow!(
+                    "Expected Map/Object but found: {}",
+                    value_type_name(&other)
+                )),
+            },
+        }
+    }
+}
+
+impl RenderChecker for Type {
+    fn render_typecheck(&self, name: &str, context_name: &str, indent: usize) -> Result<String> {
+        match self {
+            Self::Primitive(p) => p.render_typecheck(name, context_name, indent),
+            Self::Complex(c) => c.render_typecheck(name, context_name, indent),
+            Self::List { inner_type } => Ok(format!(
+                "{indent}_check_list({name}, context={context_name})\n\
+                {indent}for (i, {name}_item) in enumerate({name}):\n\
+                {next_indent}inner_context = {context_name} + [\"Checking index {{}} for field '{name}'\".format(i)]\n\
+                {field_validate}\
+                ",
+                indent = INDENT.repeat(indent),
+                next_indent = INDENT.repeat(indent + 1),
+                name = name,
+                context_name = context_name,
+                field_validate = inner_type
+                    .render_typecheck(&format!("{}_item", name), "inner_context", indent + 1)
+                    .context("When generating type checker for List inner_type",)?,
+            )),
+            Self::Map {
+                key_type,
+                value_type,
+            } => Ok(format!(
+                "{indent}_check_dict({name}, context={context_name})\n\
+                {indent}for {name}_key, {name}_value in {name}.items():\n\
+                {next_indent}inner_context = {context_name} + [\"Checking key '{{}}' for field '{name}'\".format({name}_key)]\n\
+                {key_validate}\n\
+                {value_validate}\
+                ",
+                indent = INDENT.repeat(indent),
+                next_indent = INDENT.repeat(indent + 1),
+                name = name,
+                context_name = context_name,
+                key_validate = key_type
+                    .render_typecheck(&format!("{}_key", name), "inner_context", indent + 1)
+                    .context("When generating type checker for Map key_type")?,
+                value_validate = value_type
+                    .render_typecheck(&format!("{}_value", name), "inner_context", indent + 1)
+                    .context("When generating type checker for Map value_type")?,
+            )),
+        }
+    }
+}
+
+impl RenderLiteral for ComplexType {
+    fn render_literal(&self, value: JsonValue) -> Result<String> {
+        match self {
+            Self::Enum(e) => e.render_literal(value),
+            Self::Struct(s) => s.render_literal(value),
+            Self::Union(u) => u.render_literal(value),
+        }
+    }
+}
+impl RenderChecker for ComplexType {
+    fn render_typecheck(&self, name: &str, context_name: &str, indent: usize) -> Result<String> {
+        let type_name = match self {
+            Self::Enum(e) => &e.name,
+            Self::Struct(s) => &s.name,
+            Self::Union(u) => &u.name,
+        };
+
+        Ok(format!(
+            "{}__typecheck_{}({}, err_context={})",
+            INDENT.repeat(indent),
+            type_name.0,
+            name,
+            context_name,
+        ))
+    }
+}
+
+impl RenderLiteral for Struct {
+    fn render_literal(&self, value: JsonValue) -> Result<String> {
+        let mut obj = match value {
+            JsonValue::Object(obj) => {
+                let mut out = HashMap::new();
+                for (key, value) in obj.into_iter() {
+                    let key: JsonValue = serde_json::from_str(&key)
+                        .context("Failed to convert key from string back to serde value")?;
+                    let key_str = match key {
+                        JsonValue::String(s) => s,
+                        other => {
+                            return Err(anyhow!(
+                                "Expected field name for struct '{}' to be a String but found: {}",
+                                self.name.0,
+                                value_type_name(&other)
+                            ));
+                        }
+                    };
+                    out.insert(key_str, value);
+                }
+                out
+            }
+            other => {
+                return Err(anyhow!(
+                    "Expected Map/Object when rendering default for {} but found: {}",
+                    self.name.0,
+                    value_type_name(&other)
+                ));
+            }
+        };
+
+        let mut fields = Vec::new();
+        for (field_name, field) in self.fields.iter() {
+            let value = match obj.remove(&field_name.0) {
+                Some(value) => value,
+                None => {
+                    if field.required {
+                        return Err(anyhow!(
+                            "Required field `{}.{}` was not provided in default value. Remaining options: {}",
+                            self.name.0,
+                            field_name.0,
+                            join(obj.keys(), ", "),
+                        ));
+                    } else {
+                        continue;
+                    }
+                }
+            };
+
+            let value_str = field.typ.render_literal(value).context(format!(
+                "While rendering `{}.{}`",
+                self.name.0, field_name.0
+            ))?;
+
+            fields.push(format!("{}={}", field_name.0, value_str));
+        }
+
+        if !obj.is_empty() {
+            return Err(anyhow!(
+                "Default value in json contains fields that don't exist on {}: {}",
+                self.name.0,
+                join(obj.keys(), ", "),
+            ));
+        }
+
+        Ok(format!("{}({})", self.name.0, join(fields, ", ")))
+    }
+}
+
+impl RenderLiteral for Union {
+    fn render_literal(&self, value: JsonValue) -> Result<String> {
+        let obj = match value {
+            JsonValue::Object(obj) => obj,
+            other => {
+                return Err(anyhow!(
+                    "Expected Map/Object when rendering default for '{}' but found: {}",
+                    self.name.0,
+                    value_type_name(&other)
+                ));
+            }
+        };
+
+        if obj.len() != 1 {
+            return Err(anyhow!(
+                "Expected exactly 1 value for union '{}' found {} ({})",
+                self.name.0,
+                obj.len(),
+                join(obj.keys(), ", "),
+            ));
+        }
+
+        let (key, value) = obj
+            .into_iter()
+            .next()
+            .expect("Found no item after checking len == 1");
+
+        let key = FieldName(key);
+        let field = match self.fields.get(&key) {
+            Some(f) => f,
+            None => {
+                return Err(anyhow!(
+                    "Default value provided field name '{}' which wasn't found on this Union ('{}')",
+                    key.0,
+                    self.name.0,
+                ));
+            }
+        };
+
+        let value_str = field.typ.render_literal(value).context(format!(
+            "While trying to render value for '{}.{}'",
+            self.name.0, field.name.0
+        ))?;
+
+        Ok(format!("{}({}={})", self.name.0, key.0, value_str))
+    }
+}
+
+impl RenderLiteral for Primitive {
+    fn render_literal(&self, value: JsonValue) -> Result<String> {
+        Ok(match (self, &value) {
+            // Bools in thrift are given to us as 1 and 0 so this will
+            // be wrong if we use the serde_starlark conversion
+            (Self::Bool, JsonValue::Number(n)) => {
+                serde_starlark::to_string(&(n != &serde_json::Number::from(0)))
+            }
+            (_, _) => serde_starlark::to_string(&value),
+        }?)
+    }
+}
+
+impl RenderChecker for Primitive {
+    fn render_typecheck(&self, name: &str, context_str: &str, indent: usize) -> Result<String> {
+        let add_context_str = format!("_add_context(\"Validating '{}'\", {})", name, context_str);
+        match self {
+            Self::Bool => Ok(format!(
+                "{}_check_bool({}, context={})",
+                INDENT.repeat(indent),
+                name,
+                add_context_str
+            )),
+            Self::Byte | Self::I16 | Self::I32 | Self::I64 => Ok(format!(
+                "{}_check_int({}, context={})",
+                INDENT.repeat(indent),
+                name,
+                add_context_str
+            )),
+            Self::String => Ok(format!(
+                "{}_check_string({}, context={})",
+                INDENT.repeat(indent),
+                name,
+                add_context_str
+            )),
+            _ => Err(anyhow!("No starlark type checker available for {:?}", self)),
+        }
+    }
+}
+
+fn value_type_name(value: &JsonValue) -> &'static str {
+    match value {
+        JsonValue::Null => "Null",
+        JsonValue::Bool(..) => "Bool",
+        JsonValue::Number(..) => "Number",
+        JsonValue::String(..) => "String",
+        JsonValue::Array(..) => "Array",
+        JsonValue::Object(..) => "Object",
+    }
+}

--- a/antlir/bzl/shape/gen.rs
+++ b/antlir/bzl/shape/gen.rs
@@ -560,7 +560,7 @@ impl RenderLiteral for Primitive {
 
 impl RenderChecker for Primitive {
     fn render_typecheck(&self, name: &str, context_str: &str, indent: usize) -> Result<String> {
-        let add_context_str = format!("_add_context(\"Validating '{}'\", {})", name, context_str);
+        let add_context_str = format!("add_context(\"Validating '{}'\", {})", name, context_str);
         match self {
             Self::Bool => Ok(format!(
                 "{}_check_bool({}, context={})",

--- a/antlir/bzl/shape/gen.rs
+++ b/antlir/bzl/shape/gen.rs
@@ -36,7 +36,9 @@ pub trait RenderChecker {
 
 pub(crate) fn render(types: &AllTypes) -> Result<String> {
     let hb = setup_handlebars().context("When setting up handlebars")?;
-    types.render(&hb)
+    let code = types.render(&hb)?;
+    let code = code.replace("@_generated", concat!("@", "generated"));
+    Ok(code)
 }
 
 fn setup_handlebars() -> Result<Handlebars<'static>> {

--- a/antlir/bzl/shape/gen.rs
+++ b/antlir/bzl/shape/gen.rs
@@ -8,6 +8,7 @@
 use anyhow::{anyhow, Context, Result};
 use handlebars::{no_escape, Handlebars};
 use itertools::{join, Itertools};
+use md5::{Digest, Md5};
 use serde::Serialize;
 use serde_json::Value as JsonValue;
 use std::collections::HashMap;
@@ -36,9 +37,14 @@ pub trait RenderChecker {
 
 pub(crate) fn render(types: &AllTypes) -> Result<String> {
     let hb = setup_handlebars().context("When setting up handlebars")?;
-    let code = types.render(&hb)?;
-    let code = code.replace("@_generated", concat!("@", "generated"));
-    Ok(code)
+    let code = types
+        .render(&hb)?
+        .replace("@_generated", concat!('@', "generated"));
+    let digest = format!("{:x}", Md5::digest(code.as_bytes()));
+    Ok(code.replace(
+        "<<SignedSource::*O*zOeWoEQle#+L!plEphiEmie@IsG>>",
+        &format!("SignedSource<<{}>>", digest),
+    ))
 }
 
 fn setup_handlebars() -> Result<Handlebars<'static>> {

--- a/antlir/bzl/shape/ir.rs
+++ b/antlir/bzl/shape/ir.rs
@@ -85,6 +85,16 @@ pub(crate) enum ComplexType {
     Union(Union),
 }
 
+impl ComplexType {
+    pub fn name(&self) -> &TypeName {
+        match self {
+            Self::Enum(e) => &e.name,
+            Self::Struct(s) => &s.name,
+            Self::Union(u) => &u.name,
+        }
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub(crate) struct EnumConstant {
     pub name: FieldName,

--- a/antlir/bzl/shape/ir.rs
+++ b/antlir/bzl/shape/ir.rs
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::rc::Rc;
+
+// The name of a field, variable or something like that.
+#[derive(Debug, Clone, PartialEq, Hash, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct FieldName(pub String);
+
+// The name of a struct, union, enum or other type
+#[derive(Debug, Clone, PartialEq, Hash, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TypeName(pub String);
+
+// A docstring that should never be used for any logic but only for
+// adding comments/context to the output
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct DocString(pub String);
+
+// A container to hold all the top level types
+#[derive(Debug)]
+pub(crate) struct AllTypes {
+    types: HashMap<TypeName, Rc<ComplexType>>,
+}
+
+impl<'a> IntoIterator for &'a AllTypes {
+    type Item = (&'a TypeName, &'a Rc<ComplexType>);
+    type IntoIter = std::collections::hash_map::Iter<'a, TypeName, Rc<ComplexType>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.types.iter()
+    }
+}
+
+impl AllTypes {
+    pub fn new() -> Self {
+        Self {
+            types: HashMap::new(),
+        }
+    }
+
+    // Add the item to the hashmap and give you back a reference to it so that you
+    // can use it to build more types
+    pub(crate) fn add(&mut self, name: &TypeName, typ: ComplexType) -> Result<Rc<ComplexType>> {
+        if self.types.contains_key(&name) {
+            Err(anyhow!("Attempted to add duplicate type {}", name.0))
+        } else {
+            let rc_type = Rc::new(typ);
+            self.types.insert(name.clone(), rc_type.clone());
+            Ok(rc_type)
+        }
+    }
+
+    pub fn get(&self, name: &TypeName) -> Option<&Rc<ComplexType>> {
+        self.types.get(name).clone()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum Type {
+    Primitive(Primitive),
+    List {
+        inner_type: Box<Type>,
+    },
+    Map {
+        key_type: Box<Type>,
+        value_type: Box<Type>,
+    },
+    Complex(Rc<ComplexType>),
+}
+
+#[derive(Debug)]
+pub(crate) enum ComplexType {
+    Enum(Enum),
+    Struct(Struct),
+    Union(Union),
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct EnumConstant {
+    pub name: FieldName,
+    pub value: i32,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct Enum {
+    pub name: TypeName,
+    pub options: HashMap<FieldName, EnumConstant>,
+    pub docstring: Option<DocString>,
+}
+
+#[derive(Debug)]
+pub(crate) struct Struct {
+    pub name: TypeName,
+    pub fields: HashMap<FieldName, Field>,
+    pub docstring: Option<DocString>,
+}
+
+#[derive(Debug)]
+pub(crate) struct Union {
+    pub name: TypeName,
+    pub fields: HashMap<FieldName, Field>,
+    pub docstring: Option<DocString>,
+}
+
+#[derive(Debug)]
+pub(crate) struct Field {
+    pub name: FieldName,
+    pub typ: Type,
+    pub default_value: Option<serde_json::Value>,
+    pub required: bool,
+}
+
+#[derive(Debug)]
+pub(crate) enum Primitive {
+    Bool,
+    Byte,
+    I16,
+    I32,
+    I64,
+    Float,
+    Double,
+    Binary,
+    String,
+}

--- a/antlir/bzl/shape/main.rs
+++ b/antlir/bzl/shape/main.rs
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#![feature(iter_intersperse)]
+
+mod gen;
+mod ir;
+mod parse;
+
+use anyhow::{Context, Result};
+use std::convert::TryInto;
+
+use gen::render;
+use ir::AllTypes;
+use parse::ParsedTop;
+
+fn main() -> Result<()> {
+    let input = ParsedTop::from_reader(std::io::stdin().lock())?;
+    eprintln!("{:#?}", input);
+    let types: AllTypes = input
+        .try_into()
+        .context("Failed to convert from parsed format to internal format")?;
+    eprintln!("{:#?}", types);
+    let code = render(&types).context("Trying to render output code")?;
+    println!("{}", code);
+    Ok(())
+}

--- a/antlir/bzl/shape/parse.rs
+++ b/antlir/bzl/shape/parse.rs
@@ -1,0 +1,378 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use anyhow::{anyhow, Context, Result};
+use itertools::join;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::rc::Rc;
+
+use crate::ir::{
+    AllTypes, ComplexType, DocString, Enum, EnumConstant, Field, FieldName, Primitive, Struct,
+    Type, TypeName, Union,
+};
+
+#[derive(Debug, Deserialize)]
+pub struct ParsedTop {
+    pub(crate) namespaces: Option<HashMap<String, String>>,
+    pub(crate) structs: Option<HashMap<TypeName, ParsedStruct>>,
+    pub(crate) enumerations: Option<HashMap<TypeName, ParsedEnum>>,
+}
+
+impl ParsedTop {
+    pub fn from_reader<R: std::io::Read>(reader: R) -> Result<Self, serde_json::Error> {
+        serde_json::from_reader(reader)
+    }
+
+    // Adds a given target_type to the provided all_types structure.
+    // Also provide a list of seen TypeNames so that you can detect loops
+    fn add_enum_to_alltypes(
+        &self,
+        target_type: &TypeName,
+        all_types: &mut AllTypes,
+    ) -> Result<Rc<ComplexType>> {
+        if let Some(ct) = all_types.get(target_type) {
+            match **ct {
+                ComplexType::Enum(_) => {}
+                ComplexType::Struct(_) | ComplexType::Union(_) => {
+                    return Err(anyhow!(
+                        "Thrift json corrupt: '{}' is listed as both an enum and a struct!",
+                        target_type.0
+                    ));
+                }
+            }
+            return Ok(ct.clone());
+        }
+
+        let e = match &self.enumerations {
+            Some(enums) => match enums.get(target_type) {
+                Some(e) => e,
+                None => {
+                    return Err(anyhow!(
+                        "Enum '{}' was requested but not found",
+                        target_type.0
+                    ));
+                }
+            },
+            None => {
+                return Err(anyhow!(
+                    "Enum '{}' was requested but self.enumerations is empty",
+                    target_type.0
+                ));
+            }
+        };
+        if &e.name != target_type {
+            return Err(anyhow!(
+                "Thrift json corrupt: Fetched '{}' from enum map but found '{}'",
+                target_type.0,
+                e.name.0,
+            ));
+        }
+
+        Ok(all_types
+            .add(target_type, ComplexType::Enum(e.clone().into()))
+            .context(format!("When adding enum '{}'", target_type.0))?)
+    }
+
+    // Adds a given target_type to the provided all_types structure.
+    // Also provide a list of seen TypeNames so that you can detect loops
+    fn add_struct_to_alltypes(
+        &self,
+        target_type: &TypeName,
+        all_types: &mut AllTypes,
+        mut seen: Vec<TypeName>,
+    ) -> Result<Rc<ComplexType>> {
+        if let Some(ct) = all_types.get(target_type) {
+            match **ct {
+                ComplexType::Struct(_) | ComplexType::Union(_) => {}
+                ComplexType::Enum(_) => {
+                    return Err(anyhow!(
+                        "Thrift json corrupt: '{}' is listed as both an enum and a struct!",
+                        target_type.0
+                    ));
+                }
+            }
+            return Ok(ct.clone());
+        }
+
+        if seen.contains(target_type) {
+            return Err(anyhow!(
+                "Circular reference found between types: {} -> {}",
+                join(seen.into_iter().map(|s| s.0), " -> "),
+                target_type.0,
+            ));
+        }
+        seen.push(target_type.clone());
+
+        let s = match &self.structs {
+            Some(structs) => match structs.get(target_type) {
+                Some(s) => s,
+                None => {
+                    return Err(anyhow!(
+                        "Struct '{}' was requested but not found",
+                        target_type.0
+                    ));
+                }
+            },
+            None => {
+                return Err(anyhow!(
+                    "Struct '{}' was requested but self.structs is empty",
+                    target_type.0
+                ));
+            }
+        };
+        if &s.name != target_type {
+            return Err(anyhow!(
+                "Thrift json corrupt: Fetched '{}' from map but found '{}'",
+                target_type.0,
+                s.name.0,
+            ));
+        }
+        if s.is_exception {
+            return Err(anyhow!(
+                "'{}' is an exception which is unsupported",
+                s.name.0
+            ));
+        }
+
+        let mut fields = HashMap::new();
+        for (name, field) in s.fields.iter() {
+            if name != &field.name {
+                return Err(anyhow!(
+                    "Thrift json corrupt: Field on struct '{}' is called '{}' in map but '{}' inside",
+                    s.name.0,
+                    name.0,
+                    field.name.0,
+                ));
+            }
+            let field_type: Type = self
+                .parsed_type_to_type(&field.typ, all_types, seen.clone())
+                .context(format!("When processing '{}.{}'", s.name.0, name.0))?;
+
+            fields.insert(
+                name.clone(),
+                Field {
+                    name: name.clone(),
+                    typ: field_type,
+                    default_value: field.default_value.clone(),
+                    required: (&field.required).into(),
+                },
+            );
+        }
+
+        let new_type = if s.is_union {
+            ComplexType::Union(Union {
+                name: s.name.clone(),
+                fields,
+                docstring: s.docstring.clone(),
+            })
+        } else {
+            ComplexType::Struct(Struct {
+                name: s.name.clone(),
+                fields,
+                docstring: s.docstring.clone(),
+            })
+        };
+        Ok(all_types
+            .add(target_type, new_type)
+            .context(format!("When adding struct '{}'", target_type.0))?)
+    }
+
+    fn parsed_type_to_type(
+        &self,
+        typ: &ParsedType,
+        all_types: &mut AllTypes,
+        seen: Vec<TypeName>,
+    ) -> Result<Type> {
+        Ok(match typ {
+            ParsedType::Primitive(p) => Type::Primitive(p.into()),
+            ParsedType::Complex(c) => match c {
+                ParsedComplexType::List { inner_type } => {
+                    let list_type = self
+                        .parsed_type_to_type(&*inner_type, all_types, seen.clone())
+                        .context(format!("When adding list type"))?;
+
+                    Type::List {
+                        inner_type: Box::new(list_type),
+                    }
+                }
+                ParsedComplexType::Map {
+                    key_type,
+                    value_type,
+                } => {
+                    let key_type = self
+                        .parsed_type_to_type(&*key_type, all_types, seen.clone())
+                        .context(format!("When adding key type for map"))?;
+
+                    let value_type = self
+                        .parsed_type_to_type(&*value_type, all_types, seen.clone())
+                        .context(format!("When adding value type for map"))?;
+
+                    Type::Map {
+                        key_type: Box::new(key_type),
+                        value_type: Box::new(value_type),
+                    }
+                }
+                ParsedComplexType::Struct { name } => {
+                    Type::Complex(self.add_struct_to_alltypes(name, all_types, seen.clone())?)
+                }
+                ParsedComplexType::Enum { name } => {
+                    Type::Complex(self.add_enum_to_alltypes(name, all_types)?)
+                }
+            },
+        })
+    }
+}
+
+impl<'a> TryFrom<ParsedTop> for AllTypes {
+    type Error = anyhow::Error;
+
+    fn try_from(top: ParsedTop) -> Result<AllTypes> {
+        let mut all_types = Self::new();
+        if let Some(structs) = &top.structs {
+            for name in structs.keys() {
+                top.add_struct_to_alltypes(name, &mut all_types, Vec::new())
+                    .context(format!("When trying to add struct '{}'", name.0))?;
+            }
+        }
+        if let Some(enums) = &top.enumerations {
+            for name in enums.keys() {
+                top.add_enum_to_alltypes(name, &mut all_types)
+                    .context(format!("When trying to add enum '{}'", name.0))?;
+            }
+        }
+
+        Ok(all_types)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ParsedStruct {
+    pub name: TypeName,
+    pub fields: HashMap<FieldName, ParsedField>,
+    pub docstring: Option<DocString>,
+    pub is_union: bool,
+    pub is_exception: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ParsedEnum {
+    pub name: TypeName,
+    pub constants: HashMap<FieldName, ParsedEnumConstant>,
+    pub docstring: Option<DocString>,
+}
+
+impl From<ParsedEnum> for Enum {
+    fn from(e: ParsedEnum) -> Self {
+        Self {
+            name: e.name,
+            options: e
+                .constants
+                .into_iter()
+                .map(|(n, c)| (n, c.into()))
+                .collect(),
+            docstring: e.docstring,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ParsedEnumConstant {
+    pub name: FieldName,
+    pub value: i32,
+}
+
+impl From<ParsedEnumConstant> for EnumConstant {
+    fn from(ec: ParsedEnumConstant) -> Self {
+        Self {
+            name: ec.name,
+            value: ec.value,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum ParsedRequiredness {
+    Required,
+    OptInReqOut,
+    Optional,
+}
+
+impl From<&ParsedRequiredness> for bool {
+    fn from(parsed: &ParsedRequiredness) -> bool {
+        match parsed {
+            ParsedRequiredness::Required | ParsedRequiredness::OptInReqOut => true,
+            ParsedRequiredness::Optional => false,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ParsedField {
+    pub name: FieldName,
+    #[serde(rename = "type")]
+    pub typ: ParsedType,
+    pub default_value: Option<serde_json::Value>,
+    pub required: ParsedRequiredness,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum ParsedType {
+    Primitive(ParsedPrimitive),
+    Complex(ParsedComplexType),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum ParsedPrimitive {
+    Bool,
+    Byte,
+    I16,
+    I32,
+    I64,
+    Float,
+    Double,
+    Binary,
+    String,
+}
+
+impl From<&ParsedPrimitive> for Primitive {
+    fn from(parsed: &ParsedPrimitive) -> Self {
+        match parsed {
+            ParsedPrimitive::Bool => Self::Bool,
+            ParsedPrimitive::Byte => Self::Byte,
+            ParsedPrimitive::I16 => Self::I16,
+            ParsedPrimitive::I32 => Self::I32,
+            ParsedPrimitive::I64 => Self::I64,
+            ParsedPrimitive::Float => Self::Float,
+            ParsedPrimitive::Double => Self::Double,
+            ParsedPrimitive::Binary => Self::Binary,
+            ParsedPrimitive::String => Self::String,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "lowercase", tag = "type")]
+pub(crate) enum ParsedComplexType {
+    List {
+        inner_type: Box<ParsedType>,
+    },
+    Map {
+        key_type: Box<ParsedType>,
+        value_type: Box<ParsedType>,
+    },
+    Struct {
+        name: TypeName,
+    },
+    Enum {
+        name: TypeName,
+    },
+}

--- a/antlir/bzl/shape/shape.bzl
+++ b/antlir/bzl/shape/shape.bzl
@@ -4,11 +4,11 @@
 # LICENSE file in the root directory of this source tree.
 
 load("//antlir/bzl:maybe_export_file.bzl", "maybe_export_file")
-load("//antlir/bzl:oss_shim.bzl", "buck_command_alias", "buck_genrule", "buck_sh_test")
+load("//antlir/bzl:oss_shim.bzl", "buck_command_alias", "buck_genrule", "buck_sh_test", "rust_library", "rust_python_extension", "third_party", "thrift_library")
 load("//antlir/bzl:target_helpers.bzl", "normalize_target")
 
-def shape(name, thrift):
-    thrift = normalize_target(maybe_export_file(thrift))
+def shape(name, thrift, visibility = None):
+    thrift_target = normalize_target(maybe_export_file(thrift))
     thrift_compiler = native.read_config("thrift", "compiler", None)
     buck_genrule(
         name = name + "--thrift.json",
@@ -17,19 +17,21 @@ def shape(name, thrift):
             cd $TMP
             $(exe {compiler}) --gen json_experimental $(location {thrift})
             mv gen-json_experimental/*.json $OUT
-        """.format(compiler = thrift_compiler, thrift = thrift),
+        """.format(compiler = thrift_compiler, thrift = thrift_target),
     )
+
+    bzl_name = name + ".bzl"
 
     # For completely new shape files, the bzl file will not exist, so it's hard
     # to generate the rest of these rules.
     # This is rare enough that we can just ask the user nicely to make a new
     # empty file.
-    if not native.glob([name]):
+    if not native.glob([bzl_name]):
         fail("new shape files must be created manually, please create an empty file '{}'".format(
-            name,
+            bzl_name,
         ))
 
-    out = normalize_target(maybe_export_file(name))
+    out = normalize_target(maybe_export_file(bzl_name))
     generator = normalize_target("//antlir/bzl/shape:bzl-codegen")
 
     # easy alias per-shape to update the generated code
@@ -45,12 +47,50 @@ def shape(name, thrift):
     # be diffed for test purposes
     buck_genrule(
         name = name + "-gen",
-        out = name + ".bzl",
-        cmd = "$(exe {}) $(location :{}--thrift.json) $OUT".format(generator, name),
+        out = bzl_name,
+        cmd = "$(exe {}) $(location :{}--thrift.json) bzl $OUT".format(generator, name),
     )
 
     buck_sh_test(
         name = name + "-up-to-date",
         args = ["$(location {})".format(out), "$(location :{}-gen)".format(name), "buck run {}".format(update)],
         test = "fbcode//antlir/bzl/shape:test-up-to-date",
+    )
+
+    # language support targets
+    thrift_library(
+        name = name + "-thrift",
+        languages = ["rust", "py3", "py3lite"],
+        thrift_srcs = {thrift: []},
+        thrift_rust_options = "serde",
+        visibility = visibility,
+    )
+    rust_library(
+        name = name + "-rust",
+        crate = name,
+        named_deps = {
+            "ttypes": ":{}-thrift-rust".format(name),
+        },
+        mapped_srcs = {
+            "//antlir/bzl/shape:shape.rs": "src/lib.rs",
+        },
+        deps = third_party.libraries(
+            [
+                "serde_json",
+            ],
+            platform = "rust",
+        ),
+        visibility = visibility,
+    )
+    rust_python_extension(
+        name = name + "-python",
+        module_name = name,
+        named_deps = {
+            "shape": ":{}-rust".format(name),
+        },
+        mapped_srcs = {
+            "//antlir/bzl/shape:shape_py.rs": "src/lib.rs",
+        },
+        visibility = visibility,
+        deps = ["fbsource//third-party/rust:pyo3"],
     )

--- a/antlir/bzl/shape/shape.bzl
+++ b/antlir/bzl/shape/shape.bzl
@@ -1,0 +1,56 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+load("//antlir/bzl:maybe_export_file.bzl", "maybe_export_file")
+load("//antlir/bzl:oss_shim.bzl", "buck_command_alias", "buck_genrule", "buck_sh_test")
+load("//antlir/bzl:target_helpers.bzl", "normalize_target")
+
+def shape(name, thrift):
+    thrift = normalize_target(maybe_export_file(thrift))
+    thrift_compiler = native.read_config("thrift", "compiler", None)
+    buck_genrule(
+        name = name + "--thrift.json",
+        out = "thrift.json",
+        cmd = """
+            cd $TMP
+            $(exe {compiler}) --gen json_experimental $(location {thrift})
+            mv gen-json_experimental/*.json $OUT
+        """.format(compiler = thrift_compiler, thrift = thrift),
+    )
+
+    # For completely new shape files, the bzl file will not exist, so it's hard
+    # to generate the rest of these rules.
+    # This is rare enough that we can just ask the user nicely to make a new
+    # empty file.
+    if not native.glob([name]):
+        fail("new shape files must be created manually, please create an empty file '{}'".format(
+            name,
+        ))
+
+    out = normalize_target(maybe_export_file(name))
+    generator = normalize_target("//antlir/bzl/shape:bzl-codegen")
+
+    # easy alias per-shape to update the generated code
+    buck_command_alias(
+        name = name + "-update",
+        args = ["$(location :{}--thrift.json)".format(name), "$(location {})".format(out)],
+        exe = generator,
+        labels = ["shape-update"],
+    )
+    update = normalize_target(":{}-update".format(name))
+
+    # create a buck_genrule that always outputs a fresh bzl file so that it can
+    # be diffed for test purposes
+    buck_genrule(
+        name = name + "-gen",
+        out = name + ".bzl",
+        cmd = "$(exe {}) $(location :{}--thrift.json) $OUT".format(generator, name),
+    )
+
+    buck_sh_test(
+        name = name + "-up-to-date",
+        args = ["$(location {})".format(out), "$(location :{}-gen)".format(name), "buck run {}".format(update)],
+        test = "fbcode//antlir/bzl/shape:test-up-to-date",
+    )

--- a/antlir/bzl/shape/shape.json
+++ b/antlir/bzl/shape/shape.json
@@ -1,0 +1,166 @@
+{
+  "__fbthrift": {"@generated": 0},
+  "thrift_module" : "shape",
+  "structs" : {
+    "Character" : {
+      "lineno" : 5,
+      "is_exception" : false,
+      "is_union" : false,
+      "fields" : {
+        "name" : {
+          "type_enum" : "STRING",
+          "spec_args" : null,
+          "required" : true,
+          "source_range" : {
+            "begin" : {
+              "line" : 6,
+              "column" : 3
+            },
+            "end" : {
+              "line" : 6,
+              "column" : 18
+            }
+          }
+        },
+        "appears_in" : {
+          "type_enum" : "LIST",
+          "spec_args" : { "type_enum" : "STRING", "spec_args" : null} ,
+          "required" : true,
+          "source_range" : {
+            "begin" : {
+              "line" : 7,
+              "column" : 3
+            },
+            "end" : {
+              "line" : 7,
+              "column" : 30
+            }
+          }
+        },
+        "friends" : {
+          "type_enum" : "LIST",
+          "spec_args" : { "type_enum" : "STRUCT", "spec_args" : "Friend"} ,
+          "required" : true,
+          "source_range" : {
+            "begin" : {
+              "line" : 8,
+              "column" : 3
+            },
+            "end" : {
+              "line" : 8,
+              "column" : 27
+            }
+          }
+        },
+        "lightsaber" : {
+          "type_enum" : "STRUCT",
+          "spec_args" : "Lightsaber",
+          "required" : false,
+          "source_range" : {
+            "begin" : {
+              "line" : 9,
+              "column" : 3
+            },
+            "end" : {
+              "line" : 9,
+              "column" : 37
+            }
+          }
+        },
+        "metadata" : {
+          "type_enum" : "MAP",
+          "spec_args" : { "key_type" : { "type_enum" : "STRING", "spec_args" : null }, "val_type" : { "type_enum" : "STRING", "spec_args" : null} } ,
+          "required" : true,
+          "default_value" : { "species" : "human" },
+          "source_range" : {
+            "begin" : {
+              "line" : 10,
+              "column" : 3
+            },
+            "end" : {
+              "line" : 10,
+              "column" : 58
+            }
+          }
+        }
+      },
+      "annotation_last_lineno" : -1,
+      "source_range" : {
+        "begin" : {
+          "line" : 5,
+          "column" : 1
+        },
+        "end" : {
+          "line" : 11,
+          "column" : 2
+        }
+      }
+    },
+    "Friend" : {
+      "lineno" : 13,
+      "is_exception" : false,
+      "is_union" : false,
+      "fields" : {
+        "name" : {
+          "type_enum" : "STRING",
+          "spec_args" : null,
+          "required" : true,
+          "source_range" : {
+            "begin" : {
+              "line" : 14,
+              "column" : 3
+            },
+            "end" : {
+              "line" : 14,
+              "column" : 18
+            }
+          }
+        }
+      },
+      "annotation_last_lineno" : -1,
+      "source_range" : {
+        "begin" : {
+          "line" : 13,
+          "column" : 1
+        },
+        "end" : {
+          "line" : 15,
+          "column" : 2
+        }
+      }
+    },
+    "Lightsaber" : {
+      "lineno" : 17,
+      "is_exception" : false,
+      "is_union" : false,
+      "fields" : {
+        "color" : {
+          "type_enum" : "STRING",
+          "spec_args" : null,
+          "required" : true,
+          "source_range" : {
+            "begin" : {
+              "line" : 18,
+              "column" : 3
+            },
+            "end" : {
+              "line" : 18,
+              "column" : 19
+            }
+          }
+        }
+      },
+      "annotation_last_lineno" : -1,
+      "source_range" : {
+        "begin" : {
+          "line" : 17,
+          "column" : 1
+        },
+        "end" : {
+          "line" : 19,
+          "column" : 2
+        }
+      }
+    }
+  }
+}

--- a/antlir/bzl/shape/shape.rs
+++ b/antlir/bzl/shape/shape.rs
@@ -1,0 +1,5 @@
+// runtime support for shapes
+
+pub use ttypes::types::*;
+
+pub use serde_json::*;

--- a/antlir/bzl/shape/shape_py.rs
+++ b/antlir/bzl/shape/shape_py.rs
@@ -1,0 +1,159 @@
+// @generated SignedSource<<8f2184b7a97ce1bc635ed0172dd3094b>>
+
+use pyo3::prelude::*;
+
+#[pymodule]
+/// A Python module implemented in Rust.
+fn example(py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_class::<Character>()?;
+    Ok(())
+}
+#[doc(r######"Groupings in which a character may belong.
+"######)]
+#[pyclass(subclass)]
+struct Affiliations {
+    inner: shape::Affiliations,
+}
+
+#[pymethods]
+impl Affiliations {
+    #[getter]
+    fn faction(&self) -> PyResult<String> {
+        Ok(self.inner.faction.clone().into())
+    }
+}
+
+impl From<shape::Affiliations> for Affiliations {
+    fn from(inner: shape::Affiliations) -> Self {
+        Self { inner }
+    }
+}
+
+impl From<&shape::Affiliations> for Affiliations {
+    fn from(inner: &shape::Affiliations) -> Self {
+        Self { inner: inner.clone() }
+    }
+}
+
+#[doc(r######"A character that exists in the Star Wars universe.
+Test data adapted from the GraphQL examples
+"######)]
+#[pyclass(subclass)]
+struct Character {
+    inner: shape::Character,
+}
+
+#[pymethods]
+impl Character {
+    #[getter]
+    fn affiliations(&self) -> PyResult<Affiliations> {
+        Ok(self.inner.affiliations.clone().into())
+    }
+    #[getter]
+    fn appears_in(&self) -> PyResult<Vec<i32>> {
+        Ok(self.inner.appears_in.clone().into())
+    }
+    #[getter]
+    fn friends(&self) -> PyResult<Vec<Friend>> {
+        Ok(self.inner.friends.iter().map(|e| e.clone().into()).collect())
+    }
+    #[getter]
+    fn metadata(&self) -> PyResult<::std::collections::BTreeMap<String, String>> {
+        Ok(self.inner.metadata.clone().into())
+    }
+    #[getter]
+    fn name(&self) -> PyResult<String> {
+        Ok(self.inner.name.clone().into())
+    }
+    //#[getter]
+    //fn weapon(&self) -> PyResult<Weapon> {
+    //    Ok(self.inner.weapon.clone().into())
+    //}
+}
+
+impl From<shape::Character> for Character {
+    fn from(inner: shape::Character) -> Self {
+        Self { inner }
+    }
+}
+
+impl From<&shape::Character> for Character {
+    fn from(inner: &shape::Character) -> Self {
+        Self { inner: inner.clone() }
+    }
+}
+
+#[doc(r######"A color that a lightsaber may come in.
+"######)]
+#[pyclass(subclass)]
+struct Color {
+    inner: shape::Color,
+}
+
+impl From<shape::Color> for Color {
+    fn from(inner: shape::Color) -> Self {
+        Self { inner }
+    }
+}
+
+impl From<&shape::Color> for Color {
+    fn from(inner: &shape::Color) -> Self {
+        Self { inner: inner.clone() }
+    }
+}
+
+#[pyclass(subclass)]
+struct Friend {
+    inner: shape::Friend,
+}
+
+#[pymethods]
+impl Friend {
+    #[getter]
+    fn name(&self) -> PyResult<String> {
+        Ok(self.inner.name.clone().into())
+    }
+}
+
+impl From<shape::Friend> for Friend {
+    fn from(inner: shape::Friend) -> Self {
+        Self { inner }
+    }
+}
+
+impl From<&shape::Friend> for Friend {
+    fn from(inner: &shape::Friend) -> Self {
+        Self { inner: inner.clone() }
+    }
+}
+
+#[pyclass(subclass)]
+struct Lightsaber {
+    inner: shape::Lightsaber,
+}
+
+#[pymethods]
+impl Lightsaber {
+    #[getter]
+    fn color(&self) -> PyResult<Color> {
+        Ok(self.inner.color.clone().into())
+    }
+    #[getter]
+    fn handmedown(&self) -> PyResult<bool> {
+        Ok(self.inner.handmedown.clone().into())
+    }
+}
+
+impl From<shape::Lightsaber> for Lightsaber {
+    fn from(inner: shape::Lightsaber) -> Self {
+        Self { inner }
+    }
+}
+
+impl From<&shape::Lightsaber> for Lightsaber {
+    fn from(inner: &shape::Lightsaber) -> Self {
+        Self { inner: inner.clone() }
+    }
+}
+
+

--- a/antlir/bzl/shape/templates/enum.bzl.handlebars
+++ b/antlir/bzl/shape/templates/enum.bzl.handlebars
@@ -27,7 +27,7 @@ def {{name}}(name_or_value, context=None):
     if types.is_int(name_or_value):
         value = name_or_value
         if value not in __{{name}}_value_to_name:
-            _fail_with_context(
+            fail_with_context(
                 "{} not one of ({{#each options~}}{{value}}, {{/each}})".format(value),
                 context=context,
             )
@@ -35,14 +35,14 @@ def {{name}}(name_or_value, context=None):
     elif types.is_string(name_or_value):
         name = name_or_value.upper()
         if name not in __{{name}}_name_to_value:
-            _fail_with_context(
+            fail_with_context(
                 "{} not one of ({{#each options~}}{{name}}, {{/each}})".format(name),
                 context=context,
             )
 
         value = __{{name}}_name_to_value[name]
     else:
-        _fail_with_context(
+        fail_with_context(
             "Provided value {} to {{name}} constructor was neither an int or string".format(name_or_value),
             context=context,
         )
@@ -55,12 +55,12 @@ def {{name}}(name_or_value, context=None):
 
 def __typecheck_{{name}}(e, err_context=None):
     if not hasattr(e, "__type__"):
-        _fail_with_context(
+        fail_with_context(
             "Provided value {} is not a struct or enum".format(e),
             context=err_context,
         )
     if e.__type__ != {{name}}:
-        _fail_with_context(
+        fail_with_context(
             "Provided value {} is not an instance of this enum: {}".format(e, e.__type__),
             context=err_context,
         )

--- a/antlir/bzl/shape/templates/enum.bzl.handlebars
+++ b/antlir/bzl/shape/templates/enum.bzl.handlebars
@@ -1,0 +1,66 @@
+# {{name}} Enum
+{{name}}Variants = struct(
+    {{~#each options}}
+    {{name}} = {{value}},
+    {{~/each}}
+)
+
+__{{name}}_name_to_value = {
+    {{~#each options}}
+    "{{name}}": {{value}},
+    {{~/each}}
+}
+__{{name}}_value_to_name = {
+    {{~#each options}}
+    {{value}}: "{{name}}",
+    {{~/each}}
+}
+
+# Construct a new instance of the {{name}} enum, checking that it is a valid
+# variant name or value. Returns a struct with .name and .value
+def {{name}}(name_or_value, context=None):
+    {{#if docstring ~}}
+    """
+    {{docstring}}
+    """
+    {{/if~}}
+    if types.is_int(name_or_value):
+        value = name_or_value
+        if value not in __{{name}}_value_to_name:
+            _fail_with_context(
+                "{} not one of ({{#each options~}}{{value}}, {{/each}})".format(value),
+                context=context,
+            )
+        name = __{{name}}_value_to_name[value]
+    elif types.is_string(name_or_value):
+        name = name_or_value.upper()
+        if name not in __{{name}}_name_to_value:
+            _fail_with_context(
+                "{} not one of ({{#each options~}}{{name}}, {{/each}})".format(name),
+                context=context,
+            )
+
+        value = __{{name}}_name_to_value[name]
+    else:
+        _fail_with_context(
+            "Provided value {} to {{name}} constructor was neither an int or string".format(name_or_value),
+            context=context,
+        )
+
+    return struct(
+        name = name,
+        value = value,
+        __type__ = {{name}},
+    )
+
+def __typecheck_{{name}}(e, err_context=None):
+    if not hasattr(e, "__type__"):
+        _fail_with_context(
+            "Provided value {} is not a struct or enum".format(e),
+            context=err_context,
+        )
+    if e.__type__ != {{name}}:
+        _fail_with_context(
+            "Provided value {} is not an instance of this enum: {}".format(e, e.__type__),
+            context=err_context,
+        )

--- a/antlir/bzl/shape/templates/enum.rs.handlebars
+++ b/antlir/bzl/shape/templates/enum.rs.handlebars
@@ -1,0 +1,19 @@
+{{#if docstring ~}}
+#[doc(r######"{{docstring}}"######)]
+{{/if~}}
+#[pyclass(subclass)]
+struct {{name}} {
+    inner: shape::{{name}},
+}
+
+impl From<shape::{{name}}> for {{name}} {
+    fn from(inner: shape::{{name}}) -> Self {
+        Self { inner }
+    }
+}
+
+impl From<&shape::{{name}}> for {{name}} {
+    fn from(inner: &shape::{{name}}) -> Self {
+        Self { inner: inner.clone() }
+    }
+}

--- a/antlir/bzl/shape/templates/preamble.bzl.handlebars
+++ b/antlir/bzl/shape/templates/preamble.bzl.handlebars
@@ -1,6 +1,4 @@
-"""
-@generated
-"""
+# @_generated
 load("@bazel_skylib//lib:types.bzl", "types")
 
 def _fail_with_context(msg, context):

--- a/antlir/bzl/shape/templates/preamble.bzl.handlebars
+++ b/antlir/bzl/shape/templates/preamble.bzl.handlebars
@@ -1,27 +1,11 @@
 # @_generated
+
 load("@bazel_skylib//lib:types.bzl", "types")
-
-def _fail_with_context(msg, context):
-    if types.is_none(context):
-        fail(msg)
-    elif types.is_string(context):
-        fail("{}{}".format(context + ":" if context else "", msg))
-    elif types.is_list(context):
-        stack = [msg] + context[::-1] if context else [msg]
-        fail("\n When: ".join(stack))
-    else:
-        fail("Provided invalid context {} when trying to render error: {}".format(context, msg))
-
-def _add_context(msg, context=None):
-    if msg == None:
-        return context
-    context = context or []
-    return context + [msg]
-
+load("//antlir/bzl/shape:defs.bzl", "fail_with_context", "add_context")
 
 {{#each this ~}}
 def _check_{{this}}(x, context=None):
     if not types.is_{{this}}(x):
-        _fail_with_context(msg="{} is not a {{this}}".format(repr(x)), context=context)
+        fail_with_context(msg="{} is not a {{this}}".format(repr(x)), context=context)
 
 {{/each}}

--- a/antlir/bzl/shape/templates/preamble.bzl.handlebars
+++ b/antlir/bzl/shape/templates/preamble.bzl.handlebars
@@ -1,4 +1,4 @@
-# @_generated
+# @_generated <<SignedSource::*O*zOeWoEQle#+L!plEphiEmie@IsG>>
 
 load("@bazel_skylib//lib:types.bzl", "types")
 load("//antlir/bzl/shape:defs.bzl", "fail_with_context", "add_context")

--- a/antlir/bzl/shape/templates/preamble.bzl.handlebars
+++ b/antlir/bzl/shape/templates/preamble.bzl.handlebars
@@ -1,0 +1,29 @@
+"""
+@generated
+"""
+load("@bazel_skylib//lib:types.bzl", "types")
+
+def _fail_with_context(msg, context):
+    if types.is_none(context):
+        fail(msg)
+    elif types.is_string(context):
+        fail("{}{}".format(context + ":" if context else "", msg))
+    elif types.is_list(context):
+        stack = [msg] + context[::-1] if context else [msg]
+        fail("\n When: ".join(stack))
+    else:
+        fail("Provided invalid context {} when trying to render error: {}".format(context, msg))
+
+def _add_context(msg, context=None):
+    if msg == None:
+        return context
+    context = context or []
+    return context + [msg]
+
+
+{{#each this ~}}
+def _check_{{this}}(x, context=None):
+    if not types.is_{{this}}(x):
+        _fail_with_context(msg="{} is not a {{this}}".format(repr(x)), context=context)
+
+{{/each}}

--- a/antlir/bzl/shape/templates/preamble.rs.handlebars
+++ b/antlir/bzl/shape/templates/preamble.rs.handlebars
@@ -1,0 +1,9 @@
+// @_generated <<SignedSource::*O*zOeWoEQle#+L!plEphiEmie@IsG>>
+
+use pyo3::prelude::*;
+
+#[pymodule]
+/// A Python module implemented in Rust.
+fn example(py: Python, m: &PyModule) -> PyResult<()> {
+    Ok(())
+}

--- a/antlir/bzl/shape/templates/struct.bzl.handlebars
+++ b/antlir/bzl/shape/templates/struct.bzl.handlebars
@@ -1,0 +1,43 @@
+# {{name}} Struct
+def {{name}}(
+    *,
+    {{~#each fields}}
+    {{name}} = None,
+    {{~/each}}
+    err_context=None,
+):
+    {{#if docstring ~}}
+    """
+    {{docstring}}
+    """
+    {{/if~}}
+    # prepare a dictionary with all the shape fields, starting with any default values
+    data = {
+        {{~#each fields~}}
+        {{#if default_value}}
+        "{{name}}": {{ default_value }},
+        {{~/if~}}
+        {{~/each}}
+    }
+
+    {{~#each fields}}
+    {{~#if default_value}}
+
+    if {{name}} != None:
+        data["{{name}}"] = {{name}}
+    {{~else}}
+
+    data["{{name}}"] = {{name}}
+    {{~/if~}}
+    {{~/each}}
+
+    s = struct(__type__ = {{name}}, **data)
+    __typecheck_{{name}}(s, _add_context("Constructing struct '{{name}}'", err_context))
+    return s
+
+def __typecheck_{{name}}(object, err_context=None):
+    {{~#each fields}}
+
+    {{name}} = object.{{name}}
+{{ type_check }}
+    {{~/each}}

--- a/antlir/bzl/shape/templates/struct.rs.handlebars
+++ b/antlir/bzl/shape/templates/struct.rs.handlebars
@@ -1,0 +1,34 @@
+{{#if docstring ~}}
+#[doc(r######"{{docstring}}"######)]
+{{/if~}}
+#[pyclass(subclass)]
+struct {{name}} {
+    inner: shape::{{name}},
+}
+
+#[pymethods]
+impl {{name}} {
+    {{~#each fields}}
+    #[getter]
+    fn {{name}}(&self) -> PyResult<{{pyo3_type}}> {
+        Ok(self.inner.{{name}}.clone().into())
+    }
+    {{~/each}}
+
+    #[staticmethod]
+    fn from_json_str(s: &str) -> PyResult<Self> {
+        serde_json::from_str(s)
+    }
+}
+
+impl From<shape::{{name}}> for {{name}} {
+    fn from(inner: shape::{{name}}) -> Self {
+        Self { inner }
+    }
+}
+
+impl From<&shape::{{name}}> for {{name}} {
+    fn from(inner: &shape::{{name}}) -> Self {
+        Self { inner: inner.clone() }
+    }
+}

--- a/antlir/bzl/shape/templates/union.bzl.handlebars
+++ b/antlir/bzl/shape/templates/union.bzl.handlebars
@@ -21,7 +21,7 @@ def {{name}}(
     {{~/each}}
 
     u = struct(__type__ = {{name}}, **data)
-    __typecheck_{{name}}(u, _add_context("Constructing union '{{name}}'", err_context))
+    __typecheck_{{name}}(u, add_context("Constructing union '{{name}}'", err_context))
     return u
 
 
@@ -34,12 +34,12 @@ def __typecheck_{{name}}(object, err_context=None):
     {{~/each}}
 
     if len(seen) == 0:
-        _fail_with_context(
+        fail_with_context(
             "All fields for union {{name}} were None", context=err_context
         )
 
     if len(seen) > 1:
-        _fail_with_context(
+        fail_with_context(
             "Multiple different values provided for union {{name}}: {}".format(
                 ",".join(seen)
             ),

--- a/antlir/bzl/shape/templates/union.bzl.handlebars
+++ b/antlir/bzl/shape/templates/union.bzl.handlebars
@@ -1,0 +1,54 @@
+# {{name}} Union
+def {{name}}(
+    *,
+    {{~#each fields}}
+    {{name}} = None,
+    {{~/each}}
+    err_context=None,
+):
+    {{#if docstring}}
+    """
+    {{docstring}}
+    """
+    {{/if~}}
+
+    data = {}
+
+    {{~#each fields}}
+
+    if {{name}} != None:
+        data["{{name}}"] = {{name}}
+    {{~/each}}
+
+    u = struct(__type__ = {{name}}, **data)
+    __typecheck_{{name}}(u, _add_context("Constructing union '{{name}}'", err_context))
+    return u
+
+
+def __typecheck_{{name}}(object, err_context=None):
+    seen = []
+    {{~#each fields}}
+
+    if hasattr(object, "{{name}}") and object.{{name}} != None:
+        seen.append("{{name}}")
+    {{~/each}}
+
+    if len(seen) == 0:
+        _fail_with_context(
+            "All fields for union {{name}} were None", context=err_context
+        )
+
+    if len(seen) > 1:
+        _fail_with_context(
+            "Multiple different values provided for union {{name}}: {}".format(
+                ",".join(seen)
+            ),
+            context=err_context,
+        )
+
+    {{~#each fields}}
+
+    if hasattr(object, "{{name}}") and object.{{name}} != None:
+        {{name}} = object.{{name}}
+{{ type_check}}
+    {{~/each~}}

--- a/antlir/bzl/shape/test-up-to-date.sh
+++ b/antlir/bzl/shape/test-up-to-date.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+if git diff --no-index "$1" "$2" ; then
+    echo "all good :)"
+else
+    echo
+    echo "If you changed the shape definition, run '$3' to update the generated code"
+    exit 1
+fi

--- a/antlir/bzl/shape/tests/BUCK
+++ b/antlir/bzl/shape/tests/BUCK
@@ -1,0 +1,23 @@
+load("@fbcode_macros//build_defs:export_files.bzl", "export_file")
+load("@fbcode_macros//build_defs:native_rules.bzl", "buck_genrule")
+
+export_file(
+    name = "example.thrift",
+)
+
+buck_genrule(
+    name = "example.json",
+    out = "example.json",
+    cmd = """
+        $(exe //thrift/compiler:thrift) --out $TMP --gen json_experimental $(location :example.thrift)
+        mv $TMP/* $OUT
+    """,
+)
+
+buck_genrule(
+    name = "example.bzl",
+    out = "example.bzl",
+    cmd = """
+        cat $(location :example.json) | $(exe //antlir/bzl/shape:bzl-codegen) > $OUT
+    """,
+)

--- a/antlir/bzl/shape/tests/BUCK
+++ b/antlir/bzl/shape/tests/BUCK
@@ -1,6 +1,22 @@
 load("//antlir/bzl/shape:shape.bzl", "shape")
 
 shape(
-    name = "example.bzl",
+    name = "example",
     thrift = "example.thrift",
+)
+
+rust_unittest(
+    name = "test-example-rust",
+    srcs = ["test_example.rs"],
+    crate_root = "test_example.rs",
+    deps = [":example-rust"],
+)
+
+python_unittest(
+    name = "test-example-py",
+    srcs = ["test_example.py"],
+    deps = [
+        ":example-python",
+        # ":example-thrift-py3-types",
+    ],
 )

--- a/antlir/bzl/shape/tests/BUCK
+++ b/antlir/bzl/shape/tests/BUCK
@@ -1,23 +1,6 @@
-load("@fbcode_macros//build_defs:export_files.bzl", "export_file")
-load("@fbcode_macros//build_defs:native_rules.bzl", "buck_genrule")
+load("//antlir/bzl/shape:shape.bzl", "shape")
 
-export_file(
-    name = "example.thrift",
-)
-
-buck_genrule(
-    name = "example.json",
-    out = "example.json",
-    cmd = """
-        $(exe //thrift/compiler:thrift) --out $TMP --gen json_experimental $(location :example.thrift)
-        mv $TMP/* $OUT
-    """,
-)
-
-buck_genrule(
+shape(
     name = "example.bzl",
-    out = "example.bzl",
-    cmd = """
-        cat $(location :example.json) | $(exe //antlir/bzl/shape:bzl-codegen) > $OUT
-    """,
+    thrift = "example.thrift",
 )

--- a/antlir/bzl/shape/tests/example.bzl
+++ b/antlir/bzl/shape/tests/example.bzl
@@ -1,0 +1,341 @@
+# @generated
+load("@bazel_skylib//lib:types.bzl", "types")
+
+def _fail_with_context(msg, context):
+    if types.is_none(context):
+        fail(msg)
+    elif types.is_string(context):
+        fail("{}{}".format(context + ":" if context else "", msg))
+    elif types.is_list(context):
+        stack = [msg] + context[::-1] if context else [msg]
+        fail("\n When: ".join(stack))
+    else:
+        fail("Provided invalid context {} when trying to render error: {}".format(context, msg))
+
+def _add_context(msg, context=None):
+    if msg == None:
+        return context
+    context = context or []
+    return context + [msg]
+
+
+def _check_bool(x, context=None):
+    if not types.is_bool(x):
+        _fail_with_context(msg="{} is not a bool".format(repr(x)), context=context)
+
+def _check_int(x, context=None):
+    if not types.is_int(x):
+        _fail_with_context(msg="{} is not a int".format(repr(x)), context=context)
+
+def _check_string(x, context=None):
+    if not types.is_string(x):
+        _fail_with_context(msg="{} is not a string".format(repr(x)), context=context)
+
+def _check_dict(x, context=None):
+    if not types.is_dict(x):
+        _fail_with_context(msg="{} is not a dict".format(repr(x)), context=context)
+
+def _check_list(x, context=None):
+    if not types.is_list(x):
+        _fail_with_context(msg="{} is not a list".format(repr(x)), context=context)
+
+
+
+# Affiliations Struct
+def Affiliations(
+    *,
+    faction = None,
+    err_context=None,
+):
+    """
+    Groupings in which a character may belong.
+
+    """
+    # prepare a dictionary with all the shape fields, starting with any default values
+    data = {
+    }
+
+    data["faction"] = faction
+
+    s = struct(__type__ = Affiliations, **data)
+    __typecheck_Affiliations(s, _add_context("Constructing struct 'Affiliations'", err_context))
+    return s
+
+def __typecheck_Affiliations(object, err_context=None):
+
+    faction = object.faction
+    if faction == None:
+        _fail_with_context("faction: required but is None", context=err_context)
+    else:
+        _check_string(faction, context=_add_context("Validating 'faction'", err_context))
+
+# Character Struct
+def Character(
+    *,
+    affiliations = None,
+    appears_in = None,
+    friends = None,
+    metadata = None,
+    name = None,
+    weapon = None,
+    err_context=None,
+):
+    """
+    A character that exists in the Star Wars universe.
+Test data adapted from the GraphQL examples
+
+    """
+    # prepare a dictionary with all the shape fields, starting with any default values
+    data = {
+        "affiliations": Affiliations(faction="Rebellion"),
+        "appears_in": [4,5,6],
+        "metadata": {"species": "human"},
+    }
+
+    if affiliations != None:
+        data["affiliations"] = affiliations
+
+    if appears_in != None:
+        data["appears_in"] = appears_in
+
+    data["friends"] = friends
+
+    if metadata != None:
+        data["metadata"] = metadata
+
+    data["name"] = name
+
+    data["weapon"] = weapon
+
+    s = struct(__type__ = Character, **data)
+    __typecheck_Character(s, _add_context("Constructing struct 'Character'", err_context))
+    return s
+
+def __typecheck_Character(object, err_context=None):
+
+    affiliations = object.affiliations
+    if affiliations == None:
+        _fail_with_context("affiliations: required but is None", context=err_context)
+    else:
+        __typecheck_Affiliations(affiliations, err_context=err_context)
+
+    appears_in = object.appears_in
+    if appears_in == None:
+        _fail_with_context("appears_in: required but is None", context=err_context)
+    else:
+        _check_list(appears_in, context=err_context)
+        for (i, appears_in_item) in enumerate(appears_in):
+            inner_context = err_context + ["Checking index {} for field 'appears_in'".format(i)]
+            _check_int(appears_in_item, context=_add_context("Validating 'appears_in_item'", inner_context))
+
+    friends = object.friends
+    if friends == None:
+        _fail_with_context("friends: required but is None", context=err_context)
+    else:
+        _check_list(friends, context=err_context)
+        for (i, friends_item) in enumerate(friends):
+            inner_context = err_context + ["Checking index {} for field 'friends'".format(i)]
+            __typecheck_Friend(friends_item, err_context=inner_context)
+
+    metadata = object.metadata
+    if metadata == None:
+        _fail_with_context("metadata: required but is None", context=err_context)
+    else:
+        _check_dict(metadata, context=err_context)
+        for metadata_key, metadata_value in metadata.items():
+            inner_context = err_context + ["Checking key '{}' for field 'metadata'".format(metadata_key)]
+            _check_string(metadata_key, context=_add_context("Validating 'metadata_key'", inner_context))
+            _check_string(metadata_value, context=_add_context("Validating 'metadata_value'", inner_context))
+
+    name = object.name
+    if name == None:
+        _fail_with_context("name: required but is None", context=err_context)
+    else:
+        _check_string(name, context=_add_context("Validating 'name'", err_context))
+
+    weapon = object.weapon
+    if weapon != None:
+        __typecheck_Weapon(weapon, err_context=err_context)
+
+# Color Enum
+ColorVariants = struct(
+    BLUE = 2,
+    GREEN = 1,
+    RED = 3,
+)
+
+__Color_name_to_value = {
+    "BLUE": 2,
+    "GREEN": 1,
+    "RED": 3,
+}
+__Color_value_to_name = {
+    2: "BLUE",
+    1: "GREEN",
+    3: "RED",
+}
+
+# Construct a new instance of the Color enum, checking that it is a valid
+# variant name or value. Returns a struct with .name and .value
+def Color(name_or_value, context=None):
+    """
+    A color that a lightsaber may come in.
+
+    """
+    if types.is_int(name_or_value):
+        value = name_or_value
+        if value not in __Color_value_to_name:
+            _fail_with_context(
+                "{} not one of (2, 1, 3, )".format(value),
+                context=context,
+            )
+        name = __Color_value_to_name[value]
+    elif types.is_string(name_or_value):
+        name = name_or_value.upper()
+        if name not in __Color_name_to_value:
+            _fail_with_context(
+                "{} not one of (BLUE, GREEN, RED, )".format(name),
+                context=context,
+            )
+
+        value = __Color_name_to_value[name]
+    else:
+        _fail_with_context(
+            "Provided value {} to Color constructor was neither an int or string".format(name_or_value),
+            context=context,
+        )
+
+    return struct(
+        name = name,
+        value = value,
+        __type__ = Color,
+    )
+
+def __typecheck_Color(e, err_context=None):
+    if not hasattr(e, "__type__"):
+        _fail_with_context(
+            "Provided value {} is not a struct or enum".format(e),
+            context=err_context,
+        )
+    if e.__type__ != Color:
+        _fail_with_context(
+            "Provided value {} is not an instance of this enum: {}".format(e, e.__type__),
+            context=err_context,
+        )
+
+# Friend Struct
+def Friend(
+    *,
+    name = None,
+    err_context=None,
+):
+    # prepare a dictionary with all the shape fields, starting with any default values
+    data = {
+    }
+
+    data["name"] = name
+
+    s = struct(__type__ = Friend, **data)
+    __typecheck_Friend(s, _add_context("Constructing struct 'Friend'", err_context))
+    return s
+
+def __typecheck_Friend(object, err_context=None):
+
+    name = object.name
+    if name == None:
+        _fail_with_context("name: required but is None", context=err_context)
+    else:
+        _check_string(name, context=_add_context("Validating 'name'", err_context))
+
+# Lightsaber Struct
+def Lightsaber(
+    *,
+    color = None,
+    handmedown = None,
+    err_context=None,
+):
+    # prepare a dictionary with all the shape fields, starting with any default values
+    data = {
+        "color": Color(2),
+        "handmedown": True,
+    }
+
+    if color != None:
+        data["color"] = color
+
+    if handmedown != None:
+        data["handmedown"] = handmedown
+
+    s = struct(__type__ = Lightsaber, **data)
+    __typecheck_Lightsaber(s, _add_context("Constructing struct 'Lightsaber'", err_context))
+    return s
+
+def __typecheck_Lightsaber(object, err_context=None):
+
+    color = object.color
+    if color == None:
+        _fail_with_context("color: required but is None", context=err_context)
+    else:
+        __typecheck_Color(color, err_context=err_context)
+
+    handmedown = object.handmedown
+    if handmedown == None:
+        _fail_with_context("handmedown: required but is None", context=err_context)
+    else:
+        _check_bool(handmedown, context=_add_context("Validating 'handmedown'", err_context))
+
+# Weapon Union
+def Weapon(
+    *,
+    lightsaber = None,
+    other = None,
+    err_context=None,
+):
+    data = {}
+
+    if lightsaber != None:
+        data["lightsaber"] = lightsaber
+
+    if other != None:
+        data["other"] = other
+
+    u = struct(__type__ = Weapon, **data)
+    __typecheck_Weapon(u, _add_context("Constructing union 'Weapon'", err_context))
+    return u
+
+
+def __typecheck_Weapon(object, err_context=None):
+    seen = []
+
+    if hasattr(object, "lightsaber") and object.lightsaber != None:
+        seen.append("lightsaber")
+
+    if hasattr(object, "other") and object.other != None:
+        seen.append("other")
+
+    if len(seen) == 0:
+        _fail_with_context(
+            "All fields for union Weapon were None", context=err_context
+        )
+
+    if len(seen) > 1:
+        _fail_with_context(
+            "Multiple different values provided for union Weapon: {}".format(
+                ",".join(seen)
+            ),
+            context=err_context,
+        )
+
+    if hasattr(object, "lightsaber") and object.lightsaber != None:
+        lightsaber = object.lightsaber
+        if lightsaber == None:
+            _fail_with_context("lightsaber: required but is None", context=err_context)
+        else:
+            __typecheck_Lightsaber(lightsaber, err_context=err_context)
+
+    if hasattr(object, "other") and object.other != None:
+        other = object.other
+        if other == None:
+            _fail_with_context("other: required but is None", context=err_context)
+        else:
+            _check_string(other, context=_add_context("Validating 'other'", err_context))

--- a/antlir/bzl/shape/tests/example.bzl
+++ b/antlir/bzl/shape/tests/example.bzl
@@ -1,43 +1,27 @@
 # @generated
+
 load("@bazel_skylib//lib:types.bzl", "types")
-
-def _fail_with_context(msg, context):
-    if types.is_none(context):
-        fail(msg)
-    elif types.is_string(context):
-        fail("{}{}".format(context + ":" if context else "", msg))
-    elif types.is_list(context):
-        stack = [msg] + context[::-1] if context else [msg]
-        fail("\n When: ".join(stack))
-    else:
-        fail("Provided invalid context {} when trying to render error: {}".format(context, msg))
-
-def _add_context(msg, context=None):
-    if msg == None:
-        return context
-    context = context or []
-    return context + [msg]
-
+load("//antlir/bzl/shape:defs.bzl", "fail_with_context", "add_context")
 
 def _check_bool(x, context=None):
     if not types.is_bool(x):
-        _fail_with_context(msg="{} is not a bool".format(repr(x)), context=context)
+        fail_with_context(msg="{} is not a bool".format(repr(x)), context=context)
 
 def _check_int(x, context=None):
     if not types.is_int(x):
-        _fail_with_context(msg="{} is not a int".format(repr(x)), context=context)
+        fail_with_context(msg="{} is not a int".format(repr(x)), context=context)
 
 def _check_string(x, context=None):
     if not types.is_string(x):
-        _fail_with_context(msg="{} is not a string".format(repr(x)), context=context)
+        fail_with_context(msg="{} is not a string".format(repr(x)), context=context)
 
 def _check_dict(x, context=None):
     if not types.is_dict(x):
-        _fail_with_context(msg="{} is not a dict".format(repr(x)), context=context)
+        fail_with_context(msg="{} is not a dict".format(repr(x)), context=context)
 
 def _check_list(x, context=None):
     if not types.is_list(x):
-        _fail_with_context(msg="{} is not a list".format(repr(x)), context=context)
+        fail_with_context(msg="{} is not a list".format(repr(x)), context=context)
 
 
 
@@ -67,7 +51,7 @@ def __typecheck_Affiliations(object, err_context=None):
     if faction == None:
         _fail_with_context("faction: required but is None", context=err_context)
     else:
-        _check_string(faction, context=_add_context("Validating 'faction'", err_context))
+        _check_string(faction, context=add_context("Validating 'faction'", err_context))
 
 # Character Struct
 def Character(
@@ -126,7 +110,7 @@ def __typecheck_Character(object, err_context=None):
         _check_list(appears_in, context=err_context)
         for (i, appears_in_item) in enumerate(appears_in):
             inner_context = err_context + ["Checking index {} for field 'appears_in'".format(i)]
-            _check_int(appears_in_item, context=_add_context("Validating 'appears_in_item'", inner_context))
+            _check_int(appears_in_item, context=add_context("Validating 'appears_in_item'", inner_context))
 
     friends = object.friends
     if friends == None:
@@ -144,14 +128,14 @@ def __typecheck_Character(object, err_context=None):
         _check_dict(metadata, context=err_context)
         for metadata_key, metadata_value in metadata.items():
             inner_context = err_context + ["Checking key '{}' for field 'metadata'".format(metadata_key)]
-            _check_string(metadata_key, context=_add_context("Validating 'metadata_key'", inner_context))
-            _check_string(metadata_value, context=_add_context("Validating 'metadata_value'", inner_context))
+            _check_string(metadata_key, context=add_context("Validating 'metadata_key'", inner_context))
+            _check_string(metadata_value, context=add_context("Validating 'metadata_value'", inner_context))
 
     name = object.name
     if name == None:
         _fail_with_context("name: required but is None", context=err_context)
     else:
-        _check_string(name, context=_add_context("Validating 'name'", err_context))
+        _check_string(name, context=add_context("Validating 'name'", err_context))
 
     weapon = object.weapon
     if weapon != None:
@@ -185,7 +169,7 @@ def Color(name_or_value, context=None):
     if types.is_int(name_or_value):
         value = name_or_value
         if value not in __Color_value_to_name:
-            _fail_with_context(
+            fail_with_context(
                 "{} not one of (2, 1, 3, )".format(value),
                 context=context,
             )
@@ -193,14 +177,14 @@ def Color(name_or_value, context=None):
     elif types.is_string(name_or_value):
         name = name_or_value.upper()
         if name not in __Color_name_to_value:
-            _fail_with_context(
+            fail_with_context(
                 "{} not one of (BLUE, GREEN, RED, )".format(name),
                 context=context,
             )
 
         value = __Color_name_to_value[name]
     else:
-        _fail_with_context(
+        fail_with_context(
             "Provided value {} to Color constructor was neither an int or string".format(name_or_value),
             context=context,
         )
@@ -213,12 +197,12 @@ def Color(name_or_value, context=None):
 
 def __typecheck_Color(e, err_context=None):
     if not hasattr(e, "__type__"):
-        _fail_with_context(
+        fail_with_context(
             "Provided value {} is not a struct or enum".format(e),
             context=err_context,
         )
     if e.__type__ != Color:
-        _fail_with_context(
+        fail_with_context(
             "Provided value {} is not an instance of this enum: {}".format(e, e.__type__),
             context=err_context,
         )
@@ -245,7 +229,7 @@ def __typecheck_Friend(object, err_context=None):
     if name == None:
         _fail_with_context("name: required but is None", context=err_context)
     else:
-        _check_string(name, context=_add_context("Validating 'name'", err_context))
+        _check_string(name, context=add_context("Validating 'name'", err_context))
 
 # Lightsaber Struct
 def Lightsaber(
@@ -282,7 +266,7 @@ def __typecheck_Lightsaber(object, err_context=None):
     if handmedown == None:
         _fail_with_context("handmedown: required but is None", context=err_context)
     else:
-        _check_bool(handmedown, context=_add_context("Validating 'handmedown'", err_context))
+        _check_bool(handmedown, context=add_context("Validating 'handmedown'", err_context))
 
 # Weapon Union
 def Weapon(
@@ -300,7 +284,7 @@ def Weapon(
         data["other"] = other
 
     u = struct(__type__ = Weapon, **data)
-    __typecheck_Weapon(u, _add_context("Constructing union 'Weapon'", err_context))
+    __typecheck_Weapon(u, add_context("Constructing union 'Weapon'", err_context))
     return u
 
 
@@ -314,12 +298,12 @@ def __typecheck_Weapon(object, err_context=None):
         seen.append("other")
 
     if len(seen) == 0:
-        _fail_with_context(
+        fail_with_context(
             "All fields for union Weapon were None", context=err_context
         )
 
     if len(seen) > 1:
-        _fail_with_context(
+        fail_with_context(
             "Multiple different values provided for union Weapon: {}".format(
                 ",".join(seen)
             ),
@@ -338,4 +322,4 @@ def __typecheck_Weapon(object, err_context=None):
         if other == None:
             _fail_with_context("other: required but is None", context=err_context)
         else:
-            _check_string(other, context=_add_context("Validating 'other'", err_context))
+            _check_string(other, context=add_context("Validating 'other'", err_context))

--- a/antlir/bzl/shape/tests/example.bzl
+++ b/antlir/bzl/shape/tests/example.bzl
@@ -1,4 +1,4 @@
-# @generated
+# @generated SignedSource<<d00a9143811760482ab9f0a9109e406e>>
 
 load("@bazel_skylib//lib:types.bzl", "types")
 load("//antlir/bzl/shape:defs.bzl", "fail_with_context", "add_context")

--- a/antlir/bzl/shape/tests/example.thrift
+++ b/antlir/bzl/shape/tests/example.thrift
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+namespace py3 antlir.bzl.shape.tests
+
 /// Groupings in which a character may belong.
 struct Affiliations {
   1: string faction;

--- a/antlir/bzl/shape/tests/example.thrift
+++ b/antlir/bzl/shape/tests/example.thrift
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/// Groupings in which a character may belong.
+struct Affiliations {
+  1: string faction;
+}
+
+/// A character that exists in the Star Wars universe.
+/// Test data adapted from the GraphQL examples
+struct Character {
+  1: required string name;
+  2: list<i32> appears_in = [4, 5, 6];
+  3: list<Friend> friends;
+  4: optional Weapon weapon;
+  5: map<string, string> metadata = {"species": "human"};
+  6: Affiliations affiliations = Affiliations{faction = "Rebellion"};
+} (docs = "hello")
+
+struct Friend {
+  1: string name;
+}
+
+union Weapon {
+  1: Lightsaber lightsaber;
+  2: string other;
+}
+
+struct Lightsaber {
+  1: Color color = "Color.BLUE";
+  2: bool handmedown = true;
+}
+
+/// A color that a lightsaber may come in.
+enum Color {
+  GREEN = 1,
+  BLUE = 2,
+  RED = 3,
+}

--- a/antlir/bzl/shape/tests/test_example.py
+++ b/antlir/bzl/shape/tests/test_example.py
@@ -1,0 +1,23 @@
+import unittest
+
+import antlir.bzl.shape.tests.example as example
+
+# import antlir.bzl.shape.tests.example.types as example
+# from thrift.py3.serializer import deserialize, Protocol
+
+
+class CharacterSub(example.Character):
+    def extra_method(self):
+        pass
+
+
+class TestExample(unittest.TestCase):
+    def test_example(self):
+        pass
+        # print(dir(example.Character))
+        # print(dir(Protocol))
+        # self.assertEquals(example.luke.name, "Luke Skywalker")
+        # example.Character(name="Luke Skywalker", blah=True)
+        # ch = deserialize(
+        #     example.Character, b'{"name": "Luke Skywalker"}', Protocol.JSON
+        # )

--- a/antlir/bzl/shape/tests/test_example.rs
+++ b/antlir/bzl/shape/tests/test_example.rs
@@ -1,0 +1,14 @@
+use example::{from_str, Character};
+
+#[test]
+fn test_load_from_str() {
+    let ch: Character = from_str(
+        r#"{
+        "name": "Luke Skywalker",
+        "appears_in": [4, 5, 6],
+        "friends": [{"name": "Han Solo"}]
+    }"#,
+    )
+    .unwrap();
+    assert_eq!(ch.name, "Luke Skywalker");
+}


### PR DESCRIPTION
Summary:
Generate a rust crate for shapes, and a python library backed by a rust python
extension to expose shapes to python

Differential Revision: D32414378

