### PR TITLE
[antlir][oss] use watchman

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -18,3 +18,6 @@ target_platform_detector_spec = target:antlir//...->prelude//platforms:default
 
 [project]
 ignore = antlir2-out, .git, .sl
+
+[buck2]
+file_watcher = watchman

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ jobs:
           sudo apt install \
             cpio jq systemd-container
 
+      - name: Disable watchman
+        run: |
+          echo '[buck2]' >> .buckconfig
+          echo 'file_watcher=notify' >> .buckconfig
+
       - name: Find tests
         run: |
           ./buck2 uquery 'kind(".*_test", set(%s)) - attrfilter(labels, disabled, set(%s))' \

--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,0 +1,4 @@
+{
+    "ignore_dirs": ["antlir2-out", "buck-out"],
+    "ignore_vcs": [".git", ".sl"]
+}


### PR DESCRIPTION
Summary:
Configure buck2 to use `watchman` locally, while providing a `mode/gha` file
that uses the OSS-default `notify` mechanism on GitHub Actions, where
`watchman` is not available.

Test Plan: Export to PR

Reviewed By: sergeyfd

Differential Revision: D57296213


