### PR TITLE
[antlir][oss] use bundled prelude

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -1,23 +1,26 @@
-[repositories]
-antlir = .
-prelude = prelude
-toolchains = toolchains
-none = none
-generated = generated
+[cells]
+    antlir = .
+    prelude = prelude
+    toolchains = toolchains
+    none = none
+    generated = generated
 
-[repository_aliases]
-config = prelude
-ovr_config = prelude
-fbcode = none
-fbsource = none
-fbcode_macros = none
-buck = none
+[cell_aliases]
+    config = prelude
+    ovr_config = prelude
+    fbcode = none
+    fbsource = none
+    fbcode_macros = none
+    buck = none
+
+[external_cells]
+    prelude = bundled
 
 [parser]
-target_platform_detector_spec = target:antlir//...->prelude//platforms:default
+    target_platform_detector_spec = target:antlir//...->prelude//platforms:default
 
 [project]
-ignore = antlir2-out, .git, .sl
+    ignore = antlir2-out, .git, .sl
 
 [buck2]
-file_watcher = watchman
+    file_watcher = watchman


### PR DESCRIPTION
Summary:
We can use buck2's new external cells feature
(https://buck2.build/docs/users/advanced/external_cells/#the-bundled-origin) to
avoid needing to keep the prelude updated as a submodule.

Test Plan: GitHub Actions

Differential Revision: D57675187
