### PR TITLE
[antlir][oss] fix/disable more tests and enable those that work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: facebook/install-dotslash@latest
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: nightly
+          targets: x86_64-unknown-linux-gnu,aarch64-unknown-linux-gnu
       - name: BTRFS-ify antlir2-out
         run: |
           mkdir antlir2-out
@@ -34,12 +34,14 @@ jobs:
 
       - name: Find tests
         run: |
-          ./buck2 uquery 'kind(".*_test", set(%s)) - attrfilter(labels, disabled, set(%s))' \
-            //antlir/antlir2/antlir2_facts/... \
-            //antlir/antlir2/features/clone/tests: \
-            //antlir/antlir2/features/install/tests: \
-            //antlir/antlir2/features/rpm/tests: \
-            //antlir/antlir2/features/tarball/tests: \
+          ./buck2 bxl :find_tests.bxl:find_tests -- \
+            --pattern //antlir/antlir2/antlir2_facts/... \
+            --pattern //antlir/antlir2/features/... \
+            --pattern //antlir/antlir2/test_images/... \
+            --disable //antlir/antlir2/test_images/cfg/os/... \
+            --disable //antlir/antlir2/test_images/cfg/target_arch/... \
+            --disable //antlir/antlir2/test_images/package/ext3/... \
+            --disable //antlir/antlir2/test_images/package/xar/... \
             | tee ${{ runner.temp }}/tests.txt
 
       - name: Build tests

--- a/antlir/antlir2/features/dot_meta/tests/BUCK
+++ b/antlir/antlir2/features/dot_meta/tests/BUCK
@@ -2,7 +2,7 @@ load("//antlir/antlir2/bzl/image:defs.bzl", "image")
 load("//antlir/antlir2/bzl/package:defs.bzl", "package")
 load("//antlir/antlir2/features/dot_meta:dot_meta.bzl", "dot_meta")
 load("//antlir/antlir2/testing:image_diff_test.bzl", "image_diff_test")
-load("//antlir/bzl:build_defs.bzl", "buck_sh_test")
+load("//antlir/bzl:build_defs.bzl", "buck_sh_test", "internal_external")
 
 # Normally, the `dot_meta` feature is included only when packaging up a final
 # layer, but we want to make it easier to test with image_diff_test, so these
@@ -31,7 +31,10 @@ image.layer(
 
 image_diff_test(
     name = "dot_meta-test",
-    diff = "dot_meta.toml",
+    diff = internal_external(
+        fb = "dot_meta.toml",
+        oss = "dot_meta.oss.toml",
+    ),
     diff_type = "file",
     layer = ":dot_meta",
 )
@@ -47,6 +50,12 @@ package.cpio_gz(
 
 buck_sh_test(
     name = "cpio-is-stamped",
-    args = ["$(location :stamped.cpio.gz)"],
+    args = [
+        "$(location :stamped.cpio.gz)",
+        internal_external(
+            fb = "fbcode//antlir/antlir2/features/dot_meta/tests:stamped.cpio.gz",
+            oss = "antlir//antlir/antlir2/features/dot_meta/tests:stamped.cpio.gz",
+        ),
+    ],
     test = "test-cpio-is-stamped.sh",
 )

--- a/antlir/antlir2/features/dot_meta/tests/dot_meta.oss.toml
+++ b/antlir/antlir2/features/dot_meta/tests/dot_meta.oss.toml
@@ -1,0 +1,35 @@
+[file.".meta/package"]
+op = "added"
+
+[file.".meta/package".diff]
+mode = "u+rw,g+r,o+r"
+file-type = "regular-file"
+user = "root"
+group = "root"
+text = """
+foo:bar
+"""
+
+[file.".meta/revision"]
+op = "added"
+
+[file.".meta/revision".diff]
+mode = "u+rw,g+r,o+r"
+file-type = "regular-file"
+user = "root"
+group = "root"
+text = """
+deadbeef
+"""
+
+[file.".meta/target"]
+op = "diff"
+
+[file.".meta/target".diff]
+text-patch = """
+--- parent
++++ child
+@@ -1 +1 @@
+-antlir//antlir/antlir2/features/dot_meta/tests:base
++antlir//antlir/antlir2/features/dot_meta/tests:dot_meta
+"""

--- a/antlir/antlir2/features/dot_meta/tests/test-cpio-is-stamped.sh
+++ b/antlir/antlir2/features/dot_meta/tests/test-cpio-is-stamped.sh
@@ -5,8 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 set -e
+
 target="$(zcat "$1" | cpio -i --to-stdout .meta/target)"
-if [ "$target" != "fbcode//antlir/antlir2/features/dot_meta/tests:stamped.cpio.gz" ]; then
+expected="$2"
+if [ "$target" != "$expected" ]; then
     echo "bad target: $target"
+    echo "expected: $expected"
     exit 1
 fi

--- a/antlir/antlir2/features/extract/tests/BUCK
+++ b/antlir/antlir2/features/extract/tests/BUCK
@@ -1,7 +1,7 @@
 load("//antlir/antlir2/bzl/feature:defs.bzl", "feature")
 load("//antlir/antlir2/bzl/image:defs.bzl", "image")
 load("//antlir/antlir2/testing:image_test.bzl", "image_sh_test")
-load("//antlir/bzl:build_defs.bzl", "rust_binary")
+load("//antlir/bzl:build_defs.bzl", "internal_external", "rust_binary")
 
 oncall("antlir")
 
@@ -36,11 +36,19 @@ image.layer(
             dst = "/usr/bin/test-binary-extracted",
         ),
     ],
+    labels = internal_external(
+        fb = [],
+        oss = ["disabled"],
+    ),
     parent_layer = ":base",
 )
 
 image_sh_test(
     name = "extract-buck-test",
+    labels = internal_external(
+        fb = [],
+        oss = ["disabled"],
+    ),
     layer = ":extract-buck",
     test = "test-extract-buck.sh",
 )

