### PR TITLE
[antlir][oss] set rust fixups even on transitive deps

### DIFF
--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -47,6 +47,12 @@ cargo.rust_library(
     visibility = [],
 )
 
+alias(
+    name = "ahash",
+    actual = ":ahash-0.8.11",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "ahash-0.8.11.crate",
     sha256 = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011",
@@ -61,6 +67,15 @@ cargo.rust_library(
     crate = "ahash",
     crate_root = "ahash-0.8.11.crate/src/lib.rs",
     edition = "2018",
+    env = {
+        "OUT_DIR": "$(location :ahash-0.8.11-build-script-run[out_dir])",
+    },
+    features = [
+        "default",
+        "getrandom",
+        "runtime-rng",
+        "std",
+    ],
     platform = {
         "linux-arm64": dict(
             deps = [":once_cell-1.19.0"],
@@ -81,11 +96,48 @@ cargo.rust_library(
             deps = [":once_cell-1.19.0"],
         ),
     },
+    rustc_flags = ["@$(location :ahash-0.8.11-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [
         ":cfg-if-1.0.0",
+        ":getrandom-0.2.14",
         ":zerocopy-0.7.32",
     ],
+)
+
+cargo.rust_binary(
+    name = "ahash-0.8.11-build-script-build",
+    srcs = [":ahash-0.8.11.crate"],
+    crate = "build_script_build",
+    crate_root = "ahash-0.8.11.crate/build.rs",
+    edition = "2018",
+    features = [
+        "default",
+        "getrandom",
+        "runtime-rng",
+        "std",
+    ],
+    visibility = [],
+    deps = [":version_check-0.9.4"],
+)
+
+buildscript_run(
+    name = "ahash-0.8.11-build-script-run",
+    package_name = "ahash",
+    buildscript_rule = ":ahash-0.8.11-build-script-build",
+    features = [
+        "default",
+        "getrandom",
+        "runtime-rng",
+        "std",
+    ],
+    version = "0.8.11",
+)
+
+alias(
+    name = "aho-corasick",
+    actual = ":aho-corasick-1.1.3",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -157,6 +209,12 @@ cargo.rust_library(
     deps = [":unicode-width-0.1.11"],
 )
 
+alias(
+    name = "ansi_term",
+    actual = ":ansi_term-0.12.1",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "ansi_term-0.12.1.crate",
     sha256 = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2",
@@ -180,6 +238,12 @@ cargo.rust_library(
         ),
     },
     visibility = [],
+)
+
+alias(
+    name = "anstream",
+    actual = ":anstream-0.6.13",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -217,6 +281,12 @@ cargo.rust_library(
         ":colorchoice-1.0.0",
         ":utf8parse-0.2.1",
     ],
+)
+
+alias(
+    name = "anstyle",
+    actual = ":anstyle-1.0.6",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -431,6 +501,24 @@ cargo.rust_library(
     visibility = [],
 )
 
+http_archive(
+    name = "ascii-canvas-3.0.0.crate",
+    sha256 = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6",
+    strip_prefix = "ascii-canvas-3.0.0",
+    urls = ["https://static.crates.io/crates/ascii-canvas/3.0.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "ascii-canvas-3.0.0",
+    srcs = [":ascii-canvas-3.0.0.crate"],
+    crate = "ascii_canvas",
+    crate_root = "ascii-canvas-3.0.0.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [":term-0.7.0"],
+)
+
 alias(
     name = "async-trait",
     actual = ":async-trait-0.1.80",
@@ -460,6 +548,12 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "atomic",
+    actual = ":atomic-0.5.3",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "atomic-0.5.3.crate",
     sha256 = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba",
@@ -474,6 +568,10 @@ cargo.rust_library(
     crate = "atomic",
     crate_root = "atomic-0.5.3.crate/src/lib.rs",
     edition = "2018",
+    features = [
+        "default",
+        "fallback",
+    ],
     visibility = [],
 )
 
@@ -573,6 +671,135 @@ cargo.rust_library(
     crate_root = "beef-0.5.2.crate/src/lib.rs",
     edition = "2018",
     features = ["default"],
+    visibility = [],
+)
+
+alias(
+    name = "bindgen",
+    actual = ":bindgen-0.69.4",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "bindgen-0.69.4.crate",
+    sha256 = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0",
+    strip_prefix = "bindgen-0.69.4",
+    urls = ["https://static.crates.io/crates/bindgen/0.69.4/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "bindgen-0.69.4",
+    srcs = [":bindgen-0.69.4.crate"],
+    crate = "bindgen",
+    crate_root = "bindgen-0.69.4.crate/lib.rs",
+    edition = "2018",
+    env = {
+        "OUT_DIR": "$(location :bindgen-0.69.4-build-script-run[out_dir])",
+    },
+    features = [
+        "logging",
+        "prettyplease",
+        "static",
+    ],
+    rustc_flags = ["@$(location :bindgen-0.69.4-build-script-run[rustc_flags])"],
+    visibility = [],
+    deps = [
+        ":bitflags-2.5.0",
+        ":cexpr-0.6.0",
+        ":clang-sys-1.7.0",
+        ":itertools-0.12.1",
+        ":lazy_static-1.4.0",
+        ":lazycell-1.3.0",
+        ":log-0.4.21",
+        ":prettyplease-0.2.19",
+        ":proc-macro2-1.0.81",
+        ":quote-1.0.36",
+        ":regex-1.10.4",
+        ":rustc-hash-1.1.0",
+        ":shlex-1.3.0",
+        ":syn-2.0.60",
+    ],
+)
+
+cargo.rust_binary(
+    name = "bindgen-0.69.4-build-script-build",
+    srcs = [":bindgen-0.69.4.crate"],
+    crate = "build_script_build",
+    crate_root = "bindgen-0.69.4.crate/build.rs",
+    edition = "2018",
+    features = [
+        "logging",
+        "prettyplease",
+        "static",
+    ],
+    visibility = [],
+)
+
+buildscript_run(
+    name = "bindgen-0.69.4-build-script-run",
+    package_name = "bindgen",
+    buildscript_rule = ":bindgen-0.69.4-build-script-build",
+    features = [
+        "logging",
+        "prettyplease",
+        "static",
+    ],
+    version = "0.69.4",
+)
+
+alias(
+    name = "bit-set",
+    actual = ":bit-set-0.5.3",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "bit-set-0.5.3.crate",
+    sha256 = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1",
+    strip_prefix = "bit-set-0.5.3",
+    urls = ["https://static.crates.io/crates/bit-set/0.5.3/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "bit-set-0.5.3",
+    srcs = [":bit-set-0.5.3.crate"],
+    crate = "bit_set",
+    crate_root = "bit-set-0.5.3.crate/src/lib.rs",
+    edition = "2015",
+    features = [
+        "default",
+        "std",
+    ],
+    visibility = [],
+    deps = [":bit-vec-0.6.3"],
+)
+
+alias(
+    name = "bit-vec",
+    actual = ":bit-vec-0.6.3",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "bit-vec-0.6.3.crate",
+    sha256 = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb",
+    strip_prefix = "bit-vec-0.6.3",
+    urls = ["https://static.crates.io/crates/bit-vec/0.6.3/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "bit-vec-0.6.3",
+    srcs = [":bit-vec-0.6.3.crate"],
+    crate = "bit_vec",
+    crate_root = "bit-vec-0.6.3.crate/src/lib.rs",
+    edition = "2015",
+    features = [
+        "default",
+        "std",
+    ],
     visibility = [],
 )
 
@@ -755,6 +982,12 @@ cargo.rust_library(
     visibility = [],
 )
 
+alias(
+    name = "byteorder",
+    actual = ":byteorder-1.5.0",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "byteorder-1.5.0.crate",
     sha256 = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b",
@@ -893,6 +1126,47 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "cexpr-0.6.0.crate",
+    sha256 = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766",
+    strip_prefix = "cexpr-0.6.0",
+    urls = ["https://static.crates.io/crates/cexpr/0.6.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "cexpr-0.6.0",
+    srcs = [":cexpr-0.6.0.crate"],
+    crate = "cexpr",
+    crate_root = "cexpr-0.6.0.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [":nom-7.1.3"],
+)
+
+alias(
+    name = "cfg-if",
+    actual = ":cfg-if-0.1.10",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "cfg-if-0.1.10.crate",
+    sha256 = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822",
+    strip_prefix = "cfg-if-0.1.10",
+    urls = ["https://static.crates.io/crates/cfg-if/0.1.10/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "cfg-if-0.1.10",
+    srcs = [":cfg-if-0.1.10.crate"],
+    crate = "cfg_if",
+    crate_root = "cfg-if-0.1.10.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+)
+
+http_archive(
     name = "cfg-if-1.0.0.crate",
     sha256 = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
     strip_prefix = "cfg-if-1.0.0",
@@ -972,6 +1246,12 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "chrono-tz",
+    actual = ":chrono-tz-0.8.6",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "chrono-tz-0.8.6.crate",
     sha256 = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e",
@@ -994,6 +1274,53 @@ cargo.rust_library(
     deps = [
         ":chrono-0.4.38",
         ":phf-0.11.2",
+    ],
+)
+
+alias(
+    name = "clang-sys",
+    actual = ":clang-sys-1.7.0",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "clang-sys-1.7.0.crate",
+    sha256 = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1",
+    strip_prefix = "clang-sys-1.7.0",
+    urls = ["https://static.crates.io/crates/clang-sys/1.7.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "clang-sys-1.7.0",
+    srcs = [":clang-sys-1.7.0.crate"],
+    crate = "clang_sys",
+    crate_root = "clang-sys-1.7.0.crate/src/lib.rs",
+    edition = "2015",
+    features = [
+        "clang_10_0",
+        "clang_11_0",
+        "clang_12_0",
+        "clang_3_5",
+        "clang_3_6",
+        "clang_3_7",
+        "clang_3_8",
+        "clang_3_9",
+        "clang_4_0",
+        "clang_5_0",
+        "clang_6_0",
+        "clang_7_0",
+        "clang_8_0",
+        "clang_9_0",
+        "libloading",
+        "runtime",
+        "static",
+    ],
+    visibility = [],
+    deps = [
+        ":glob-0.3.1",
+        ":libc-0.2.153",
+        ":libloading-0.8.3",
     ],
 )
 
@@ -1298,6 +1625,33 @@ cargo.rust_library(
     visibility = [],
 )
 
+alias(
+    name = "codespan-reporting",
+    actual = ":codespan-reporting-0.11.1",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "codespan-reporting-0.11.1.crate",
+    sha256 = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e",
+    strip_prefix = "codespan-reporting-0.11.1",
+    urls = ["https://static.crates.io/crates/codespan-reporting/0.11.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "codespan-reporting-0.11.1",
+    srcs = [":codespan-reporting-0.11.1.crate"],
+    crate = "codespan_reporting",
+    crate_root = "codespan-reporting-0.11.1.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [
+        ":termcolor-1.4.1",
+        ":unicode-width-0.1.11",
+    ],
+)
+
 http_archive(
     name = "colorchoice-1.0.0.crate",
     sha256 = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7",
@@ -1400,6 +1754,12 @@ cargo.rust_library(
     deps = [":indexmap-2.2.6"],
 )
 
+alias(
+    name = "console",
+    actual = ":console-0.15.8",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "console-0.15.8.crate",
     sha256 = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb",
@@ -1414,6 +1774,11 @@ cargo.rust_library(
     crate = "console",
     crate_root = "console-0.15.8.crate/src/lib.rs",
     edition = "2018",
+    features = [
+        "ansi-parsing",
+        "default",
+        "unicode-width",
+    ],
     platform = {
         "windows-gnu": dict(
             deps = [
@@ -1432,6 +1797,7 @@ cargo.rust_library(
     deps = [
         ":lazy_static-1.4.0",
         ":libc-0.2.153",
+        ":unicode-width-0.1.11",
     ],
 )
 
@@ -1456,6 +1822,12 @@ cargo.rust_library(
     crate_root = "const-cstr-0.3.0.crate/src/lib.rs",
     edition = "2015",
     visibility = [],
+)
+
+alias(
+    name = "convert_case",
+    actual = ":convert_case-0.4.0",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -1546,6 +1918,12 @@ cargo.rust_library(
     visibility = [],
 )
 
+alias(
+    name = "crc",
+    actual = ":crc-3.2.1",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "crc-3.2.1.crate",
     sha256 = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636",
@@ -1619,12 +1997,46 @@ cargo.rust_library(
     crate = "crc32fast",
     crate_root = "crc32fast-1.4.0.crate/src/lib.rs",
     edition = "2015",
+    env = {
+        "OUT_DIR": "$(location :crc32fast-1.4.0-build-script-run[out_dir])",
+    },
+    features = [
+        "default",
+        "std",
+    ],
+    rustc_flags = ["@$(location :crc32fast-1.4.0-build-script-run[rustc_flags])"],
+    visibility = [],
+    deps = [":cfg-if-1.0.0"],
+)
+
+cargo.rust_binary(
+    name = "crc32fast-1.4.0-build-script-build",
+    srcs = [":crc32fast-1.4.0.crate"],
+    crate = "build_script_build",
+    crate_root = "crc32fast-1.4.0.crate/build.rs",
+    edition = "2015",
     features = [
         "default",
         "std",
     ],
     visibility = [],
-    deps = [":cfg-if-1.0.0"],
+)
+
+buildscript_run(
+    name = "crc32fast-1.4.0-build-script-run",
+    package_name = "crc32fast",
+    buildscript_rule = ":crc32fast-1.4.0-build-script-build",
+    features = [
+        "default",
+        "std",
+    ],
+    version = "1.4.0",
+)
+
+alias(
+    name = "crossbeam",
+    actual = ":crossbeam-0.8.4",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -1660,6 +2072,12 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "crossbeam-channel",
+    actual = ":crossbeam-channel-0.5.12",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "crossbeam-channel-0.5.12.crate",
     sha256 = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95",
@@ -1674,7 +2092,10 @@ cargo.rust_library(
     crate = "crossbeam_channel",
     crate_root = "crossbeam-channel-0.5.12.crate/src/lib.rs",
     edition = "2021",
-    features = ["std"],
+    features = [
+        "default",
+        "std",
+    ],
     visibility = [],
     deps = [":crossbeam-utils-0.8.19"],
 )
@@ -1767,6 +2188,55 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
+)
+
+http_archive(
+    name = "crunchy-0.2.2.crate",
+    sha256 = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7",
+    strip_prefix = "crunchy-0.2.2",
+    urls = ["https://static.crates.io/crates/crunchy/0.2.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "crunchy-0.2.2",
+    srcs = [":crunchy-0.2.2.crate"],
+    crate = "crunchy",
+    crate_root = "crunchy-0.2.2.crate/src/lib.rs",
+    edition = "2015",
+    env = {
+        "OUT_DIR": "$(location :crunchy-0.2.2-build-script-run[out_dir])",
+    },
+    features = [
+        "default",
+        "limit_128",
+    ],
+    rustc_flags = ["@$(location :crunchy-0.2.2-build-script-run[rustc_flags])"],
+    visibility = [],
+)
+
+cargo.rust_binary(
+    name = "crunchy-0.2.2-build-script-build",
+    srcs = [":crunchy-0.2.2.crate"],
+    crate = "build_script_build",
+    crate_root = "crunchy-0.2.2.crate/build.rs",
+    edition = "2015",
+    features = [
+        "default",
+        "limit_128",
+    ],
+    visibility = [],
+)
+
+buildscript_run(
+    name = "crunchy-0.2.2-build-script-run",
+    package_name = "crunchy",
+    buildscript_rule = ":crunchy-0.2.2-build-script-build",
+    features = [
+        "default",
+        "limit_128",
+    ],
+    version = "0.2.2",
 )
 
 http_archive(
@@ -1949,6 +2419,12 @@ cargo.rust_library(
         ":darling_core-0.13.4",
         ":darling_macro-0.13.4",
     ],
+)
+
+alias(
+    name = "darling",
+    actual = ":darling-0.14.4",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -2144,29 +2620,6 @@ cargo.rust_library(
     ],
 )
 
-http_archive(
-    name = "deranged-0.3.11.crate",
-    sha256 = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4",
-    strip_prefix = "deranged-0.3.11",
-    urls = ["https://static.crates.io/crates/deranged/0.3.11/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "deranged-0.3.11",
-    srcs = [":deranged-0.3.11.crate"],
-    crate = "deranged",
-    crate_root = "deranged-0.3.11.crate/src/lib.rs",
-    edition = "2021",
-    features = [
-        "alloc",
-        "powerfmt",
-        "std",
-    ],
-    visibility = [],
-    deps = [":powerfmt-0.2.0"],
-)
-
 alias(
     name = "derivative",
     actual = ":derivative-2.2.0",
@@ -2348,6 +2801,12 @@ cargo.rust_library(
     visibility = [],
 )
 
+alias(
+    name = "diff",
+    actual = ":diff-0.1.13",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "diff-0.1.13.crate",
     sha256 = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8",
@@ -2366,6 +2825,30 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "difference-2.0.0.crate",
+    sha256 = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198",
+    strip_prefix = "difference-2.0.0",
+    urls = ["https://static.crates.io/crates/difference/2.0.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "difference-2.0.0",
+    srcs = [":difference-2.0.0.crate"],
+    crate = "difference",
+    crate_root = "difference-2.0.0.crate/src/lib.rs",
+    edition = "2015",
+    features = ["default"],
+    visibility = [],
+)
+
+alias(
+    name = "difflib",
+    actual = ":difflib-0.4.0",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
     name = "difflib-0.4.0.crate",
     sha256 = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8",
     strip_prefix = "difflib-0.4.0",
@@ -2380,6 +2863,12 @@ cargo.rust_library(
     crate_root = "difflib-0.4.0.crate/src/lib.rs",
     edition = "2015",
     visibility = [],
+)
+
+alias(
+    name = "digest",
+    actual = ":digest-0.10.7",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -2540,6 +3029,24 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "ena-0.14.2.crate",
+    sha256 = "c533630cf40e9caa44bd91aadc88a75d75a4c3a12b4cfde353cbed41daa1e1f1",
+    strip_prefix = "ena-0.14.2",
+    urls = ["https://static.crates.io/crates/ena/0.14.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "ena-0.14.2",
+    srcs = [":ena-0.14.2.crate"],
+    crate = "ena",
+    crate_root = "ena-0.14.2.crate/src/lib.rs",
+    edition = "2015",
+    visibility = [],
+    deps = [":log-0.4.21"],
+)
+
+http_archive(
     name = "encode_unicode-0.3.6.crate",
     sha256 = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f",
     strip_prefix = "encode_unicode-0.3.6",
@@ -2575,6 +3082,43 @@ cargo.rust_library(
     crate_root = "endian-type-0.1.2.crate/src/lib.rs",
     edition = "2015",
     visibility = [],
+)
+
+alias(
+    name = "env_logger",
+    actual = ":env_logger-0.10.2",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "env_logger-0.10.2.crate",
+    sha256 = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580",
+    strip_prefix = "env_logger-0.10.2",
+    urls = ["https://static.crates.io/crates/env_logger/0.10.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "env_logger-0.10.2",
+    srcs = [":env_logger-0.10.2.crate"],
+    crate = "env_logger",
+    crate_root = "env_logger-0.10.2.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "auto-color",
+        "color",
+        "default",
+        "humantime",
+        "regex",
+    ],
+    visibility = [],
+    deps = [
+        ":humantime-2.1.0",
+        ":is-terminal-0.4.12",
+        ":log-0.4.21",
+        ":regex-1.10.4",
+        ":termcolor-1.4.1",
+    ],
 )
 
 http_archive(
@@ -2664,7 +3208,10 @@ cargo.rust_library(
     crate = "erased_serde",
     crate_root = "erased-serde-0.4.4.crate/src/lib.rs",
     edition = "2021",
-    features = ["alloc"],
+    features = [
+        "alloc",
+        "std",
+    ],
     visibility = [],
     deps = [":serde-1.0.198"],
 )
@@ -2858,6 +3405,12 @@ cargo.rust_library(
     deps = [":cfg-if-1.0.0"],
 )
 
+alias(
+    name = "filetime",
+    actual = ":filetime-0.2.23",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "filetime-0.2.23.crate",
     sha256 = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd",
@@ -2946,6 +3499,35 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "float-cmp-0.8.0.crate",
+    sha256 = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4",
+    strip_prefix = "float-cmp-0.8.0",
+    urls = ["https://static.crates.io/crates/float-cmp/0.8.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "float-cmp-0.8.0",
+    srcs = [":float-cmp-0.8.0.crate"],
+    crate = "float_cmp",
+    crate_root = "float-cmp-0.8.0.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "default",
+        "num-traits",
+        "ratio",
+    ],
+    visibility = [],
+    deps = [":num-traits-0.2.18"],
+)
+
+alias(
+    name = "float-cmp",
+    actual = ":float-cmp-0.9.0",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
     name = "float-cmp-0.9.0.crate",
     sha256 = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4",
     strip_prefix = "float-cmp-0.9.0",
@@ -2995,6 +3577,12 @@ cargo.rust_library(
     visibility = [],
 )
 
+alias(
+    name = "foreign-types",
+    actual = ":foreign-types-0.3.2",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "foreign-types-0.3.2.crate",
     sha256 = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1",
@@ -3011,6 +3599,12 @@ cargo.rust_library(
     edition = "2015",
     visibility = [],
     deps = [":foreign-types-shared-0.1.1"],
+)
+
+alias(
+    name = "foreign-types-shared",
+    actual = ":foreign-types-shared-0.1.1",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -3133,6 +3727,12 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "futures-channel",
+    actual = ":futures-channel-0.3.30",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "futures-channel-0.3.30.crate",
     sha256 = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78",
@@ -3161,6 +3761,12 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "futures-core",
+    actual = ":futures-core-0.3.30",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "futures-core-0.3.30.crate",
     sha256 = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d",
@@ -3183,6 +3789,12 @@ cargo.rust_library(
     visibility = [],
 )
 
+alias(
+    name = "futures-executor",
+    actual = ":futures-executor-0.3.30",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "futures-executor-0.3.30.crate",
     sha256 = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d",
@@ -3197,7 +3809,10 @@ cargo.rust_library(
     crate = "futures_executor",
     crate_root = "futures-executor-0.3.30.crate/src/lib.rs",
     edition = "2018",
-    features = ["std"],
+    features = [
+        "default",
+        "std",
+    ],
     visibility = [],
     deps = [
         ":futures-core-0.3.30",
@@ -3310,6 +3925,12 @@ cargo.rust_library(
     visibility = [],
 )
 
+alias(
+    name = "futures-util",
+    actual = ":futures-util-0.3.30",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "futures-util-0.3.30.crate",
     sha256 = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48",
@@ -3403,6 +4024,12 @@ cargo.rust_library(
     deps = [":typenum-1.17.0"],
 )
 
+alias(
+    name = "getrandom",
+    actual = ":getrandom-0.2.14",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "getrandom-0.2.14.crate",
     sha256 = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c",
@@ -3417,7 +4044,10 @@ cargo.rust_library(
     crate = "getrandom",
     crate_root = "getrandom-0.2.14.crate/src/lib.rs",
     edition = "2018",
-    features = ["std"],
+    features = [
+        "custom",
+        "std",
+    ],
     platform = {
         "linux-arm64": dict(
             deps = [":libc-0.2.153"],
@@ -3465,6 +4095,12 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "glob",
+    actual = ":glob-0.3.1",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "glob-0.3.1.crate",
     sha256 = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b",
@@ -3480,6 +4116,12 @@ cargo.rust_library(
     crate_root = "glob-0.3.1.crate/src/lib.rs",
     edition = "2015",
     visibility = [],
+)
+
+alias(
+    name = "globset",
+    actual = ":globset-0.4.14",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -3499,6 +4141,8 @@ cargo.rust_library(
     features = [
         "default",
         "log",
+        "serde",
+        "serde1",
     ],
     visibility = [],
     deps = [
@@ -3507,7 +4151,14 @@ cargo.rust_library(
         ":log-0.4.21",
         ":regex-automata-0.4.6",
         ":regex-syntax-0.8.3",
+        ":serde-1.0.198",
     ],
+)
+
+alias(
+    name = "globwalk",
+    actual = ":globwalk-0.8.1",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -3726,6 +4377,12 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "heck",
+    actual = ":heck-0.3.3",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "heck-0.3.3.crate",
     sha256 = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c",
@@ -3807,6 +4464,31 @@ cargo.rust_library(
     visibility = [],
 )
 
+http_archive(
+    name = "home-0.5.9.crate",
+    sha256 = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5",
+    strip_prefix = "home-0.5.9",
+    urls = ["https://static.crates.io/crates/home/0.5.9/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "home-0.5.9",
+    srcs = [":home-0.5.9.crate"],
+    crate = "home",
+    crate_root = "home-0.5.9.crate/src/lib.rs",
+    edition = "2021",
+    platform = {
+        "windows-gnu": dict(
+            deps = [":windows-sys-0.52.0"],
+        ),
+        "windows-msvc": dict(
+            deps = [":windows-sys-0.52.0"],
+        ),
+    },
+    visibility = [],
+)
+
 alias(
     name = "http",
     actual = ":http-0.2.12",
@@ -3835,6 +4517,12 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "http-body",
+    actual = ":http-body-0.4.6",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "http-body-0.4.6.crate",
     sha256 = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2",
@@ -3857,6 +4545,12 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "httparse",
+    actual = ":httparse-1.8.0",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "httparse-1.8.0.crate",
     sha256 = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904",
@@ -3871,11 +4565,39 @@ cargo.rust_library(
     crate = "httparse",
     crate_root = "httparse-1.8.0.crate/src/lib.rs",
     edition = "2018",
+    env = {
+        "OUT_DIR": "$(location :httparse-1.8.0-build-script-run[out_dir])",
+    },
+    features = [
+        "default",
+        "std",
+    ],
+    rustc_flags = ["@$(location :httparse-1.8.0-build-script-run[rustc_flags])"],
+    visibility = [],
+)
+
+cargo.rust_binary(
+    name = "httparse-1.8.0-build-script-build",
+    srcs = [":httparse-1.8.0.crate"],
+    crate = "build_script_build",
+    crate_root = "httparse-1.8.0.crate/build.rs",
+    edition = "2018",
     features = [
         "default",
         "std",
     ],
     visibility = [],
+)
+
+buildscript_run(
+    name = "httparse-1.8.0-build-script-run",
+    package_name = "httparse",
+    buildscript_rule = ":httparse-1.8.0-build-script-build",
+    features = [
+        "default",
+        "std",
+    ],
+    version = "1.8.0",
 )
 
 http_archive(
@@ -3911,6 +4633,29 @@ cargo.rust_library(
     edition = "2021",
     visibility = [],
     deps = [":libm-0.2.8"],
+)
+
+alias(
+    name = "humantime",
+    actual = ":humantime-2.1.0",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "humantime-2.1.0.crate",
+    sha256 = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4",
+    strip_prefix = "humantime-2.1.0",
+    urls = ["https://static.crates.io/crates/humantime/2.1.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "humantime-2.1.0",
+    srcs = [":humantime-2.1.0.crate"],
+    crate = "humantime",
+    crate_root = "humantime-2.1.0.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
 )
 
 alias(
@@ -4067,6 +4812,12 @@ cargo.rust_library(
         ":unicode-bidi-0.3.15",
         ":unicode-normalization-0.1.23",
     ],
+)
+
+alias(
+    name = "ignore",
+    actual = ":ignore-0.4.22",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -4365,6 +5116,24 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "itertools-0.12.1.crate",
+    sha256 = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569",
+    strip_prefix = "itertools-0.12.1",
+    urls = ["https://static.crates.io/crates/itertools/0.12.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "itertools-0.12.1",
+    srcs = [":itertools-0.12.1.crate"],
+    crate = "itertools",
+    crate_root = "itertools-0.12.1.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [":either-1.11.0"],
+)
+
+http_archive(
     name = "itoa-1.0.11.crate",
     sha256 = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b",
     strip_prefix = "itoa-1.0.11",
@@ -4440,6 +5209,89 @@ cargo.rust_library(
 )
 
 alias(
+    name = "lalrpop",
+    actual = ":lalrpop-0.19.12",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "lalrpop-0.19.12.crate",
+    sha256 = "0a1cbf952127589f2851ab2046af368fd20645491bb4b376f04b7f94d7a9837b",
+    strip_prefix = "lalrpop-0.19.12",
+    urls = ["https://static.crates.io/crates/lalrpop/0.19.12/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "lalrpop-0.19.12",
+    srcs = [":lalrpop-0.19.12.crate"],
+    crate = "lalrpop",
+    crate_root = "lalrpop-0.19.12.crate/src/lib.rs",
+    edition = "2015",
+    features = [
+        "default",
+        "lexer",
+        "pico-args",
+    ],
+    visibility = [],
+    deps = [
+        ":ascii-canvas-3.0.0",
+        ":bit-set-0.5.3",
+        ":diff-0.1.13",
+        ":ena-0.14.2",
+        ":is-terminal-0.4.12",
+        ":itertools-0.10.5",
+        ":lalrpop-util-0.19.12",
+        ":petgraph-0.6.4",
+        ":pico-args-0.4.2",
+        ":regex-1.10.4",
+        ":regex-syntax-0.6.29",
+        ":string_cache-0.8.7",
+        ":term-0.7.0",
+        ":tiny-keccak-2.0.2",
+        ":unicode-xid-0.2.4",
+    ],
+)
+
+alias(
+    name = "lalrpop-lalrpop",
+    actual = ":lalrpop-0.19.12-lalrpop",
+    visibility = ["PUBLIC"],
+)
+
+cargo.rust_binary(
+    name = "lalrpop-0.19.12-lalrpop",
+    srcs = [":lalrpop-0.19.12.crate"],
+    crate = "lalrpop",
+    crate_root = "lalrpop-0.19.12.crate/src/main.rs",
+    edition = "2015",
+    features = [
+        "default",
+        "lexer",
+        "pico-args",
+    ],
+    visibility = [],
+    deps = [
+        ":ascii-canvas-3.0.0",
+        ":bit-set-0.5.3",
+        ":diff-0.1.13",
+        ":ena-0.14.2",
+        ":is-terminal-0.4.12",
+        ":itertools-0.10.5",
+        ":lalrpop-0.19.12",
+        ":lalrpop-util-0.19.12",
+        ":petgraph-0.6.4",
+        ":pico-args-0.4.2",
+        ":regex-1.10.4",
+        ":regex-syntax-0.6.29",
+        ":string_cache-0.8.7",
+        ":term-0.7.0",
+        ":tiny-keccak-2.0.2",
+        ":unicode-xid-0.2.4",
+    ],
+)
+
+alias(
     name = "lalrpop-util",
     actual = ":lalrpop-util-0.19.12",
     visibility = ["PUBLIC"],
@@ -4461,9 +5313,12 @@ cargo.rust_library(
     edition = "2018",
     features = [
         "default",
+        "lexer",
+        "regex",
         "std",
     ],
     visibility = [],
+    deps = [":regex-1.10.4"],
 )
 
 alias(
@@ -4485,6 +5340,23 @@ cargo.rust_library(
     srcs = [":lazy_static-1.4.0.crate"],
     crate = "lazy_static",
     crate_root = "lazy_static-1.4.0.crate/src/lib.rs",
+    edition = "2015",
+    visibility = [],
+)
+
+http_archive(
+    name = "lazycell-1.3.0.crate",
+    sha256 = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55",
+    strip_prefix = "lazycell-1.3.0",
+    urls = ["https://static.crates.io/crates/lazycell/1.3.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "lazycell-1.3.0",
+    srcs = [":lazycell-1.3.0.crate"],
+    crate = "lazycell",
+    crate_root = "lazycell-1.3.0.crate/src/lib.rs",
     edition = "2015",
     visibility = [],
 )
@@ -4591,6 +5463,49 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "libloading-0.8.3.crate",
+    sha256 = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19",
+    strip_prefix = "libloading-0.8.3",
+    urls = ["https://static.crates.io/crates/libloading/0.8.3/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "libloading-0.8.3",
+    srcs = [":libloading-0.8.3.crate"],
+    crate = "libloading",
+    crate_root = "libloading-0.8.3.crate/src/lib.rs",
+    edition = "2015",
+    platform = {
+        "linux-arm64": dict(
+            deps = [":cfg-if-1.0.0"],
+        ),
+        "linux-x86_64": dict(
+            deps = [":cfg-if-1.0.0"],
+        ),
+        "macos-arm64": dict(
+            deps = [":cfg-if-1.0.0"],
+        ),
+        "macos-x86_64": dict(
+            deps = [":cfg-if-1.0.0"],
+        ),
+        "windows-gnu": dict(
+            deps = [":windows-targets-0.52.5"],
+        ),
+        "windows-msvc": dict(
+            deps = [":windows-targets-0.52.5"],
+        ),
+    },
+    visibility = [],
+)
+
+alias(
+    name = "libm",
+    actual = ":libm-0.2.8",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
     name = "libm-0.2.8.crate",
     sha256 = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058",
     strip_prefix = "libm-0.2.8",
@@ -4604,8 +5519,59 @@ cargo.rust_library(
     crate = "libm",
     crate_root = "libm-0.2.8.crate/src/lib.rs",
     edition = "2018",
+    env = {
+        "OUT_DIR": "$(location :libm-0.2.8-build-script-run[out_dir])",
+    },
+    features = ["default"],
+    rustc_flags = ["@$(location :libm-0.2.8-build-script-run[rustc_flags])"],
+    visibility = [],
+)
+
+cargo.rust_binary(
+    name = "libm-0.2.8-build-script-build",
+    srcs = [":libm-0.2.8.crate"],
+    crate = "build_script_build",
+    crate_root = "libm-0.2.8.crate/build.rs",
+    edition = "2018",
     features = ["default"],
     visibility = [],
+)
+
+buildscript_run(
+    name = "libm-0.2.8-build-script-run",
+    package_name = "libm",
+    buildscript_rule = ":libm-0.2.8-build-script-build",
+    features = ["default"],
+    version = "0.2.8",
+)
+
+alias(
+    name = "libz-sys",
+    actual = ":libz-sys-1.1.16",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "libz-sys-1.1.16.crate",
+    sha256 = "5e143b5e666b2695d28f6bca6497720813f699c9602dd7f5cac91008b8ada7f9",
+    strip_prefix = "libz-sys-1.1.16",
+    urls = ["https://static.crates.io/crates/libz-sys/1.1.16/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "libz-sys-1.1.16",
+    srcs = [":libz-sys-1.1.16.crate"],
+    crate = "libz_sys",
+    crate_root = "libz-sys-1.1.16.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "default",
+        "libc",
+        "stock-zlib",
+    ],
+    visibility = [],
+    deps = [":libc-0.2.153"],
 )
 
 http_archive(
@@ -4688,12 +5654,47 @@ cargo.rust_library(
     crate = "lock_api",
     crate_root = "lock_api-0.4.11.crate/src/lib.rs",
     edition = "2018",
+    env = {
+        "OUT_DIR": "$(location :lock_api-0.4.11-build-script-run[out_dir])",
+    },
+    features = [
+        "atomic_usize",
+        "default",
+    ],
+    rustc_flags = ["@$(location :lock_api-0.4.11-build-script-run[rustc_flags])"],
+    visibility = [],
+    deps = [":scopeguard-1.2.0"],
+)
+
+cargo.rust_binary(
+    name = "lock_api-0.4.11-build-script-build",
+    srcs = [":lock_api-0.4.11.crate"],
+    crate = "build_script_build",
+    crate_root = "lock_api-0.4.11.crate/build.rs",
+    edition = "2018",
     features = [
         "atomic_usize",
         "default",
     ],
     visibility = [],
-    deps = [":scopeguard-1.2.0"],
+    deps = [":autocfg-1.2.0"],
+)
+
+buildscript_run(
+    name = "lock_api-0.4.11-build-script-run",
+    package_name = "lock_api",
+    buildscript_rule = ":lock_api-0.4.11-build-script-build",
+    features = [
+        "atomic_usize",
+        "default",
+    ],
+    version = "0.4.11",
+)
+
+alias(
+    name = "log",
+    actual = ":log-0.4.21",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -4710,8 +5711,16 @@ cargo.rust_library(
     crate = "log",
     crate_root = "log-0.4.21.crate/src/lib.rs",
     edition = "2021",
-    features = ["std"],
+    features = [
+        "kv",
+        "kv_std",
+        "kv_unstable",
+        "kv_unstable_std",
+        "std",
+        "value-bag",
+    ],
     visibility = [],
+    deps = [":value-bag-1.8.1"],
 )
 
 alias(
@@ -5095,6 +6104,12 @@ cargo.rust_library(
     visibility = [],
 )
 
+alias(
+    name = "miniz_oxide",
+    actual = ":miniz_oxide-0.7.2",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "miniz_oxide-0.7.2.crate",
     sha256 = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7",
@@ -5109,9 +6124,73 @@ cargo.rust_library(
     crate = "miniz_oxide",
     crate_root = "miniz_oxide-0.7.2.crate/src/lib.rs",
     edition = "2018",
-    features = ["with-alloc"],
+    features = [
+        "default",
+        "with-alloc",
+    ],
     visibility = [],
     deps = [":adler-1.0.2"],
+)
+
+alias(
+    name = "mio",
+    actual = ":mio-0.7.14",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "mio-0.7.14.crate",
+    sha256 = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc",
+    strip_prefix = "mio-0.7.14",
+    urls = ["https://static.crates.io/crates/mio/0.7.14/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "mio-0.7.14",
+    srcs = [":mio-0.7.14.crate"],
+    crate = "mio",
+    crate_root = "mio-0.7.14.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "default",
+        "net",
+        "os-ext",
+        "os-poll",
+        "os-util",
+        "tcp",
+        "udp",
+    ],
+    platform = {
+        "linux-arm64": dict(
+            deps = [":libc-0.2.153"],
+        ),
+        "linux-x86_64": dict(
+            deps = [":libc-0.2.153"],
+        ),
+        "macos-arm64": dict(
+            deps = [":libc-0.2.153"],
+        ),
+        "macos-x86_64": dict(
+            deps = [":libc-0.2.153"],
+        ),
+        "windows-gnu": dict(
+            deps = [
+                ":miow-0.3.7",
+                ":ntapi-0.3.7",
+                ":winapi-0.3.9",
+            ],
+        ),
+        "windows-msvc": dict(
+            deps = [
+                ":miow-0.3.7",
+                ":ntapi-0.3.7",
+                ":winapi-0.3.9",
+            ],
+        ),
+    },
+    visibility = [],
+    deps = [":log-0.4.21"],
 )
 
 http_archive(
@@ -5154,6 +6233,24 @@ cargo.rust_library(
         ),
     },
     visibility = [],
+)
+
+http_archive(
+    name = "miow-0.3.7.crate",
+    sha256 = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21",
+    strip_prefix = "miow-0.3.7",
+    urls = ["https://static.crates.io/crates/miow/0.3.7/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "miow-0.3.7",
+    srcs = [":miow-0.3.7.crate"],
+    crate = "miow",
+    crate_root = "miow-0.3.7.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [":winapi-0.3.9"],
 )
 
 alias(
@@ -5212,6 +6309,12 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "native-tls",
+    actual = ":native-tls-0.2.11",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "native-tls-0.2.11.crate",
     sha256 = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e",
@@ -5268,6 +6371,23 @@ cargo.rust_library(
             deps = [":schannel-0.1.23"],
         ),
     },
+    visibility = [],
+)
+
+http_archive(
+    name = "new_debug_unreachable-1.0.6.crate",
+    sha256 = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086",
+    strip_prefix = "new_debug_unreachable-1.0.6",
+    urls = ["https://static.crates.io/crates/new_debug_unreachable/1.0.6/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "new_debug_unreachable-1.0.6",
+    srcs = [":new_debug_unreachable-1.0.6.crate"],
+    crate = "debug_unreachable",
+    crate_root = "new_debug_unreachable-1.0.6.crate/src/lib.rs",
+    edition = "2021",
     visibility = [],
 )
 
@@ -5455,6 +6575,28 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "ntapi-0.3.7.crate",
+    sha256 = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f",
+    strip_prefix = "ntapi-0.3.7",
+    urls = ["https://static.crates.io/crates/ntapi/0.3.7/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "ntapi-0.3.7",
+    srcs = [":ntapi-0.3.7.crate"],
+    crate = "ntapi",
+    crate_root = "ntapi-0.3.7.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "default",
+        "user",
+    ],
+    visibility = [],
+    deps = [":winapi-0.3.9"],
+)
+
+http_archive(
     name = "nu-ansi-term-0.46.0.crate",
     sha256 = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84",
     strip_prefix = "nu-ansi-term-0.46.0",
@@ -5530,35 +6672,12 @@ cargo.rust_library(
     crate = "num_bigint",
     crate_root = "num-bigint-0.2.6.crate/src/lib.rs",
     edition = "2015",
-    env = {
-        "OUT_DIR": "$(location :num-bigint-0.2.6-build-script-run[out_dir])",
-    },
     features = ["std"],
-    rustc_flags = ["@$(location :num-bigint-0.2.6-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [
         ":num-integer-0.1.46",
         ":num-traits-0.2.18",
     ],
-)
-
-cargo.rust_binary(
-    name = "num-bigint-0.2.6-build-script-build",
-    srcs = [":num-bigint-0.2.6.crate"],
-    crate = "build_script_build",
-    crate_root = "num-bigint-0.2.6.crate/build.rs",
-    edition = "2015",
-    features = ["std"],
-    visibility = [],
-    deps = [":autocfg-1.2.0"],
-)
-
-buildscript_run(
-    name = "num-bigint-0.2.6-build-script-run",
-    package_name = "num-bigint",
-    buildscript_rule = ":num-bigint-0.2.6-build-script-build",
-    features = ["std"],
-    version = "0.2.6",
 )
 
 alias(
@@ -5581,48 +6700,17 @@ cargo.rust_library(
     crate = "num_bigint",
     crate_root = "num-bigint-0.4.4.crate/src/lib.rs",
     edition = "2018",
-    env = {
-        "OUT_DIR": "$(location :num-bigint-0.4.4-build-script-run[out_dir])",
-    },
     features = [
         "default",
         "rand",
         "std",
     ],
-    rustc_flags = ["@$(location :num-bigint-0.4.4-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [
         ":num-integer-0.1.46",
         ":num-traits-0.2.18",
         ":rand-0.8.5",
     ],
-)
-
-cargo.rust_binary(
-    name = "num-bigint-0.4.4-build-script-build",
-    srcs = [":num-bigint-0.4.4.crate"],
-    crate = "build_script_build",
-    crate_root = "num-bigint-0.4.4.crate/build.rs",
-    edition = "2018",
-    features = [
-        "default",
-        "rand",
-        "std",
-    ],
-    visibility = [],
-    deps = [":autocfg-1.2.0"],
-)
-
-buildscript_run(
-    name = "num-bigint-0.4.4-build-script-run",
-    package_name = "num-bigint",
-    buildscript_rule = ":num-bigint-0.4.4-build-script-build",
-    features = [
-        "default",
-        "rand",
-        "std",
-    ],
-    version = "0.4.4",
 )
 
 http_archive(
@@ -5642,23 +6730,6 @@ cargo.rust_library(
     features = ["std"],
     visibility = [],
     deps = [":num-traits-0.2.18"],
-)
-
-http_archive(
-    name = "num-conv-0.1.0.crate",
-    sha256 = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9",
-    strip_prefix = "num-conv-0.1.0",
-    urls = ["https://static.crates.io/crates/num-conv/0.1.0/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "num-conv-0.1.0",
-    srcs = [":num-conv-0.1.0.crate"],
-    crate = "num_conv",
-    crate_root = "num-conv-0.1.0.crate/src/lib.rs",
-    edition = "2021",
-    visibility = [],
 )
 
 alias(
@@ -5690,6 +6761,12 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "num-integer",
+    actual = ":num-integer-0.1.46",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "num-integer-0.1.46.crate",
     sha256 = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f",
@@ -5705,6 +6782,7 @@ cargo.rust_library(
     crate_root = "num-integer-0.1.46.crate/src/lib.rs",
     edition = "2018",
     features = [
+        "default",
         "i128",
         "std",
     ],
@@ -5781,43 +6859,12 @@ cargo.rust_library(
     crate = "num_traits",
     crate_root = "num-traits-0.2.18.crate/src/lib.rs",
     edition = "2018",
-    env = {
-        "OUT_DIR": "$(location :num-traits-0.2.18-build-script-run[out_dir])",
-    },
-    features = [
-        "default",
-        "i128",
-        "std",
-    ],
-    rustc_flags = ["@$(location :num-traits-0.2.18-build-script-run[rustc_flags])"],
-    visibility = [],
-)
-
-cargo.rust_binary(
-    name = "num-traits-0.2.18-build-script-build",
-    srcs = [":num-traits-0.2.18.crate"],
-    crate = "build_script_build",
-    crate_root = "num-traits-0.2.18.crate/build.rs",
-    edition = "2018",
     features = [
         "default",
         "i128",
         "std",
     ],
     visibility = [],
-    deps = [":autocfg-1.2.0"],
-)
-
-buildscript_run(
-    name = "num-traits-0.2.18-build-script-run",
-    package_name = "num-traits",
-    buildscript_rule = ":num-traits-0.2.18-build-script-build",
-    features = [
-        "default",
-        "i128",
-        "std",
-    ],
-    version = "0.2.18",
 )
 
 alias(
@@ -5913,6 +6960,12 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "openssl",
+    actual = ":openssl-0.10.64",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "openssl-0.10.64.crate",
     sha256 = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f",
@@ -5927,10 +6980,14 @@ cargo.rust_library(
     crate = "openssl",
     crate_root = "openssl-0.10.64.crate/src/lib.rs",
     edition = "2018",
+    env = {
+        "OUT_DIR": "$(location :openssl-0.10.64-build-script-run[out_dir])",
+    },
     features = ["default"],
     named_deps = {
         "ffi": ":openssl-sys-0.9.102",
     },
+    rustc_flags = ["@$(location :openssl-0.10.64-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [
         ":bitflags-2.5.0",
@@ -5940,6 +6997,24 @@ cargo.rust_library(
         ":once_cell-1.19.0",
         ":openssl-macros-0.1.1",
     ],
+)
+
+cargo.rust_binary(
+    name = "openssl-0.10.64-build-script-build",
+    srcs = [":openssl-0.10.64.crate"],
+    crate = "build_script_build",
+    crate_root = "openssl-0.10.64.crate/build.rs",
+    edition = "2018",
+    features = ["default"],
+    visibility = [],
+)
+
+buildscript_run(
+    name = "openssl-0.10.64-build-script-run",
+    package_name = "openssl",
+    buildscript_rule = ":openssl-0.10.64-build-script-build",
+    features = ["default"],
+    version = "0.10.64",
 )
 
 http_archive(
@@ -5980,6 +7055,12 @@ cargo.rust_library(
     crate_root = "openssl-probe-0.1.5.crate/src/lib.rs",
     edition = "2015",
     visibility = [],
+)
+
+alias(
+    name = "openssl-sys",
+    actual = ":openssl-sys-0.9.102",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -6033,6 +7114,12 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "os_str_bytes",
+    actual = ":os_str_bytes-6.6.1",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "os_str_bytes-6.6.1.crate",
     sha256 = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1",
@@ -6047,8 +7134,14 @@ cargo.rust_library(
     crate = "os_str_bytes",
     crate_root = "os_str_bytes-6.6.1.crate/src/lib.rs",
     edition = "2021",
-    features = ["raw_os_str"],
+    features = [
+        "conversions",
+        "default",
+        "memchr",
+        "raw_os_str",
+    ],
     visibility = [],
+    deps = [":memchr-2.7.2"],
 )
 
 http_archive(
@@ -6136,6 +7229,9 @@ cargo.rust_library(
     crate = "parking_lot_core",
     crate_root = "parking_lot_core-0.9.9.crate/src/lib.rs",
     edition = "2018",
+    env = {
+        "OUT_DIR": "$(location :parking_lot_core-0.9.9-build-script-run[out_dir])",
+    },
     platform = {
         "linux-arm64": dict(
             deps = [":libc-0.2.153"],
@@ -6156,11 +7252,28 @@ cargo.rust_library(
             deps = [":windows-targets-0.48.5"],
         ),
     },
+    rustc_flags = ["@$(location :parking_lot_core-0.9.9-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [
         ":cfg-if-1.0.0",
         ":smallvec-1.13.2",
     ],
+)
+
+cargo.rust_binary(
+    name = "parking_lot_core-0.9.9-build-script-build",
+    srcs = [":parking_lot_core-0.9.9.crate"],
+    crate = "build_script_build",
+    crate_root = "parking_lot_core-0.9.9.crate/build.rs",
+    edition = "2018",
+    visibility = [],
+)
+
+buildscript_run(
+    name = "parking_lot_core-0.9.9-build-script-run",
+    package_name = "parking_lot_core",
+    buildscript_rule = ":parking_lot_core-0.9.9-build-script-build",
+    version = "0.9.9",
 )
 
 http_archive(
@@ -6225,6 +7338,12 @@ buildscript_run(
     version = "1.0.14",
 )
 
+alias(
+    name = "percent-encoding",
+    actual = ":percent-encoding-2.3.1",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "percent-encoding-2.3.1.crate",
     sha256 = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e",
@@ -6245,6 +7364,12 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
+)
+
+alias(
+    name = "pest",
+    actual = ":pest-2.7.9",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -6306,6 +7431,12 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "pest_generator",
+    actual = ":pest_generator-2.7.9",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "pest_generator-2.7.9.crate",
     sha256 = "c35eeed0a3fab112f75165fdc026b3913f4183133f19b49be773ac9ea966e8bd",
@@ -6320,7 +7451,10 @@ cargo.rust_library(
     crate = "pest_generator",
     crate_root = "pest_generator-2.7.9.crate/src/lib.rs",
     edition = "2021",
-    features = ["std"],
+    features = [
+        "default",
+        "std",
+    ],
     visibility = [],
     deps = [
         ":pest-2.7.9",
@@ -6391,6 +7525,12 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "phf",
+    actual = ":phf-0.11.2",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "phf-0.11.2.crate",
     sha256 = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc",
@@ -6405,8 +7545,112 @@ cargo.rust_library(
     crate = "phf",
     crate_root = "phf-0.11.2.crate/src/lib.rs",
     edition = "2021",
+    features = [
+        "default",
+        "macros",
+        "phf_macros",
+        "std",
+    ],
     visibility = [],
-    deps = [":phf_shared-0.11.2"],
+    deps = [
+        ":phf_macros-0.11.2",
+        ":phf_shared-0.11.2",
+    ],
+)
+
+alias(
+    name = "phf_codegen",
+    actual = ":phf_codegen-0.11.2",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "phf_codegen-0.11.2.crate",
+    sha256 = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a",
+    strip_prefix = "phf_codegen-0.11.2",
+    urls = ["https://static.crates.io/crates/phf_codegen/0.11.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "phf_codegen-0.11.2",
+    srcs = [":phf_codegen-0.11.2.crate"],
+    crate = "phf_codegen",
+    crate_root = "phf_codegen-0.11.2.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+    deps = [
+        ":phf_generator-0.11.2",
+        ":phf_shared-0.11.2",
+    ],
+)
+
+http_archive(
+    name = "phf_generator-0.11.2.crate",
+    sha256 = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0",
+    strip_prefix = "phf_generator-0.11.2",
+    urls = ["https://static.crates.io/crates/phf_generator/0.11.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "phf_generator-0.11.2",
+    srcs = [":phf_generator-0.11.2.crate"],
+    crate = "phf_generator",
+    crate_root = "phf_generator-0.11.2.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+    deps = [
+        ":phf_shared-0.11.2",
+        ":rand-0.8.5",
+    ],
+)
+
+http_archive(
+    name = "phf_macros-0.11.2.crate",
+    sha256 = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b",
+    strip_prefix = "phf_macros-0.11.2",
+    urls = ["https://static.crates.io/crates/phf_macros/0.11.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "phf_macros-0.11.2",
+    srcs = [":phf_macros-0.11.2.crate"],
+    crate = "phf_macros",
+    crate_root = "phf_macros-0.11.2.crate/src/lib.rs",
+    edition = "2021",
+    proc_macro = True,
+    visibility = [],
+    deps = [
+        ":phf_generator-0.11.2",
+        ":phf_shared-0.11.2",
+        ":proc-macro2-1.0.81",
+        ":quote-1.0.36",
+        ":syn-2.0.60",
+    ],
+)
+
+http_archive(
+    name = "phf_shared-0.10.0.crate",
+    sha256 = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096",
+    strip_prefix = "phf_shared-0.10.0",
+    urls = ["https://static.crates.io/crates/phf_shared/0.10.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "phf_shared-0.10.0",
+    srcs = [":phf_shared-0.10.0.crate"],
+    crate = "phf_shared",
+    crate_root = "phf_shared-0.10.0.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "default",
+        "std",
+    ],
+    visibility = [],
+    deps = [":siphasher-0.3.11"],
 )
 
 http_archive(
@@ -6432,6 +7676,23 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "pico-args-0.4.2.crate",
+    sha256 = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468",
+    strip_prefix = "pico-args-0.4.2",
+    urls = ["https://static.crates.io/crates/pico-args/0.4.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "pico-args-0.4.2",
+    srcs = [":pico-args-0.4.2.crate"],
+    crate = "pico_args",
+    crate_root = "pico-args-0.4.2.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+)
+
+http_archive(
     name = "pin-project-lite-0.2.14.crate",
     sha256 = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02",
     strip_prefix = "pin-project-lite-0.2.14",
@@ -6446,6 +7707,12 @@ cargo.rust_library(
     crate_root = "pin-project-lite-0.2.14.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
+)
+
+alias(
+    name = "pin-utils",
+    actual = ":pin-utils-0.1.0",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -6463,6 +7730,12 @@ cargo.rust_library(
     crate_root = "pin-utils-0.1.0.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
+)
+
+alias(
+    name = "plain",
+    actual = ":plain-0.2.3",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -6504,23 +7777,6 @@ cargo.rust_library(
 )
 
 http_archive(
-    name = "powerfmt-0.2.0.crate",
-    sha256 = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391",
-    strip_prefix = "powerfmt-0.2.0",
-    urls = ["https://static.crates.io/crates/powerfmt/0.2.0/download"],
-    visibility = [],
-)
-
-cargo.rust_library(
-    name = "powerfmt-0.2.0",
-    srcs = [":powerfmt-0.2.0.crate"],
-    crate = "powerfmt",
-    crate_root = "powerfmt-0.2.0.crate/src/lib.rs",
-    edition = "2021",
-    visibility = [],
-)
-
-http_archive(
     name = "ppv-lite86-0.2.17.crate",
     sha256 = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de",
     strip_prefix = "ppv-lite86-0.2.17",
@@ -6539,6 +7795,60 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
+)
+
+http_archive(
+    name = "precomputed-hash-0.1.1.crate",
+    sha256 = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c",
+    strip_prefix = "precomputed-hash-0.1.1",
+    urls = ["https://static.crates.io/crates/precomputed-hash/0.1.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "precomputed-hash-0.1.1",
+    srcs = [":precomputed-hash-0.1.1.crate"],
+    crate = "precomputed_hash",
+    crate_root = "precomputed-hash-0.1.1.crate/src/lib.rs",
+    edition = "2015",
+    visibility = [],
+)
+
+alias(
+    name = "predicates",
+    actual = ":predicates-1.0.8",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "predicates-1.0.8.crate",
+    sha256 = "f49cfaf7fdaa3bfacc6fa3e7054e65148878354a5cfddcf661df4c851f8021df",
+    strip_prefix = "predicates-1.0.8",
+    urls = ["https://static.crates.io/crates/predicates/1.0.8/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "predicates-1.0.8",
+    srcs = [":predicates-1.0.8.crate"],
+    crate = "predicates",
+    crate_root = "predicates-1.0.8.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "default",
+        "difference",
+        "float-cmp",
+        "normalize-line-endings",
+        "regex",
+    ],
+    visibility = [],
+    deps = [
+        ":difference-2.0.0",
+        ":float-cmp-0.8.0",
+        ":normalize-line-endings-0.3.0",
+        ":predicates-core-1.0.6",
+        ":regex-1.10.4",
+    ],
 )
 
 http_archive(
@@ -6639,6 +7949,62 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "prettyplease",
+    actual = ":prettyplease-0.2.19",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "prettyplease-0.2.19.crate",
+    sha256 = "5ac2cf0f2e4f42b49f5ffd07dae8d746508ef7526c13940e5f524012ae6c6550",
+    strip_prefix = "prettyplease-0.2.19",
+    urls = ["https://static.crates.io/crates/prettyplease/0.2.19/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "prettyplease-0.2.19",
+    srcs = [":prettyplease-0.2.19.crate"],
+    crate = "prettyplease",
+    crate_root = "prettyplease-0.2.19.crate/src/lib.rs",
+    edition = "2021",
+    env = {
+        "OUT_DIR": "$(location :prettyplease-0.2.19-build-script-run[out_dir])",
+    },
+    features = ["verbatim"],
+    rustc_flags = ["@$(location :prettyplease-0.2.19-build-script-run[rustc_flags])"],
+    visibility = [],
+    deps = [
+        ":proc-macro2-1.0.81",
+        ":syn-2.0.60",
+    ],
+)
+
+cargo.rust_binary(
+    name = "prettyplease-0.2.19-build-script-build",
+    srcs = [":prettyplease-0.2.19.crate"],
+    crate = "build_script_build",
+    crate_root = "prettyplease-0.2.19.crate/build.rs",
+    edition = "2021",
+    features = ["verbatim"],
+    visibility = [],
+)
+
+buildscript_run(
+    name = "prettyplease-0.2.19-build-script-run",
+    package_name = "prettyplease",
+    buildscript_rule = ":prettyplease-0.2.19-build-script-build",
+    features = ["verbatim"],
+    version = "0.2.19",
+)
+
+alias(
+    name = "proc-macro-error",
+    actual = ":proc-macro-error-1.0.4",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "proc-macro-error-1.0.4.crate",
     sha256 = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c",
@@ -6709,43 +8075,13 @@ cargo.rust_library(
     crate = "proc_macro2",
     crate_root = "proc-macro2-1.0.81.crate/src/lib.rs",
     edition = "2021",
-    env = {
-        "OUT_DIR": "$(location :proc-macro2-1.0.81-build-script-run[out_dir])",
-    },
     features = [
         "default",
         "proc-macro",
         "span-locations",
     ],
-    rustc_flags = ["@$(location :proc-macro2-1.0.81-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [":unicode-ident-1.0.12"],
-)
-
-cargo.rust_binary(
-    name = "proc-macro2-1.0.81-build-script-build",
-    srcs = [":proc-macro2-1.0.81.crate"],
-    crate = "build_script_build",
-    crate_root = "proc-macro2-1.0.81.crate/build.rs",
-    edition = "2021",
-    features = [
-        "default",
-        "proc-macro",
-        "span-locations",
-    ],
-    visibility = [],
-)
-
-buildscript_run(
-    name = "proc-macro2-1.0.81-build-script-run",
-    package_name = "proc-macro2",
-    buildscript_rule = ":proc-macro2-1.0.81-build-script-build",
-    features = [
-        "default",
-        "proc-macro",
-        "span-locations",
-    ],
-    version = "1.0.81",
 )
 
 alias(
@@ -6775,6 +8111,12 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "prost",
+    actual = ":prost-0.11.9",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "prost-0.11.9.crate",
     sha256 = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd",
@@ -6790,6 +8132,7 @@ cargo.rust_library(
     crate_root = "prost-0.11.9.crate/src/lib.rs",
     edition = "2021",
     features = [
+        "default",
         "prost-derive",
         "std",
     ],
@@ -7126,6 +8469,12 @@ cargo.rust_library(
     deps = [":proc-macro2-1.0.81"],
 )
 
+alias(
+    name = "radix_trie",
+    actual = ":radix_trie-0.2.1",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "radix_trie-0.2.1.crate",
     sha256 = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd",
@@ -7140,10 +8489,12 @@ cargo.rust_library(
     crate = "radix_trie",
     crate_root = "radix_trie-0.2.1.crate/src/lib.rs",
     edition = "2018",
+    features = ["serde"],
     visibility = [],
     deps = [
         ":endian-type-0.1.2",
         ":nibble_vec-0.1.0",
+        ":serde-1.0.198",
     ],
 )
 
@@ -7201,6 +8552,12 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "rand_chacha",
+    actual = ":rand_chacha-0.3.1",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "rand_chacha-0.3.1.crate",
     sha256 = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88",
@@ -7215,12 +8572,21 @@ cargo.rust_library(
     crate = "rand_chacha",
     crate_root = "rand_chacha-0.3.1.crate/src/lib.rs",
     edition = "2018",
-    features = ["std"],
+    features = [
+        "default",
+        "std",
+    ],
     visibility = [],
     deps = [
         ":ppv-lite86-0.2.17",
         ":rand_core-0.6.4",
     ],
+)
+
+alias(
+    name = "rand_core",
+    actual = ":rand_core-0.6.4",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -7247,6 +8613,37 @@ cargo.rust_library(
     visibility = [],
     deps = [
         ":getrandom-0.2.14",
+        ":serde-1.0.198",
+    ],
+)
+
+alias(
+    name = "rand_pcg",
+    actual = ":rand_pcg-0.3.1",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "rand_pcg-0.3.1.crate",
+    sha256 = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e",
+    strip_prefix = "rand_pcg-0.3.1",
+    urls = ["https://static.crates.io/crates/rand_pcg/0.3.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "rand_pcg-0.3.1",
+    srcs = [":rand_pcg-0.3.1.crate"],
+    crate = "rand_pcg",
+    crate_root = "rand_pcg-0.3.1.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "serde",
+        "serde1",
+    ],
+    visibility = [],
+    deps = [
+        ":rand_core-0.6.4",
         ":serde-1.0.198",
     ],
 )
@@ -7319,28 +8716,8 @@ cargo.rust_library(
     crate = "ref_cast",
     crate_root = "ref-cast-1.0.22.crate/src/lib.rs",
     edition = "2021",
-    env = {
-        "OUT_DIR": "$(location :ref-cast-1.0.22-build-script-run[out_dir])",
-    },
-    rustc_flags = ["@$(location :ref-cast-1.0.22-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [":ref-cast-impl-1.0.22"],
-)
-
-cargo.rust_binary(
-    name = "ref-cast-1.0.22-build-script-build",
-    srcs = [":ref-cast-1.0.22.crate"],
-    crate = "build_script_build",
-    crate_root = "ref-cast-1.0.22.crate/build.rs",
-    edition = "2021",
-    visibility = [],
-)
-
-buildscript_run(
-    name = "ref-cast-1.0.22-build-script-run",
-    package_name = "ref-cast",
-    buildscript_rule = ":ref-cast-1.0.22-build-script-build",
-    version = "1.0.22",
 )
 
 http_archive(
@@ -7437,6 +8814,64 @@ cargo.rust_library(
     deps = [":regex-syntax-0.6.29"],
 )
 
+alias(
+    name = "regex-automata",
+    actual = ":regex-automata-0.3.9",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "regex-automata-0.3.9.crate",
+    sha256 = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9",
+    strip_prefix = "regex-automata-0.3.9",
+    urls = ["https://static.crates.io/crates/regex-automata/0.3.9/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "regex-automata-0.3.9",
+    srcs = [":regex-automata-0.3.9.crate"],
+    crate = "regex_automata",
+    crate_root = "regex-automata-0.3.9.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "alloc",
+        "default",
+        "dfa",
+        "dfa-build",
+        "dfa-onepass",
+        "dfa-search",
+        "hybrid",
+        "meta",
+        "nfa",
+        "nfa-backtrack",
+        "nfa-pikevm",
+        "nfa-thompson",
+        "perf",
+        "perf-inline",
+        "perf-literal",
+        "perf-literal-multisubstring",
+        "perf-literal-substring",
+        "std",
+        "syntax",
+        "unicode",
+        "unicode-age",
+        "unicode-bool",
+        "unicode-case",
+        "unicode-gencat",
+        "unicode-perl",
+        "unicode-script",
+        "unicode-segment",
+        "unicode-word-boundary",
+    ],
+    visibility = [],
+    deps = [
+        ":aho-corasick-1.1.3",
+        ":memchr-2.7.2",
+        ":regex-syntax-0.7.5",
+    ],
+)
+
 http_archive(
     name = "regex-automata-0.4.6.crate",
     sha256 = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea",
@@ -7502,6 +8937,41 @@ cargo.rust_library(
     edition = "2018",
     features = [
         "default",
+        "unicode",
+        "unicode-age",
+        "unicode-bool",
+        "unicode-case",
+        "unicode-gencat",
+        "unicode-perl",
+        "unicode-script",
+        "unicode-segment",
+    ],
+    visibility = [],
+)
+
+alias(
+    name = "regex-syntax",
+    actual = ":regex-syntax-0.7.5",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "regex-syntax-0.7.5.crate",
+    sha256 = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da",
+    strip_prefix = "regex-syntax-0.7.5",
+    urls = ["https://static.crates.io/crates/regex-syntax/0.7.5/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "regex-syntax-0.7.5",
+    srcs = [":regex-syntax-0.7.5.crate"],
+    crate = "regex_syntax",
+    crate_root = "regex-syntax-0.7.5.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "default",
+        "std",
         "unicode",
         "unicode-age",
         "unicode-bool",
@@ -7646,8 +9116,12 @@ cargo.rust_library(
     crate = "rstest_macros",
     crate_root = "rstest_macros-0.18.2.crate/src/lib.rs",
     edition = "2021",
+    env = {
+        "OUT_DIR": "$(location :rstest_macros-0.18.2-build-script-run[out_dir])",
+    },
     features = ["async-timeout"],
     proc_macro = True,
+    rustc_flags = ["@$(location :rstest_macros-0.18.2-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [
         ":cfg-if-1.0.0",
@@ -7659,6 +9133,25 @@ cargo.rust_library(
         ":syn-2.0.60",
         ":unicode-ident-1.0.12",
     ],
+)
+
+cargo.rust_binary(
+    name = "rstest_macros-0.18.2-build-script-build",
+    srcs = [":rstest_macros-0.18.2.crate"],
+    crate = "build_script_build",
+    crate_root = "rstest_macros-0.18.2.crate/build.rs",
+    edition = "2021",
+    features = ["async-timeout"],
+    visibility = [],
+    deps = [":rustc_version-0.4.0"],
+)
+
+buildscript_run(
+    name = "rstest_macros-0.18.2-build-script-run",
+    package_name = "rstest_macros",
+    buildscript_rule = ":rstest_macros-0.18.2-build-script-build",
+    features = ["async-timeout"],
+    version = "0.18.2",
 )
 
 alias(
@@ -7688,6 +9181,30 @@ cargo.rust_library(
     visibility = [],
 )
 
+alias(
+    name = "rustc_version",
+    actual = ":rustc_version-0.4.0",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "rustc_version-0.4.0.crate",
+    sha256 = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366",
+    strip_prefix = "rustc_version-0.4.0",
+    urls = ["https://static.crates.io/crates/rustc_version/0.4.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "rustc_version-0.4.0",
+    srcs = [":rustc_version-0.4.0.crate"],
+    crate = "rustc_version",
+    crate_root = "rustc_version-0.4.0.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [":semver-1.0.22"],
+)
+
 http_archive(
     name = "rustix-0.37.27.crate",
     sha256 = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2",
@@ -7702,6 +9219,9 @@ cargo.rust_library(
     crate = "rustix",
     crate_root = "rustix-0.37.27.crate/src/lib.rs",
     edition = "2018",
+    env = {
+        "OUT_DIR": "$(location :rustix-0.37.27-build-script-run[out_dir])",
+    },
     features = [
         "default",
         "io-lifetimes",
@@ -7748,11 +9268,44 @@ cargo.rust_library(
             deps = [":windows-sys-0.48.0"],
         ),
     },
+    rustc_flags = ["@$(location :rustix-0.37.27-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [
         ":bitflags-1.3.2",
         ":io-lifetimes-1.0.11",
     ],
+)
+
+cargo.rust_binary(
+    name = "rustix-0.37.27-build-script-build",
+    srcs = [":rustix-0.37.27.crate"],
+    crate = "build_script_build",
+    crate_root = "rustix-0.37.27.crate/build.rs",
+    edition = "2018",
+    features = [
+        "default",
+        "io-lifetimes",
+        "libc",
+        "std",
+        "termios",
+        "use-libc-auxv",
+    ],
+    visibility = [],
+)
+
+buildscript_run(
+    name = "rustix-0.37.27-build-script-run",
+    package_name = "rustix",
+    buildscript_rule = ":rustix-0.37.27-build-script-build",
+    features = [
+        "default",
+        "io-lifetimes",
+        "libc",
+        "std",
+        "termios",
+        "use-libc-auxv",
+    ],
+    version = "0.37.27",
 )
 
 http_archive(
@@ -7769,6 +9322,9 @@ cargo.rust_library(
     crate = "rustix",
     crate_root = "rustix-0.38.34.crate/src/lib.rs",
     edition = "2021",
+    env = {
+        "OUT_DIR": "$(location :rustix-0.38.34-build-script-run[out_dir])",
+    },
     features = [
         "alloc",
         "default",
@@ -7822,8 +9378,43 @@ cargo.rust_library(
             deps = [":windows-sys-0.52.0"],
         ),
     },
+    rustc_flags = ["@$(location :rustix-0.38.34-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [":bitflags-2.5.0"],
+)
+
+cargo.rust_binary(
+    name = "rustix-0.38.34-build-script-build",
+    srcs = [":rustix-0.38.34.crate"],
+    crate = "build_script_build",
+    crate_root = "rustix-0.38.34.crate/build.rs",
+    edition = "2021",
+    features = [
+        "alloc",
+        "default",
+        "fs",
+        "libc-extra-traits",
+        "std",
+        "termios",
+        "use-libc-auxv",
+    ],
+    visibility = [],
+)
+
+buildscript_run(
+    name = "rustix-0.38.34-build-script-run",
+    package_name = "rustix",
+    buildscript_rule = ":rustix-0.38.34-build-script-build",
+    features = [
+        "alloc",
+        "default",
+        "fs",
+        "libc-extra-traits",
+        "std",
+        "termios",
+        "use-libc-auxv",
+    ],
+    version = "0.38.34",
 )
 
 alias(
@@ -7846,8 +9437,28 @@ cargo.rust_library(
     crate = "rustversion",
     crate_root = "rustversion-1.0.15.crate/src/lib.rs",
     edition = "2018",
+    env = {
+        "OUT_DIR": "$(location :rustversion-1.0.15-build-script-run[out_dir])",
+    },
     proc_macro = True,
+    rustc_flags = ["@$(location :rustversion-1.0.15-build-script-run[rustc_flags])"],
     visibility = [],
+)
+
+cargo.rust_binary(
+    name = "rustversion-1.0.15-build-script-build",
+    srcs = [":rustversion-1.0.15.crate"],
+    crate = "build_script_build",
+    crate_root = "rustversion-1.0.15.crate/build/build.rs",
+    edition = "2018",
+    visibility = [],
+)
+
+buildscript_run(
+    name = "rustversion-1.0.15-build-script-run",
+    package_name = "rustversion",
+    buildscript_rule = ":rustversion-1.0.15-build-script-build",
+    version = "1.0.15",
 )
 
 alias(
@@ -7977,6 +9588,12 @@ cargo.rust_library(
     visibility = [],
 )
 
+alias(
+    name = "same-file",
+    actual = ":same-file-1.0.6",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "same-file-1.0.6.crate",
     sha256 = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502",
@@ -8096,6 +9713,12 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "scopeguard",
+    actual = ":scopeguard-1.2.0",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "scopeguard-1.2.0.crate",
     sha256 = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49",
@@ -8115,6 +9738,36 @@ cargo.rust_library(
         "use_std",
     ],
     visibility = [],
+)
+
+alias(
+    name = "scroll",
+    actual = ":scroll-0.10.2",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "scroll-0.10.2.crate",
+    sha256 = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec",
+    strip_prefix = "scroll-0.10.2",
+    urls = ["https://static.crates.io/crates/scroll/0.10.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "scroll-0.10.2",
+    srcs = [":scroll-0.10.2.crate"],
+    crate = "scroll",
+    crate_root = "scroll-0.10.2.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "default",
+        "derive",
+        "scroll_derive",
+        "std",
+    ],
+    visibility = [],
+    deps = [":scroll_derive-0.10.5"],
 )
 
 http_archive(
@@ -8138,6 +9791,29 @@ cargo.rust_library(
     ],
     visibility = [],
     deps = [":scroll_derive-0.11.1"],
+)
+
+http_archive(
+    name = "scroll_derive-0.10.5.crate",
+    sha256 = "aaaae8f38bb311444cfb7f1979af0bc9240d95795f75f9ceddf6a59b79ceffa0",
+    strip_prefix = "scroll_derive-0.10.5",
+    urls = ["https://static.crates.io/crates/scroll_derive/0.10.5/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "scroll_derive-0.10.5",
+    srcs = [":scroll_derive-0.10.5.crate"],
+    crate = "scroll_derive",
+    crate_root = "scroll_derive-0.10.5.crate/src/lib.rs",
+    edition = "2018",
+    proc_macro = True,
+    visibility = [],
+    deps = [
+        ":proc-macro2-1.0.81",
+        ":quote-1.0.36",
+        ":syn-1.0.109-syn1",
+    ],
 )
 
 http_archive(
@@ -8218,6 +9894,65 @@ cargo.rust_library(
         ":core-foundation-sys-0.8.6",
         ":libc-0.2.153",
     ],
+)
+
+alias(
+    name = "semver",
+    actual = ":semver-1.0.22",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "semver-1.0.22.crate",
+    sha256 = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca",
+    strip_prefix = "semver-1.0.22",
+    urls = ["https://static.crates.io/crates/semver/1.0.22/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "semver-1.0.22",
+    srcs = [":semver-1.0.22.crate"],
+    crate = "semver",
+    crate_root = "semver-1.0.22.crate/src/lib.rs",
+    edition = "2018",
+    env = {
+        "OUT_DIR": "$(location :semver-1.0.22-build-script-run[out_dir])",
+    },
+    features = [
+        "default",
+        "serde",
+        "std",
+    ],
+    rustc_flags = ["@$(location :semver-1.0.22-build-script-run[rustc_flags])"],
+    visibility = [],
+    deps = [":serde-1.0.198"],
+)
+
+cargo.rust_binary(
+    name = "semver-1.0.22-build-script-build",
+    srcs = [":semver-1.0.22.crate"],
+    crate = "build_script_build",
+    crate_root = "semver-1.0.22.crate/build.rs",
+    edition = "2018",
+    features = [
+        "default",
+        "serde",
+        "std",
+    ],
+    visibility = [],
+)
+
+buildscript_run(
+    name = "semver-1.0.22-build-script-run",
+    package_name = "semver",
+    buildscript_rule = ":semver-1.0.22-build-script-build",
+    features = [
+        "default",
+        "serde",
+        "std",
+    ],
+    version = "1.0.22",
 )
 
 alias(
@@ -8316,6 +10051,24 @@ cargo.rust_library(
         ":quote-1.0.36",
         ":syn-2.0.60",
     ],
+)
+
+http_archive(
+    name = "serde_fmt-1.0.3.crate",
+    sha256 = "e1d4ddca14104cd60529e8c7f7ba71a2c8acd8f7f5cfcdc2faf97eeb7c3010a4",
+    strip_prefix = "serde_fmt-1.0.3",
+    urls = ["https://static.crates.io/crates/serde_fmt/1.0.3/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "serde_fmt-1.0.3",
+    srcs = [":serde_fmt-1.0.3.crate"],
+    crate = "serde_fmt",
+    crate_root = "serde_fmt-1.0.3.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [":serde-1.0.198"],
 )
 
 alias(
@@ -8599,6 +10352,33 @@ cargo.rust_library(
     deps = [":lazy_static-1.4.0"],
 )
 
+alias(
+    name = "shlex",
+    actual = ":shlex-1.3.0",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "shlex-1.3.0.crate",
+    sha256 = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64",
+    strip_prefix = "shlex-1.3.0",
+    urls = ["https://static.crates.io/crates/shlex/1.3.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "shlex-1.3.0",
+    srcs = [":shlex-1.3.0.crate"],
+    crate = "shlex",
+    crate_root = "shlex-1.3.0.crate/src/lib.rs",
+    edition = "2015",
+    features = [
+        "default",
+        "std",
+    ],
+    visibility = [],
+)
+
 http_archive(
     name = "signal-hook-registry-1.4.2.crate",
     sha256 = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1",
@@ -8680,6 +10460,12 @@ cargo.rust_library(
         ":console-0.15.8",
         ":similar-2.5.0",
     ],
+)
+
+alias(
+    name = "siphasher",
+    actual = ":siphasher-0.3.11",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -8850,7 +10636,7 @@ cargo.rust_library(
         ":slog-2.7.0",
         ":term-0.7.0",
         ":thread_local-1.1.8",
-        ":time-0.3.36",
+        ":time-0.3.17",
     ],
 )
 
@@ -8910,6 +10696,12 @@ buildscript_run(
     version = "1.0.7",
 )
 
+alias(
+    name = "slug",
+    actual = ":slug-0.1.5",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "slug-0.1.5.crate",
     sha256 = "3bd94acec9c8da640005f8e135a39fc0372e74535e6b368b7a04b875f784c8c4",
@@ -8925,6 +10717,7 @@ cargo.rust_library(
     crate_root = "slug-0.1.5.crate/src/lib.rs",
     dlopen_enable = True,
     edition = "2021",
+    linkable_alias = "slug",
     visibility = [],
     deps = [":deunicode-1.4.4"],
 )
@@ -9068,6 +10861,30 @@ cargo.rust_library(
     crate_root = "str-buf-1.0.6.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
+)
+
+http_archive(
+    name = "string_cache-0.8.7.crate",
+    sha256 = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b",
+    strip_prefix = "string_cache-0.8.7",
+    urls = ["https://static.crates.io/crates/string_cache/0.8.7/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "string_cache-0.8.7",
+    srcs = [":string_cache-0.8.7.crate"],
+    crate = "string_cache",
+    crate_root = "string_cache-0.8.7.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [
+        ":new_debug_unreachable-1.0.6",
+        ":once_cell-1.19.0",
+        ":parking_lot-0.12.1",
+        ":phf_shared-0.10.0",
+        ":precomputed-hash-0.1.1",
+    ],
 )
 
 alias(
@@ -9236,6 +11053,220 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "subtle",
+    actual = ":subtle-2.5.0",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "subtle-2.5.0.crate",
+    sha256 = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc",
+    strip_prefix = "subtle-2.5.0",
+    urls = ["https://static.crates.io/crates/subtle/2.5.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "subtle-2.5.0",
+    srcs = [":subtle-2.5.0.crate"],
+    crate = "subtle",
+    crate_root = "subtle-2.5.0.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "default",
+        "i128",
+        "std",
+    ],
+    visibility = [],
+)
+
+http_archive(
+    name = "sval-2.13.0.crate",
+    sha256 = "53eb957fbc79a55306d5d25d87daf3627bc3800681491cda0709eef36c748bfe",
+    strip_prefix = "sval-2.13.0",
+    urls = ["https://static.crates.io/crates/sval/2.13.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "sval-2.13.0",
+    srcs = [":sval-2.13.0.crate"],
+    crate = "sval",
+    crate_root = "sval-2.13.0.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "alloc",
+        "std",
+    ],
+    visibility = [],
+)
+
+http_archive(
+    name = "sval_buffer-2.13.0.crate",
+    sha256 = "96e860aef60e9cbf37888d4953a13445abf523c534640d1f6174d310917c410d",
+    strip_prefix = "sval_buffer-2.13.0",
+    urls = ["https://static.crates.io/crates/sval_buffer/2.13.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "sval_buffer-2.13.0",
+    srcs = [":sval_buffer-2.13.0.crate"],
+    crate = "sval_buffer",
+    crate_root = "sval_buffer-2.13.0.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "alloc",
+        "std",
+    ],
+    visibility = [],
+    deps = [
+        ":sval-2.13.0",
+        ":sval_ref-2.13.0",
+    ],
+)
+
+http_archive(
+    name = "sval_dynamic-2.13.0.crate",
+    sha256 = "ea3f2b07929a1127d204ed7cb3905049381708245727680e9139dac317ed556f",
+    strip_prefix = "sval_dynamic-2.13.0",
+    urls = ["https://static.crates.io/crates/sval_dynamic/2.13.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "sval_dynamic-2.13.0",
+    srcs = [":sval_dynamic-2.13.0.crate"],
+    crate = "sval_dynamic",
+    crate_root = "sval_dynamic-2.13.0.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+    deps = [":sval-2.13.0"],
+)
+
+http_archive(
+    name = "sval_fmt-2.13.0.crate",
+    sha256 = "c4e188677497de274a1367c4bda15bd2296de4070d91729aac8f0a09c1abf64d",
+    strip_prefix = "sval_fmt-2.13.0",
+    urls = ["https://static.crates.io/crates/sval_fmt/2.13.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "sval_fmt-2.13.0",
+    srcs = [":sval_fmt-2.13.0.crate"],
+    crate = "sval_fmt",
+    crate_root = "sval_fmt-2.13.0.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+    deps = [
+        ":itoa-1.0.11",
+        ":ryu-1.0.17",
+        ":sval-2.13.0",
+    ],
+)
+
+http_archive(
+    name = "sval_json-2.13.0.crate",
+    sha256 = "32f456c07dae652744781f2245d5e3b78e6a9ebad70790ac11eb15dbdbce5282",
+    strip_prefix = "sval_json-2.13.0",
+    urls = ["https://static.crates.io/crates/sval_json/2.13.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "sval_json-2.13.0",
+    srcs = [":sval_json-2.13.0.crate"],
+    crate = "sval_json",
+    crate_root = "sval_json-2.13.0.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "alloc",
+        "std",
+    ],
+    visibility = [],
+    deps = [
+        ":itoa-1.0.11",
+        ":ryu-1.0.17",
+        ":sval-2.13.0",
+    ],
+)
+
+http_archive(
+    name = "sval_nested-2.13.0.crate",
+    sha256 = "886feb24709f0476baaebbf9ac10671a50163caa7e439d7a7beb7f6d81d0a6fb",
+    strip_prefix = "sval_nested-2.13.0",
+    urls = ["https://static.crates.io/crates/sval_nested/2.13.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "sval_nested-2.13.0",
+    srcs = [":sval_nested-2.13.0.crate"],
+    crate = "sval_nested",
+    crate_root = "sval_nested-2.13.0.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "alloc",
+        "std",
+    ],
+    visibility = [],
+    deps = [
+        ":sval-2.13.0",
+        ":sval_buffer-2.13.0",
+        ":sval_ref-2.13.0",
+    ],
+)
+
+http_archive(
+    name = "sval_ref-2.13.0.crate",
+    sha256 = "be2e7fc517d778f44f8cb64140afa36010999565528d48985f55e64d45f369ce",
+    strip_prefix = "sval_ref-2.13.0",
+    urls = ["https://static.crates.io/crates/sval_ref/2.13.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "sval_ref-2.13.0",
+    srcs = [":sval_ref-2.13.0.crate"],
+    crate = "sval_ref",
+    crate_root = "sval_ref-2.13.0.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "alloc",
+        "std",
+    ],
+    visibility = [],
+    deps = [":sval-2.13.0"],
+)
+
+http_archive(
+    name = "sval_serde-2.13.0.crate",
+    sha256 = "79bf66549a997ff35cd2114a27ac4b0c2843280f2cfa84b240d169ecaa0add46",
+    strip_prefix = "sval_serde-2.13.0",
+    urls = ["https://static.crates.io/crates/sval_serde/2.13.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "sval_serde-2.13.0",
+    srcs = [":sval_serde-2.13.0.crate"],
+    crate = "sval_serde",
+    crate_root = "sval_serde-2.13.0.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "alloc",
+        "std",
+    ],
+    visibility = [],
+    deps = [
+        ":serde-1.0.198",
+        ":sval-2.13.0",
+        ":sval_nested-2.13.0",
+    ],
+)
+
 http_archive(
     name = "syn-1.0.109.crate",
     sha256 = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237",
@@ -9365,6 +11396,12 @@ cargo.rust_library(
         ":quote-1.0.36",
         ":unicode-ident-1.0.12",
     ],
+)
+
+alias(
+    name = "synstructure",
+    actual = ":synstructure-0.12.6",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -9596,6 +11633,56 @@ cargo.rust_library(
     deps = [":dirs-next-2.0.0"],
 )
 
+alias(
+    name = "term_size",
+    actual = ":term_size-0.3.2",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "term_size-0.3.2.crate",
+    sha256 = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9",
+    strip_prefix = "term_size-0.3.2",
+    urls = ["https://static.crates.io/crates/term_size/0.3.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "term_size-0.3.2",
+    srcs = [":term_size-0.3.2.crate"],
+    crate = "term_size",
+    crate_root = "term_size-0.3.2.crate/src/lib.rs",
+    edition = "2015",
+    features = ["default"],
+    platform = {
+        "linux-arm64": dict(
+            deps = [":libc-0.2.153"],
+        ),
+        "linux-x86_64": dict(
+            deps = [":libc-0.2.153"],
+        ),
+        "macos-arm64": dict(
+            deps = [":libc-0.2.153"],
+        ),
+        "macos-x86_64": dict(
+            deps = [":libc-0.2.153"],
+        ),
+        "windows-gnu": dict(
+            deps = [":winapi-0.3.9"],
+        ),
+        "windows-msvc": dict(
+            deps = [":winapi-0.3.9"],
+        ),
+    },
+    visibility = [],
+)
+
+alias(
+    name = "termcolor",
+    actual = ":termcolor-1.4.1",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "termcolor-1.4.1.crate",
     sha256 = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755",
@@ -9656,6 +11743,12 @@ cargo.rust_library(
         ),
     },
     visibility = [],
+)
+
+alias(
+    name = "terminal_size",
+    actual = ":terminal_size-0.3.0",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -9833,6 +11926,12 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "thread_local",
+    actual = ":thread_local-1.1.8",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "thread_local-1.1.8.crate",
     sha256 = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c",
@@ -9854,76 +11953,105 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "time",
+    actual = ":time-0.3.17",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
-    name = "time-0.3.36.crate",
-    sha256 = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885",
-    strip_prefix = "time-0.3.36",
-    urls = ["https://static.crates.io/crates/time/0.3.36/download"],
+    name = "time-0.3.17.crate",
+    sha256 = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376",
+    strip_prefix = "time-0.3.17",
+    urls = ["https://static.crates.io/crates/time/0.3.17/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "time-0.3.36",
-    srcs = [":time-0.3.36.crate"],
+    name = "time-0.3.17",
+    srcs = [":time-0.3.17.crate"],
     crate = "time",
-    crate_root = "time-0.3.36.crate/src/lib.rs",
+    crate_root = "time-0.3.17.crate/src/lib.rs",
     edition = "2021",
     features = [
         "alloc",
+        "default",
         "formatting",
         "macros",
         "std",
     ],
     visibility = [],
     deps = [
-        ":deranged-0.3.11",
         ":itoa-1.0.11",
-        ":num-conv-0.1.0",
-        ":powerfmt-0.2.0",
         ":serde-1.0.198",
-        ":time-core-0.1.2",
-        ":time-macros-0.2.18",
+        ":time-core-0.1.0",
+        ":time-macros-0.2.6",
     ],
 )
 
 http_archive(
-    name = "time-core-0.1.2.crate",
-    sha256 = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3",
-    strip_prefix = "time-core-0.1.2",
-    urls = ["https://static.crates.io/crates/time-core/0.1.2/download"],
+    name = "time-core-0.1.0.crate",
+    sha256 = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd",
+    strip_prefix = "time-core-0.1.0",
+    urls = ["https://static.crates.io/crates/time-core/0.1.0/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "time-core-0.1.2",
-    srcs = [":time-core-0.1.2.crate"],
+    name = "time-core-0.1.0",
+    srcs = [":time-core-0.1.0.crate"],
     crate = "time_core",
-    crate_root = "time-core-0.1.2.crate/src/lib.rs",
+    crate_root = "time-core-0.1.0.crate/src/lib.rs",
     edition = "2021",
     visibility = [],
 )
 
 http_archive(
-    name = "time-macros-0.2.18.crate",
-    sha256 = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf",
-    strip_prefix = "time-macros-0.2.18",
-    urls = ["https://static.crates.io/crates/time-macros/0.2.18/download"],
+    name = "time-macros-0.2.6.crate",
+    sha256 = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2",
+    strip_prefix = "time-macros-0.2.6",
+    urls = ["https://static.crates.io/crates/time-macros/0.2.6/download"],
     visibility = [],
 )
 
 cargo.rust_library(
-    name = "time-macros-0.2.18",
-    srcs = [":time-macros-0.2.18.crate"],
+    name = "time-macros-0.2.6",
+    srcs = [":time-macros-0.2.6.crate"],
     crate = "time_macros",
-    crate_root = "time-macros-0.2.18.crate/src/lib.rs",
+    crate_root = "time-macros-0.2.6.crate/src/lib.rs",
     edition = "2021",
     features = ["formatting"],
     proc_macro = True,
     visibility = [],
-    deps = [
-        ":num-conv-0.1.0",
-        ":time-core-0.1.2",
+    deps = [":time-core-0.1.0"],
+)
+
+alias(
+    name = "tiny-keccak",
+    actual = ":tiny-keccak-2.0.2",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "tiny-keccak-2.0.2.crate",
+    sha256 = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237",
+    strip_prefix = "tiny-keccak-2.0.2",
+    urls = ["https://static.crates.io/crates/tiny-keccak/2.0.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "tiny-keccak-2.0.2",
+    srcs = [":tiny-keccak-2.0.2.crate"],
+    crate = "tiny_keccak",
+    crate_root = "tiny-keccak-2.0.2.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "default",
+        "sha3",
     ],
+    visibility = [],
+    deps = [":crunchy-0.2.2"],
 )
 
 http_archive(
@@ -10212,6 +12340,40 @@ cargo.rust_library(
     deps = [":serde-1.0.198"],
 )
 
+alias(
+    name = "toml_edit",
+    actual = ":toml_edit-0.20.7",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "toml_edit-0.20.7.crate",
+    sha256 = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81",
+    strip_prefix = "toml_edit-0.20.7",
+    urls = ["https://static.crates.io/crates/toml_edit/0.20.7/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "toml_edit-0.20.7",
+    srcs = [":toml_edit-0.20.7.crate"],
+    crate = "toml_edit",
+    crate_root = "toml_edit-0.20.7.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "default",
+        "serde",
+    ],
+    visibility = [],
+    deps = [
+        ":indexmap-2.2.6",
+        ":serde-1.0.198",
+        ":serde_spanned-0.6.5",
+        ":toml_datetime-0.6.5",
+        ":winnow-0.5.40",
+    ],
+)
+
 http_archive(
     name = "toml_edit-0.22.12.crate",
     sha256 = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef",
@@ -10239,6 +12401,12 @@ cargo.rust_library(
         ":toml_datetime-0.6.5",
         ":winnow-0.6.6",
     ],
+)
+
+alias(
+    name = "tower-service",
+    actual = ":tower-service-0.3.2",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -10380,6 +12548,12 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "tracing-log",
+    actual = ":tracing-log-0.2.0",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "tracing-log-0.2.0.crate",
     sha256 = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3",
@@ -10395,6 +12569,7 @@ cargo.rust_library(
     crate_root = "tracing-log-0.2.0.crate/src/lib.rs",
     edition = "2018",
     features = [
+        "default",
         "log-tracer",
         "std",
     ],
@@ -10402,6 +12577,33 @@ cargo.rust_library(
     deps = [
         ":log-0.4.21",
         ":once_cell-1.19.0",
+        ":tracing-core-0.1.32",
+    ],
+)
+
+alias(
+    name = "tracing-serde",
+    actual = ":tracing-serde-0.1.3",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "tracing-serde-0.1.3.crate",
+    sha256 = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1",
+    strip_prefix = "tracing-serde-0.1.3",
+    urls = ["https://static.crates.io/crates/tracing-serde/0.1.3/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "tracing-serde-0.1.3",
+    srcs = [":tracing-serde-0.1.3.crate"],
+    crate = "tracing_serde",
+    crate_root = "tracing-serde-0.1.3.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [
+        ":serde-1.0.198",
         ":tracing-core-0.1.32",
     ],
 )
@@ -10625,6 +12827,12 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "typenum",
+    actual = ":typenum-1.17.0",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "typenum-1.17.0.crate",
     sha256 = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825",
@@ -10639,7 +12847,29 @@ cargo.rust_library(
     crate = "typenum",
     crate_root = "typenum-1.17.0.crate/src/lib.rs",
     edition = "2018",
+    env = {
+        "OUT_DIR": "$(location :typenum-1.17.0-build-script-main-run[out_dir])",
+    },
+    features = ["force_unix_path_separator"],
     visibility = [],
+)
+
+cargo.rust_binary(
+    name = "typenum-1.17.0-build-script-main",
+    srcs = [":typenum-1.17.0.crate"],
+    crate = "build_script_main",
+    crate_root = "typenum-1.17.0.crate/build/main.rs",
+    edition = "2018",
+    features = ["force_unix_path_separator"],
+    visibility = [],
+)
+
+buildscript_run(
+    name = "typenum-1.17.0-build-script-main-run",
+    package_name = "typenum",
+    buildscript_rule = ":typenum-1.17.0-build-script-main",
+    features = ["force_unix_path_separator"],
+    version = "1.17.0",
 )
 
 alias(
@@ -10825,6 +13055,12 @@ cargo.rust_library(
     deps = [":unic-common-0.9.0"],
 )
 
+alias(
+    name = "unicase",
+    actual = ":unicase-2.7.0",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "unicase-2.7.0.crate",
     sha256 = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89",
@@ -10839,7 +13075,28 @@ cargo.rust_library(
     crate = "unicase",
     crate_root = "unicase-2.7.0.crate/src/lib.rs",
     edition = "2015",
+    env = {
+        "OUT_DIR": "$(location :unicase-2.7.0-build-script-run[out_dir])",
+    },
+    rustc_flags = ["@$(location :unicase-2.7.0-build-script-run[rustc_flags])"],
     visibility = [],
+)
+
+cargo.rust_binary(
+    name = "unicase-2.7.0-build-script-build",
+    srcs = [":unicase-2.7.0.crate"],
+    crate = "build_script_build",
+    crate_root = "unicase-2.7.0.crate/build.rs",
+    edition = "2015",
+    visibility = [],
+    deps = [":version_check-0.9.4"],
+)
+
+buildscript_run(
+    name = "unicase-2.7.0-build-script-run",
+    package_name = "unicase",
+    buildscript_rule = ":unicase-2.7.0-build-script-build",
+    version = "2.7.0",
 )
 
 http_archive(
@@ -10861,6 +13118,12 @@ cargo.rust_library(
         "std",
     ],
     visibility = [],
+)
+
+alias(
+    name = "unicode-ident",
+    actual = ":unicode-ident-1.0.12",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -10916,6 +13179,12 @@ cargo.rust_library(
     deps = [":tinyvec-1.6.0"],
 )
 
+alias(
+    name = "unicode-segmentation",
+    actual = ":unicode-segmentation-1.11.0",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "unicode-segmentation-1.11.0.crate",
     sha256 = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202",
@@ -10931,6 +13200,12 @@ cargo.rust_library(
     crate_root = "unicode-segmentation-1.11.0.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
+)
+
+alias(
+    name = "unicode-width",
+    actual = ":unicode-width-0.1.11",
+    visibility = ["PUBLIC"],
 )
 
 http_archive(
@@ -11080,6 +13355,95 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "value-bag-1.8.1.crate",
+    sha256 = "74797339c3b98616c009c7c3eb53a0ce41e85c8ec66bd3db96ed132d20cfdee8",
+    strip_prefix = "value-bag-1.8.1",
+    urls = ["https://static.crates.io/crates/value-bag/1.8.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "value-bag-1.8.1",
+    srcs = [":value-bag-1.8.1.crate"],
+    crate = "value_bag",
+    crate_root = "value-bag-1.8.1.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "alloc",
+        "error",
+        "inline-i128",
+        "std",
+    ],
+    visibility = [],
+    deps = [
+        ":value-bag-serde1-1.8.1",
+        ":value-bag-sval2-1.8.1",
+    ],
+)
+
+http_archive(
+    name = "value-bag-serde1-1.8.1.crate",
+    sha256 = "cc35703541cbccb5278ef7b589d79439fc808ff0b5867195a3230f9a47421d39",
+    strip_prefix = "value-bag-serde1-1.8.1",
+    urls = ["https://static.crates.io/crates/value-bag-serde1/1.8.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "value-bag-serde1-1.8.1",
+    srcs = [":value-bag-serde1-1.8.1.crate"],
+    crate = "value_bag_serde1",
+    crate_root = "value-bag-serde1-1.8.1.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "alloc",
+        "std",
+    ],
+    visibility = [],
+    deps = [
+        ":erased-serde-0.4.4",
+        ":serde-1.0.198",
+        ":serde_fmt-1.0.3",
+    ],
+)
+
+http_archive(
+    name = "value-bag-sval2-1.8.1.crate",
+    sha256 = "285b43c29d0b4c0e65aad24561baee67a1b69dc9be9375d4a85138cbf556f7f8",
+    strip_prefix = "value-bag-sval2-1.8.1",
+    urls = ["https://static.crates.io/crates/value-bag-sval2/1.8.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "value-bag-sval2-1.8.1",
+    srcs = [":value-bag-sval2-1.8.1.crate"],
+    crate = "value_bag_sval2",
+    crate_root = "value-bag-sval2-1.8.1.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "alloc",
+        "std",
+    ],
+    visibility = [],
+    deps = [
+        ":sval-2.13.0",
+        ":sval_buffer-2.13.0",
+        ":sval_dynamic-2.13.0",
+        ":sval_fmt-2.13.0",
+        ":sval_json-2.13.0",
+        ":sval_ref-2.13.0",
+        ":sval_serde-2.13.0",
+    ],
+)
+
+alias(
+    name = "vec_map",
+    actual = ":vec_map-0.8.2",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
     name = "vec_map-0.8.2.crate",
     sha256 = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191",
     strip_prefix = "vec_map-0.8.2",
@@ -11164,6 +13528,183 @@ cargo.rust_library(
 )
 
 alias(
+    name = "wasm-bindgen",
+    actual = ":wasm-bindgen-0.2.92",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "wasm-bindgen-0.2.92.crate",
+    sha256 = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8",
+    strip_prefix = "wasm-bindgen-0.2.92",
+    urls = ["https://static.crates.io/crates/wasm-bindgen/0.2.92/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "wasm-bindgen-0.2.92",
+    srcs = [":wasm-bindgen-0.2.92.crate"],
+    crate = "wasm_bindgen",
+    crate_root = "wasm-bindgen-0.2.92.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "default",
+        "spans",
+        "std",
+    ],
+    visibility = [],
+    deps = [
+        ":cfg-if-1.0.0",
+        ":wasm-bindgen-macro-0.2.92",
+    ],
+)
+
+http_archive(
+    name = "wasm-bindgen-backend-0.2.92.crate",
+    sha256 = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da",
+    strip_prefix = "wasm-bindgen-backend-0.2.92",
+    urls = ["https://static.crates.io/crates/wasm-bindgen-backend/0.2.92/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "wasm-bindgen-backend-0.2.92",
+    srcs = [":wasm-bindgen-backend-0.2.92.crate"],
+    crate = "wasm_bindgen_backend",
+    crate_root = "wasm-bindgen-backend-0.2.92.crate/src/lib.rs",
+    edition = "2018",
+    features = ["spans"],
+    visibility = [],
+    deps = [
+        ":bumpalo-3.16.0",
+        ":log-0.4.21",
+        ":once_cell-1.19.0",
+        ":proc-macro2-1.0.81",
+        ":quote-1.0.36",
+        ":syn-2.0.60",
+        ":wasm-bindgen-shared-0.2.92",
+    ],
+)
+
+http_archive(
+    name = "wasm-bindgen-macro-0.2.92.crate",
+    sha256 = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726",
+    strip_prefix = "wasm-bindgen-macro-0.2.92",
+    urls = ["https://static.crates.io/crates/wasm-bindgen-macro/0.2.92/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "wasm-bindgen-macro-0.2.92",
+    srcs = [":wasm-bindgen-macro-0.2.92.crate"],
+    crate = "wasm_bindgen_macro",
+    crate_root = "wasm-bindgen-macro-0.2.92.crate/src/lib.rs",
+    edition = "2018",
+    features = ["spans"],
+    proc_macro = True,
+    visibility = [],
+    deps = [
+        ":quote-1.0.36",
+        ":wasm-bindgen-macro-support-0.2.92",
+    ],
+)
+
+http_archive(
+    name = "wasm-bindgen-macro-support-0.2.92.crate",
+    sha256 = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7",
+    strip_prefix = "wasm-bindgen-macro-support-0.2.92",
+    urls = ["https://static.crates.io/crates/wasm-bindgen-macro-support/0.2.92/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "wasm-bindgen-macro-support-0.2.92",
+    srcs = [":wasm-bindgen-macro-support-0.2.92.crate"],
+    crate = "wasm_bindgen_macro_support",
+    crate_root = "wasm-bindgen-macro-support-0.2.92.crate/src/lib.rs",
+    edition = "2018",
+    features = ["spans"],
+    visibility = [],
+    deps = [
+        ":proc-macro2-1.0.81",
+        ":quote-1.0.36",
+        ":syn-2.0.60",
+        ":wasm-bindgen-backend-0.2.92",
+        ":wasm-bindgen-shared-0.2.92",
+    ],
+)
+
+http_archive(
+    name = "wasm-bindgen-shared-0.2.92.crate",
+    sha256 = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96",
+    strip_prefix = "wasm-bindgen-shared-0.2.92",
+    urls = ["https://static.crates.io/crates/wasm-bindgen-shared/0.2.92/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "wasm-bindgen-shared-0.2.92",
+    srcs = [":wasm-bindgen-shared-0.2.92.crate"],
+    crate = "wasm_bindgen_shared",
+    crate_root = "wasm-bindgen-shared-0.2.92.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+)
+
+alias(
+    name = "which",
+    actual = ":which-4.4.2",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "which-4.4.2.crate",
+    sha256 = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7",
+    strip_prefix = "which-4.4.2",
+    urls = ["https://static.crates.io/crates/which/4.4.2/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "which-4.4.2",
+    srcs = [":which-4.4.2.crate"],
+    crate = "which",
+    crate_root = "which-4.4.2.crate/src/lib.rs",
+    edition = "2021",
+    platform = {
+        "linux-arm64": dict(
+            deps = [":home-0.5.9"],
+        ),
+        "linux-x86_64": dict(
+            deps = [":home-0.5.9"],
+        ),
+        "macos-arm64": dict(
+            deps = [":home-0.5.9"],
+        ),
+        "macos-x86_64": dict(
+            deps = [":home-0.5.9"],
+        ),
+        "windows-gnu": dict(
+            deps = [
+                ":home-0.5.9",
+                ":once_cell-1.19.0",
+            ],
+        ),
+        "windows-msvc": dict(
+            deps = [
+                ":home-0.5.9",
+                ":once_cell-1.19.0",
+            ],
+        ),
+    },
+    visibility = [],
+    deps = [
+        ":either-1.11.0",
+        ":rustix-0.38.34",
+    ],
+)
+
+alias(
     name = "whoami",
     actual = ":whoami-1.5.1",
     visibility = ["PUBLIC"],
@@ -11207,15 +13748,24 @@ cargo.rust_library(
     edition = "2015",
     features = [
         "basetsd",
+        "cfg",
         "consoleapi",
         "errhandlingapi",
+        "evntrace",
         "fileapi",
         "handleapi",
+        "in6addr",
+        "inaddr",
+        "ioapiset",
         "knownfolders",
         "libloaderapi",
         "minwinbase",
         "minwindef",
+        "mstcpip",
+        "mswsock",
+        "namedpipeapi",
         "ntdef",
+        "ntsecapi",
         "objbase",
         "processenv",
         "shellapi",
@@ -11225,8 +13775,13 @@ cargo.rust_library(
         "synchapi",
         "winbase",
         "wincon",
+        "windef",
         "winerror",
+        "winioctl",
+        "winsock2",
         "winuser",
+        "ws2def",
+        "ws2ipdef",
     ],
     platform = {
         "windows-gnu": dict(
@@ -11363,6 +13918,7 @@ cargo.rust_library(
         "Win32_Storage",
         "Win32_Storage_FileSystem",
         "Win32_System",
+        "Win32_System_Com",
         "Win32_System_Console",
         "Win32_System_Diagnostics",
         "Win32_System_Diagnostics_Debug",
@@ -11374,6 +13930,7 @@ cargo.rust_library(
         "Win32_UI",
         "Win32_UI_Input",
         "Win32_UI_Input_KeyboardAndMouse",
+        "Win32_UI_Shell",
         "default",
     ],
     visibility = [],
@@ -11505,6 +14062,29 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "winnow-0.5.40.crate",
+    sha256 = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876",
+    strip_prefix = "winnow-0.5.40",
+    urls = ["https://static.crates.io/crates/winnow/0.5.40/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "winnow-0.5.40",
+    srcs = [":winnow-0.5.40.crate"],
+    crate = "winnow",
+    crate_root = "winnow-0.5.40.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "alloc",
+        "default",
+        "std",
+    ],
+    visibility = [],
+    deps = [":memchr-2.7.2"],
+)
+
+http_archive(
     name = "winnow-0.6.6.crate",
     sha256 = "f0c976aaaa0e1f90dbb21e9587cdaf1d9679a1cde8875c0d6bd83ab96a208352",
     strip_prefix = "winnow-0.6.6",
@@ -11602,6 +14182,35 @@ cargo.rust_library(
     visibility = [],
 )
 
+alias(
+    name = "yansi",
+    actual = ":yansi-1.0.1",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "yansi-1.0.1.crate",
+    sha256 = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049",
+    strip_prefix = "yansi-1.0.1",
+    urls = ["https://static.crates.io/crates/yansi/1.0.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "yansi-1.0.1",
+    srcs = [":yansi-1.0.1.crate"],
+    crate = "yansi",
+    crate_root = "yansi-1.0.1.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "alloc",
+        "default",
+        "hyperlink",
+        "std",
+    ],
+    visibility = [],
+)
+
 http_archive(
     name = "zerocopy-0.7.32.crate",
     sha256 = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be",
@@ -11616,7 +14225,33 @@ cargo.rust_library(
     crate = "zerocopy",
     crate_root = "zerocopy-0.7.32.crate/src/lib.rs",
     edition = "2018",
+    env = {
+        "CARGO_PKG_VERSION": "0.7.32",
+    },
     features = ["simd"],
+    visibility = [],
+)
+
+alias(
+    name = "zeroize",
+    actual = ":zeroize-1.8.0",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "zeroize-1.8.0.crate",
+    sha256 = "63381fa6624bf92130a6b87c0d07380116f80b565c42cf0d754136f0238359ef",
+    strip_prefix = "zeroize-1.8.0",
+    urls = ["https://static.crates.io/crates/zeroize/1.8.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "zeroize-1.8.0",
+    srcs = [":zeroize-1.8.0.crate"],
+    crate = "zeroize",
+    crate_root = "zeroize-1.8.0.crate/src/lib.rs",
+    edition = "2021",
     visibility = [],
 )
 
@@ -11652,6 +14287,12 @@ cargo.rust_library(
     deps = [":zstd-safe-7.1.0"],
 )
 
+alias(
+    name = "zstd-safe",
+    actual = ":zstd-safe-7.1.0",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "zstd-safe-7.1.0.crate",
     sha256 = "1cd99b45c6bc03a018c8b8a86025678c87e55526064e38f9df301989dce7ec0a",
@@ -11668,6 +14309,7 @@ cargo.rust_library(
     edition = "2018",
     features = [
         "arrays",
+        "default",
         "experimental",
         "legacy",
         "std",


### PR DESCRIPTION
Summary:
The current codegen implementation misses setting fixups on crates that are
transitive dependencies. This diff fixes that so that all crates should be
buildable.

Test Plan:
```
❯ buck run fbcode//antlir/facebook/opensource:reindeer
```

Differential Revision: D56532758
