### PR TITLE
[antlir][build_appliance] build everything into the msdk packages and leave it untouched

### DIFF
--- a/antlir/antlir2/antlir2/BUCK
+++ b/antlir/antlir2/antlir2/BUCK
@@ -21,6 +21,7 @@ rust_binary(
         "tracing",
         "tracing-subscriber",
         "//antlir/antlir2/antlir2_btrfs:antlir2_btrfs",
+        "//antlir/antlir2/antlir2_cas_dir:antlir2_cas_dir",
         "//antlir/antlir2/antlir2_compile:antlir2_compile",
         "//antlir/antlir2/antlir2_depgraph:antlir2_depgraph",
         "//antlir/antlir2/antlir2_features:antlir2_features",

--- a/antlir/antlir2/antlir2/src/cmd/cas_dir.rs
+++ b/antlir/antlir2/antlir2/src/cmd/cas_dir.rs
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::path::PathBuf;
+
+use antlir2_cas_dir::CasDirOpts;
+use anyhow::Context;
+use clap::Parser;
+use clap::Subcommand;
+
+use crate::Result;
+
+#[derive(Parser, Debug)]
+pub(crate) struct CasDir {
+    #[clap(long)]
+    rootless: bool,
+    #[command(subcommand)]
+    sub: Sub,
+}
+
+#[derive(Subcommand, Debug)]
+enum Sub {
+    Dehydrate(Dehydrate),
+}
+
+#[derive(Parser, Debug)]
+struct Dehydrate {
+    #[clap(long)]
+    subvol: PathBuf,
+    #[clap(long)]
+    out: PathBuf,
+}
+
+impl CasDir {
+    #[tracing::instrument(name = "cas-dir", skip_all, ret, err)]
+    pub(crate) fn run(self, rootless: antlir2_rootless::Rootless) -> Result<()> {
+        // This naming is a little confusing, but basically `rootless` exists to
+        // drop privileges when the process is invoked with `sudo`, and as such
+        // is not used if the entire build is running solely as an unprivileged
+        // user.
+        let rootless = if self.rootless {
+            antlir2_rootless::unshare_new_userns().context("while setting up userns")?;
+            None
+        } else {
+            Some(rootless)
+        };
+        match self.sub {
+            Sub::Dehydrate(dehydrate) => {
+                let mut opts = CasDirOpts::default();
+                if let Some(uid) = rootless.and_then(|r| r.unprivileged_uid()) {
+                    opts = opts.uid(uid);
+                }
+                if let Some(gid) = rootless.and_then(|r| r.unprivileged_gid()) {
+                    opts = opts.gid(gid);
+                }
+                let root_guard = rootless.map(|r| r.escalate()).transpose()?;
+                antlir2_cas_dir::CasDir::dehydrate(&dehydrate.subvol, dehydrate.out, opts)?;
+                drop(root_guard);
+            }
+        }
+        Ok(())
+    }
+}

--- a/antlir/antlir2/antlir2/src/cmd/map.rs
+++ b/antlir/antlir2/antlir2/src/cmd/map.rs
@@ -24,6 +24,7 @@ use super::compile::Compile;
 use super::compile::CompileExternal;
 use super::plan::Plan;
 use super::plan::PlanExternal;
+use super::BuildApplianceArg;
 use super::Compileish;
 use super::CompileishExternal;
 use crate::Result;
@@ -38,8 +39,7 @@ pub(crate) struct Map {
     #[clap(flatten)]
     setup: SetupArgs,
     #[clap(long)]
-    /// Path to mounted build appliance image
-    build_appliance: PathBuf,
+    build_appliance: BuildApplianceArg,
     #[clap(long)]
     /// Use an unprivileged usernamespace
     rootless: bool,

--- a/antlir/antlir2/antlir2/src/cmd/mod.rs
+++ b/antlir/antlir2/antlir2/src/cmd/mod.rs
@@ -8,6 +8,7 @@
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use antlir2_compile::Arch;
 use antlir2_compile::CompilerContext;
@@ -21,6 +22,7 @@ use json_arg::JsonFile;
 use crate::Error;
 use crate::Result;
 
+mod cas_dir;
 mod compile;
 mod depgraph;
 mod map;
@@ -28,6 +30,7 @@ mod plan;
 mod shell;
 #[cfg(facebook)]
 use antlir2_compile::facebook::FbpkgContext;
+pub(crate) use cas_dir::CasDir;
 pub(crate) use compile::Compile;
 pub(crate) use depgraph::Depgraph;
 pub(crate) use map::Map;
@@ -46,8 +49,7 @@ struct Compileish {
     /// empty or as a snapshot of a parent layer)
     pub(crate) root: PathBuf,
     #[clap(long)]
-    /// Path to mounted build appliance image
-    pub(crate) build_appliance: PathBuf,
+    pub(crate) build_appliance: BuildApplianceArg,
     #[clap(flatten)]
     pub(crate) external: CompileishExternal,
     #[clap(flatten)]
@@ -111,7 +113,7 @@ impl Compileish {
             self.label.clone(),
             self.external.target_arch,
             self.root.clone(),
-            self.build_appliance.clone(),
+            self.build_appliance.clone().0,
             DnfContext::new(
                 self.dnf.repos.clone(),
                 dnf_versionlock,
@@ -127,5 +129,16 @@ impl Compileish {
             FbpkgContext::new(self.fbpkg.resolved_fbpkgs.clone().map(JsonFile::into_inner)),
         )
         .map_err(Error::Compile)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct BuildApplianceArg(antlir2_cas_dir::CasDir);
+
+impl FromStr for BuildApplianceArg {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self> {
+        Ok(Self(antlir2_cas_dir::CasDir::open(s)?))
     }
 }

--- a/antlir/antlir2/antlir2/src/main.rs
+++ b/antlir/antlir2/antlir2/src/main.rs
@@ -85,6 +85,7 @@ impl LogArgs {
 
 #[derive(Parser, Debug)]
 enum Subcommand {
+    CasDir(cmd::CasDir),
     Depgraph(cmd::Depgraph),
     Map(cmd::Map),
     Shell(cmd::Shell),
@@ -105,6 +106,7 @@ fn main() -> Result<()> {
         .init();
 
     let result = match args.subcommand {
+        Subcommand::CasDir(x) => x.run(rootless),
         Subcommand::Depgraph(x) => x.run(rootless),
         Subcommand::Map(x) => x.run(rootless),
         Subcommand::Shell(x) => x.run(),

--- a/antlir/antlir2/antlir2_compile/BUCK
+++ b/antlir/antlir2/antlir2_compile/BUCK
@@ -18,6 +18,7 @@ rust_library(
         "thiserror",
         "tracing",
         "xattr",
+        "//antlir/antlir2/antlir2_cas_dir:antlir2_cas_dir",
         "//antlir/antlir2/antlir2_features:antlir2_features",
         "//antlir/antlir2/antlir2_isolate:antlir2_isolate",
         "//antlir/antlir2/antlir2_users:antlir2_users",

--- a/antlir/antlir2/antlir2_compile/src/lib.rs
+++ b/antlir/antlir2/antlir2_compile/src/lib.rs
@@ -15,6 +15,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
 
+use antlir2_cas_dir::CasDir;
 use antlir2_features::Feature;
 use buck_label::Label;
 use nix::dir::Dir;
@@ -93,7 +94,7 @@ pub struct CompilerContext {
     /// Path to the root of the image being built
     root_path: PathBuf,
     /// Build appliance tree with tools that might be necessary
-    build_appliance: PathBuf,
+    build_appliance: CasDir,
     /// Open fd to the image root directory
     root: Dir,
     /// Setup information for dnf repos
@@ -160,7 +161,7 @@ impl CompilerContext {
         label: Label,
         target_arch: Arch,
         root: PathBuf,
-        build_appliance: PathBuf,
+        build_appliance: CasDir,
         dnf: DnfContext,
         plan: Option<plan::Plan>,
         #[cfg(facebook)] fbpkg: facebook::FbpkgContext,
@@ -193,7 +194,7 @@ impl CompilerContext {
         &self.root_path
     }
 
-    pub fn build_appliance(&self) -> &Path {
+    pub fn build_appliance(&self) -> &CasDir {
         &self.build_appliance
     }
 

--- a/antlir/antlir2/antlir2_facts/BUCK
+++ b/antlir/antlir2/antlir2_facts/BUCK
@@ -51,6 +51,7 @@ rust_binary(
         "tracing",
         "tracing-subscriber",
         ":antlir2_facts",
+        "//antlir/antlir2/antlir2_cas_dir:antlir2_cas_dir",
         "//antlir/antlir2/antlir2_isolate:antlir2_isolate",
         "//antlir/antlir2/antlir2_rootless:antlir2_rootless",
         "//antlir/antlir2/antlir2_systemd:antlir2_systemd",

--- a/antlir/antlir2/antlir2_isolate/isolate_unshare/isolate_unshare_preexec/src/lib.rs
+++ b/antlir/antlir2/antlir2_isolate/isolate_unshare/isolate_unshare_preexec/src/lib.rs
@@ -91,7 +91,7 @@ pub fn isolate_unshare_preexec(args: &Args) -> Result<()> {
             Some(&args.root),
             "/tmp/__antlir2__/ephemeral_lower",
             None::<&str>,
-            MsFlags::MS_BIND | MsFlags::MS_REC,
+            MsFlags::MS_BIND | MsFlags::MS_REC | MsFlags::MS_RDONLY,
             None::<&str>,
         )?;
         mount(

--- a/antlir/antlir2/antlir2_packager/src/build_appliance.rs
+++ b/antlir/antlir2/antlir2_packager/src/build_appliance.rs
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::path::Path;
+use std::path::PathBuf;
+
+use antlir2_cas_dir::CasDir;
+use serde::de::Deserializer;
+use serde::de::Error as _;
+use serde::Deserialize;
+
+#[derive(Debug, Clone)]
+pub(crate) struct BuildAppliance {
+    cas_dir: CasDir,
+}
+
+impl BuildAppliance {
+    pub(crate) fn unreliable_metadata_contents_path(&self) -> &Path {
+        self.cas_dir.unreliable_metadata_contents_path()
+    }
+}
+
+impl<'de> Deserialize<'de> for BuildAppliance {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let path = PathBuf::deserialize(deserializer)?;
+        CasDir::open(path)
+            .map_err(D::Error::custom)
+            .map(|cas_dir| Self { cas_dir })
+    }
+}

--- a/antlir/antlir2/antlir2_packager/src/ext.rs
+++ b/antlir/antlir2/antlir2_packager/src/ext.rs
@@ -21,11 +21,12 @@ use serde::Deserialize;
 use walkdir::WalkDir;
 
 use crate::run_cmd;
+use crate::BuildAppliance;
 use crate::PackageFormat;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Ext3 {
-    build_appliance: PathBuf,
+    build_appliance: BuildAppliance,
     layer: PathBuf,
     label: Option<String>,
     size_mb: Option<u64>,
@@ -37,18 +38,19 @@ impl PackageFormat for Ext3 {
         let rootless = antlir2_rootless::init().context("while initializing rootless")?;
         File::create(out).context("failed to create output file")?;
 
-        let isol_context = IsolationContext::builder(&self.build_appliance)
-            .ephemeral(false)
-            .readonly()
-            .tmpfs(Path::new("/__antlir2__/out"))
-            .outputs(("/__antlir2__/out/ext3", out))
-            .inputs((Path::new("/__antlir2__/root"), self.layer.as_path()))
-            .inputs((
-                PathBuf::from("/__antlir2__/working_directory"),
-                std::env::current_dir()?,
-            ))
-            .working_directory(Path::new("/__antlir2__/working_directory"))
-            .build();
+        let isol_context =
+            IsolationContext::builder(self.build_appliance.unreliable_metadata_contents_path())
+                .ephemeral(false)
+                .readonly()
+                .tmpfs(Path::new("/__antlir2__/out"))
+                .outputs(("/__antlir2__/out/ext3", out))
+                .inputs((Path::new("/__antlir2__/root"), self.layer.as_path()))
+                .inputs((
+                    PathBuf::from("/__antlir2__/working_directory"),
+                    std::env::current_dir()?,
+                ))
+                .working_directory(Path::new("/__antlir2__/working_directory"))
+                .build();
 
         let isol = unshare(isol_context)?;
         let mut cmd = isol.command("mkfs.ext3")?;

--- a/antlir/antlir2/antlir2_packager/src/main.rs
+++ b/antlir/antlir2/antlir2_packager/src/main.rs
@@ -28,6 +28,8 @@ mod tar;
 mod vfat;
 mod xar;
 use spec::Spec;
+mod build_appliance;
+pub(crate) use build_appliance::BuildAppliance;
 
 pub(crate) trait PackageFormat {
     fn build(&self, out: &Path) -> Result<()>;

--- a/antlir/antlir2/antlir2_packager/src/rpm.rs
+++ b/antlir/antlir2/antlir2_packager/src/rpm.rs
@@ -24,11 +24,12 @@ use serde::Deserialize;
 use tempfile::NamedTempFile;
 
 use crate::run_cmd;
+use crate::BuildAppliance;
 use crate::PackageFormat;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Rpm {
-    build_appliance: PathBuf,
+    build_appliance: BuildAppliance,
     layer: PathBuf,
     #[serde(rename = "rpm_name")]
     name: String,
@@ -223,7 +224,8 @@ License: {license}
         std::fs::create_dir(output_dir.path().join(&self.arch))
             .context("while creating output dir")?;
 
-        let mut isol_context = IsolationContext::builder(&self.build_appliance);
+        let mut isol_context =
+            IsolationContext::builder(self.build_appliance.unreliable_metadata_contents_path());
         isol_context
             .ephemeral(false)
             .readonly()
@@ -272,7 +274,8 @@ License: {license}
 
         if let Some(privkey) = &self.sign_with_private_key {
             let rpm_path = outputs[0].path();
-            let mut isol_context = IsolationContext::builder(&self.build_appliance);
+            let mut isol_context =
+                IsolationContext::builder(self.build_appliance.unreliable_metadata_contents_path());
             isol_context
                 .ephemeral(false)
                 .readonly()

--- a/antlir/antlir2/antlir2_packager/src/squashfs.rs
+++ b/antlir/antlir2/antlir2_packager/src/squashfs.rs
@@ -17,11 +17,12 @@ use anyhow::Result;
 use serde::Deserialize;
 
 use crate::run_cmd;
+use crate::BuildAppliance;
 use crate::PackageFormat;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Squashfs {
-    build_appliance: PathBuf,
+    build_appliance: BuildAppliance,
     layer: PathBuf,
 }
 
@@ -29,18 +30,19 @@ impl PackageFormat for Squashfs {
     fn build(&self, out: &Path) -> Result<()> {
         File::create(out).context("failed to create output file")?;
 
-        let isol_context = IsolationContext::builder(&self.build_appliance)
-            .ephemeral(false)
-            .readonly()
-            .tmpfs(Path::new("/__antlir2__/out"))
-            .outputs(("/__antlir2__/out/squashfs", out))
-            .inputs((Path::new("/__antlir2__/root"), self.layer.as_path()))
-            .inputs((
-                PathBuf::from("/__antlir2__/working_directory"),
-                std::env::current_dir()?,
-            ))
-            .working_directory(Path::new("/__antlir2__/working_directory"))
-            .build();
+        let isol_context =
+            IsolationContext::builder(self.build_appliance.unreliable_metadata_contents_path())
+                .ephemeral(false)
+                .readonly()
+                .tmpfs(Path::new("/__antlir2__/out"))
+                .outputs(("/__antlir2__/out/squashfs", out))
+                .inputs((Path::new("/__antlir2__/root"), self.layer.as_path()))
+                .inputs((
+                    PathBuf::from("/__antlir2__/working_directory"),
+                    std::env::current_dir()?,
+                ))
+                .working_directory(Path::new("/__antlir2__/working_directory"))
+                .build();
 
         run_cmd(
             unshare(isol_context)?

--- a/antlir/antlir2/antlir2_packager/src/tar.rs
+++ b/antlir/antlir2/antlir2_packager/src/tar.rs
@@ -17,11 +17,12 @@ use anyhow::Result;
 use serde::Deserialize;
 
 use crate::run_cmd;
+use crate::BuildAppliance;
 use crate::PackageFormat;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Tar {
-    build_appliance: PathBuf,
+    build_appliance: BuildAppliance,
     layer: PathBuf,
 }
 
@@ -29,18 +30,19 @@ impl PackageFormat for Tar {
     fn build(&self, out: &Path) -> Result<()> {
         File::create(out).context("failed to create output file")?;
 
-        let isol_context = IsolationContext::builder(&self.build_appliance)
-            .ephemeral(false)
-            .readonly()
-            .tmpfs(Path::new("/__antlir2__/out"))
-            .outputs(("/__antlir2__/out/tar", out))
-            .inputs((Path::new("/__antlir2__/root"), self.layer.as_path()))
-            .inputs((
-                PathBuf::from("/__antlir2__/working_directory"),
-                std::env::current_dir()?,
-            ))
-            .working_directory(Path::new("/__antlir2__/working_directory"))
-            .build();
+        let isol_context =
+            IsolationContext::builder(self.build_appliance.unreliable_metadata_contents_path())
+                .ephemeral(false)
+                .readonly()
+                .tmpfs(Path::new("/__antlir2__/out"))
+                .outputs(("/__antlir2__/out/tar", out))
+                .inputs((Path::new("/__antlir2__/root"), self.layer.as_path()))
+                .inputs((
+                    PathBuf::from("/__antlir2__/working_directory"),
+                    std::env::current_dir()?,
+                ))
+                .working_directory(Path::new("/__antlir2__/working_directory"))
+                .build();
 
         run_cmd(
             unshare(isol_context)?

--- a/antlir/antlir2/antlir2_rootless/src/lib.rs
+++ b/antlir/antlir2/antlir2_rootless/src/lib.rs
@@ -121,6 +121,18 @@ impl Rootless {
             setgid: self.setgid,
         })
     }
+
+    pub fn unprivileged_ids(&self) -> (Option<Uid>, Option<Gid>) {
+        (self.setuid, self.setgid)
+    }
+
+    pub fn unprivileged_uid(&self) -> Option<Uid> {
+        self.setuid
+    }
+
+    pub fn unprivileged_gid(&self) -> Option<Gid> {
+        self.setgid
+    }
 }
 
 /// As long as this [EscalationGuard] is in scope, the process will be running

--- a/antlir/antlir2/bzl/flavor/defs.bzl
+++ b/antlir/antlir2/bzl/flavor/defs.bzl
@@ -4,12 +4,12 @@
 # LICENSE file in the root directory of this source tree.
 
 load("//antlir/antlir2/bzl:platform.bzl", "rule_with_default_target_platform")
-load("//antlir/antlir2/bzl:types.bzl", "FlavorDnfInfo", "FlavorInfo", "LayerInfo")
+load("//antlir/antlir2/bzl:types.bzl", "BuildApplianceInfo", "FlavorDnfInfo", "FlavorInfo")
 # @oss-disable
 load("//antlir/antlir2/package_managers/dnf/rules:repo.bzl", "RepoSetInfo")
 
 _flavor_attrs = {
-    "default_build_appliance": attrs.dep(providers = [LayerInfo]),
+    "default_build_appliance": attrs.dep(providers = [BuildApplianceInfo]),
     "default_dnf_excluded_rpms": attrs.list(
         attrs.string(),
         default = [],

--- a/antlir/antlir2/bzl/image/facts.bzl
+++ b/antlir/antlir2/bzl/image/facts.bzl
@@ -35,7 +35,7 @@ def _new_facts_db(
             "sudo" if not rootless else cmd_args(),
             new_facts_db,
             cmd_args(subvol_symlink, format = "--root={}"),
-            cmd_args(build_appliance.subvol_symlink, format = "--build-appliance={}") if build_appliance else cmd_args(),
+            cmd_args(build_appliance.cas_dir, format = "--build-appliance={}") if build_appliance else cmd_args(),
             cmd_args(output.as_output(), format = "--db={}"),
             "--rootless" if rootless else cmd_args(),
         ),

--- a/antlir/antlir2/bzl/package/btrfs.bzl
+++ b/antlir/antlir2/bzl/package/btrfs.bzl
@@ -30,7 +30,6 @@ def _impl(ctx: AnalysisContext) -> list[Provider]:
                         "sendstream": anon_v1_sendstream(
                             ctx = ctx,
                             layer = subvol["layer"],
-                            build_appliance = ctx.attrs.build_appliance,
                         ).artifact("anon_v1_sendstream"),
                         "writable": subvol.get("writable"),
                     }
@@ -60,7 +59,6 @@ _btrfs = rule(
     attrs = {
         "antlir2_packager": attrs.default_only(attrs.exec_dep(default = antlir2_dep("//antlir/antlir2/antlir2_packager:antlir2-packager"))),
         "btrfs_packager": attrs.default_only(attrs.exec_dep(providers = [RunInfo], default = antlir2_dep("//antlir/antlir2/antlir2_packager/btrfs_packager:btrfs-packager"))),
-        "build_appliance": attrs.option(attrs.dep(providers = [LayerInfo]), default = None),
         "compression_level": attrs.int(default = 3),
         # used by transition
         "default_os": attrs.option(attrs.string(), default = None),

--- a/antlir/antlir2/bzl/package/defs.bzl
+++ b/antlir/antlir2/bzl/package/defs.bzl
@@ -5,7 +5,7 @@
 
 load("//antlir/antlir2/bzl:macro_dep.bzl", "antlir2_dep")
 load("//antlir/antlir2/bzl:platform.bzl", "arch_select")
-load("//antlir/antlir2/bzl:types.bzl", "LayerInfo")
+load("//antlir/antlir2/bzl:types.bzl", "BuildApplianceInfo", "LayerInfo")
 load("//antlir/antlir2/bzl/image:cfg.bzl", "attrs_selected_by_cfg")
 load("//antlir/buck2/bzl:ensure_single_output.bzl", "ensure_single_output")
 load(":btrfs.bzl", "btrfs")
@@ -51,7 +51,7 @@ def _generic_impl_with_layer(
 
     package = ctx.actions.declare_output(output_name, dir = is_dir)
     spec_opts = {
-        "build_appliance": build_appliance[LayerInfo].subvol_symlink,
+        "build_appliance": build_appliance[BuildApplianceInfo].cas_dir,
         "layer": layer[LayerInfo].subvol_symlink,
     }
     for key in rule_attr_keys:

--- a/antlir/antlir2/bzl/types.bzl
+++ b/antlir/antlir2/bzl/types.bzl
@@ -36,5 +36,8 @@ LayerInfo = provider(fields = [
 ])
 
 BuildApplianceInfo = provider(fields = {
-    "subvol_symlink": Artifact,
+    # For Build Appliance images, exact ownership and other fs metadata (aside
+    # from executable bits, which RE will preserve) doesn't matter, so we can
+    # directly use a plain directory as the build appliance.
+    "cas_dir": Artifact,
 })

--- a/antlir/antlir2/genrule_in_image/genrule_in_image.bzl
+++ b/antlir/antlir2/genrule_in_image/genrule_in_image.bzl
@@ -59,7 +59,6 @@ def _impl(ctx: AnalysisContext) -> list[Provider] | Promise:
 
     return ctx.actions.anon_target(layer_rule, {
         "antlir2": ctx.attrs._layer_antlir2,
-        "antlir_internal_build_appliance": False,
         "flavor": ctx.attrs.flavor,
         "parent_layer": ctx.attrs.layer,
         "rootless": ctx.attrs._rootless,
@@ -74,7 +73,6 @@ def _impl(ctx: AnalysisContext) -> list[Provider] | Promise:
 _genrule_in_image = rule(
     impl = _impl,
     attrs = {
-        "antlir_internal_build_appliance": attrs.default_only(attrs.bool(default = False, doc = "for transition")),
         "bash": attrs.arg(),
         "default_out": attrs.option(attrs.string(), default = None),
         "layer": attrs.dep(providers = [LayerInfo]),

--- a/antlir/antlir2/image_command_alias/image_command_alias.bzl
+++ b/antlir/antlir2/image_command_alias/image_command_alias.bzl
@@ -12,7 +12,6 @@ load("//antlir/antlir2/bzl/image:layer.bzl", "layer_rule")
 def _impl(ctx: AnalysisContext) -> list[Provider] | Promise:
     _anon_layer = ctx.actions.anon_target(layer_rule, {
         "antlir2": ctx.attrs._layer_antlir2,
-        "antlir_internal_build_appliance": False,
         "flavor": ctx.attrs.flavor,
         "parent_layer": ctx.attrs.layer,
         "rootless": ctx.attrs._rootless,
@@ -42,7 +41,6 @@ def _impl(ctx: AnalysisContext) -> list[Provider] | Promise:
 _image_command_alias = rule(
     impl = _impl,
     attrs = {
-        "antlir_internal_build_appliance": attrs.default_only(attrs.bool(default = False, doc = "for transition")),
         "args": attrs.list(attrs.string(), default = []),
         "exe": attrs.arg(),
         "layer": attrs.dep(providers = [LayerInfo]),

--- a/antlir/antlir2/testing/image_rpms_test.bzl
+++ b/antlir/antlir2/testing/image_rpms_test.bzl
@@ -25,7 +25,6 @@ def _rpm_names_test_impl(ctx: AnalysisContext) -> list[Provider]:
 _rpm_names_test = rule(
     impl = _rpm_names_test_impl,
     attrs = {
-        "antlir_internal_build_appliance": attrs.default_only(attrs.bool(default = False), doc = "read by cfg.bzl"),
         "image_rpms_test": attrs.default_only(attrs.exec_dep(default = "//antlir/antlir2/testing/image_rpms_test:image-rpms-test")),
         "not_installed": attrs.bool(default = False),
         "src": attrs.source(),

--- a/antlir/antlir2/testing/image_test.bzl
+++ b/antlir/antlir2/testing/image_test.bzl
@@ -119,7 +119,6 @@ def _impl(ctx: AnalysisContext) -> list[Provider]:
 _image_test = rule(
     impl = _impl,
     attrs = {
-        "antlir_internal_build_appliance": attrs.default_only(attrs.bool(default = False), doc = "read by cfg.bzl"),
         "boot": attrs.bool(
             default = False,
             doc = "boot the container with /init as pid1 before running the test",

--- a/antlir/third-party/qemu/BUCK
+++ b/antlir/third-party/qemu/BUCK
@@ -58,7 +58,7 @@ third_party.build(
 export MAKEFLAGS=-j
 
 ./configure \\
-    --target-list=x86_64-softmmu,aarch64-softmmu \\
+    --target-list=x86_64-softmmu,aarch64-softmmu,aarch64-linux-user \\
     --prefix="${OUTPUT}" \\
     --without-default-features \\
     --disable-download \\

--- a/flavor/centos9/BUCK
+++ b/flavor/centos9/BUCK
@@ -32,7 +32,6 @@ image.prebuilt(
     name = "build-appliance.prebuilt",
     src = ":build-appliance.tar.zst",
     format = "tar",
-    antlir_internal_build_appliance = True,
 )
 
 image.layer(
@@ -45,5 +44,4 @@ image.layer(
     dnf_available_repos = "//antlir/antlir2/package_managers/dnf/build_appliance:empty-dnf-reposet",
     dnf_versionlock = "//antlir/antlir2/package_managers/dnf/build_appliance:empty-dnf-versionlock.json",
     dnf_excluded_rpms = [],
-    antlir_internal_build_appliance = True,
 )


### PR DESCRIPTION
Summary:
This diff completes the untangling of layers and build appliances, which are
now completely separate things.

If we stop mutating the build appliances by adding stuff on top of the stable
images, these can be entirely deferred and won't require any local operations
before they can be made available to any RE actions.

The downside is we would lose the ability to change the dnf driver
implementation, but we can easily unbundle it from the build appliance image
and make it contained to the `rpm` feature (next diffs).

Test Plan:
```
❯ buck2 audit providers --quiet fbcode//antlir/...
```
waitforsandcastle

Differential Revision: D55970042