--- a/antlir/antlir2/features/genrule/tests/genrule-with-repo.sh
+++ b/antlir/antlir2/features/genrule/tests/genrule-with-repo.sh
@@ -13,9 +13,11 @@ if [ -f "/is-facebook" ]; then
         echo "not in repo" > /status
     fi
 else
-    if [ -f ".git" ]; then
+    if [ -d ".git" ]; then
         echo "in repo" > /status
-    elif [ -f ".hg" ]; then
+    elif [ -d ".hg" ]; then
+        echo "in repo" > /status
+    elif [ -d ".sl" ]; then
         echo "in repo" > /status
     else
         echo "not in repo" > /status

--- a/antlir/antlir2/features/rpm/tests/centos8/BUCK
+++ b/antlir/antlir2/features/rpm/tests/centos8/BUCK
@@ -3,6 +3,7 @@ load("//antlir/antlir2/bzl/image:defs.bzl", "image")
 load("//antlir/antlir2/features/rpm/tests:defs.bzl", "expected_t", "test_rpms")
 load("//antlir/antlir2/package_managers/dnf/rules:repo.bzl", "repo_set")
 load("//antlir/antlir2/testing:image_test.bzl", "image_python_test")
+load("//antlir/bzl:build_defs.bzl", "internal_external")
 
 oncall("antlir")
 
@@ -33,6 +34,10 @@ test_rpms(
             ] + _RPM_DEPS_OF_TEST,
         ),
     ],
+    labels = internal_external(
+        fb = [],
+        oss = ["disabled"],
+    ),
 )
 
 image.layer(
@@ -40,10 +45,18 @@ image.layer(
     features = [
         feature.rpms_install(rpms = _RPM_DEPS_OF_TEST),
     ],
+    labels = internal_external(
+        fb = [],
+        oss = ["disabled"],
+    ),
 )
 
 image_python_test(
     name = "test-db-backend",
     srcs = ["test_db_backend.py"],
+    labels = internal_external(
+        fb = [],
+        oss = ["disabled"],
+    ),
     layer = ":simple",
 )

--- a/antlir/antlir2/testing/image_test.bzl
+++ b/antlir/antlir2/testing/image_test.bzl
@@ -15,7 +15,7 @@ load("//antlir/antlir2/bzl:types.bzl", "LayerInfo")
 load("//antlir/antlir2/bzl/feature:defs.bzl", "feature")
 load("//antlir/antlir2/bzl/image:cfg.bzl", "cfg_attrs", "layer_cfg")
 load("//antlir/antlir2/bzl/image:defs.bzl", "image")
-load("//antlir/bzl:build_defs.bzl", "add_test_framework_label", "buck_sh_test", "cpp_unittest", "is_facebook", "python_unittest", "rust_unittest")
+load("//antlir/bzl:build_defs.bzl", "add_test_framework_label", "buck_sh_test", "cpp_unittest", "internal_external", "is_facebook", "python_unittest", "rust_unittest")
 load("//antlir/bzl:constants.bzl", "REPO_CFG")
 load("//antlir/bzl:systemd.bzl", "systemd")
 load("//antlir/bzl:oss_shim.bzl", "special_tags") # @oss-enable
@@ -253,7 +253,11 @@ image_cpp_test = partial(
     _implicit_image_test,
     cpp_unittest,
     _static_list_wrapper = antlir2_dep("//antlir/antlir2/testing/image_test:static-list-cpp"),
-    _add_outer_labels = ["tpx:optout-test-result-output-spec"],
+    _add_outer_labels = ["tpx:optout-test-result-output-spec"] + internal_external(
+        fb = [],
+        # don't have working gtest in oss (yet)
+        oss = ["disabled"],
+    ),
 )
 
 image_rust_test = partial(_implicit_image_test, rust_unittest)

--- a/find_tests.bxl
+++ b/find_tests.bxl
@@ -1,0 +1,20 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+def _impl(ctx):
+    tests = ctx.uquery().kind(".*_test", ctx.cli_args.pattern)
+
+    tests = tests - ctx.uquery().attrregexfilter("labels", "disabled", tests)
+    disable = ctx.unconfigured_targets([t for disable in ctx.cli_args.disable for t in disable])
+    tests = tests - disable
+    ctx.output.print("\n".join([str(t.label) for t in tests]))
+
+find_tests = bxl_main(
+    impl = _impl,
+    cli_args = {
+        "disable": cli_args.list(cli_args.target_expr(), default = []),
+        "pattern": cli_args.list(cli_args.string(), default = ["antlir//..."]),
+    },
+)


### PR DESCRIPTION
Summary:
We don't have centos8 in OSS and it's not worth adding.
We don't yet have buckified gtest.
Buck binaries are built against the system platform which then conflicts with
the system platform installed in the image (this would be a good use case for
epilatow's antlir2 toolchain stuff)

Enable a lot of other tests that should work.

Differential Revision: D57311394
