### PR TITLE
[antlir2][oss] cache buck-out

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -21,3 +21,7 @@ ignore = antlir2-out, .git, .sl
 
 [buck2]
 file_watcher = watchman
+materializations = deferred
+sqlite_materializer_state = true
+defer_write_actions = true
+hash_all_commands = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,20 +12,33 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+
       - uses: facebook/install-dotslash@latest
+
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: nightly
+        id: rust-toolchain
+
       - name: BTRFS-ify antlir2-out
         run: |
           mkdir antlir2-out
           truncate -s 100G ${{ runner.temp }}/image.btrfs
           mkfs.btrfs ${{ runner.temp }}/image.btrfs
           sudo mount ${{ runner.temp }}/image.btrfs antlir2-out
+
       - name: Install deps
         run: |
           sudo apt install \
             cpio jq systemd-container
+
+      - name: Restore buck2 cache
+        id: cache-buck2-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            buck-out
+          key: buck2-${{steps.rust-toolchain.outputs.cachekey}}-${{ github.sha }}
+          restore-keys: |
+            buck2-${{steps.rust-toolchain.outputs.cachekey}}
 
       - name: Disable watchman
         run: |
@@ -49,3 +62,12 @@ jobs:
       - name: Run tests
         run: |
           ./buck2 test @${{ runner.temp }}/tests.txt
+
+      - name: Save buck2 cache
+        id: cache-buck2-save
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          path: |
+            buck-out
+          key: buck2-${{steps.rust-toolchain.outputs.cachekey}}-${{ github.sha }}


### PR DESCRIPTION
Summary:
Cache buck-out for faster builds. Uses the rust toolchain cache key as the base
since nightly compilers changing need to bust the cache.

Test Plan: GitHub Actions

Differential Revision: D57142707


