### PR TITLE
[antlir][oss] enable setcap in install feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install deps
         run: |
           sudo apt install \
-            cpio jq systemd-container
+            cpio jq libcap-dev systemd-container
 
       - name: Disable watchman
         run: |

--- a/antlir/antlir2/antlir2_packager/BUCK
+++ b/antlir/antlir2/antlir2_packager/BUCK
@@ -1,11 +1,6 @@
-load("//antlir/bzl:build_defs.bzl", "internal_external", "rust_binary")
+load("//antlir/bzl:build_defs.bzl", "rust_binary")
 
 oncall("antlir")
-
-have_libcap = internal_external(
-    fb = True,
-    oss = False,
-)
 
 rust_binary(
     name = "antlir2-packager",
@@ -13,7 +8,6 @@ rust_binary(
     compatible_with = [
         "ovr_config//os:linux",
     ],
-    rustc_flags = ["--cfg=libcap"] if have_libcap else [],
     visibility = ["PUBLIC"],
     deps = [
         "anyhow",
@@ -36,6 +30,7 @@ rust_binary(
         "//antlir/antlir2/antlir2_isolate:antlir2_isolate",
         "//antlir/antlir2/antlir2_rootless:antlir2_rootless",
         "//antlir/antlir2/antlir2_working_volume:antlir2_working_volume",
+        "//antlir/antlir2/libcap:libcap",
         "//antlir/util/cli/json_arg:json_arg",
-    ] + (["//antlir/antlir2/libcap:libcap"] if have_libcap else []),
+    ],
 )

--- a/antlir/antlir2/antlir2_packager/src/rpm.rs
+++ b/antlir/antlir2/antlir2_packager/src/rpm.rs
@@ -18,7 +18,6 @@ use anyhow::Context;
 use anyhow::Result;
 use chrono::prelude::*;
 use itertools::Itertools;
-#[cfg(libcap)]
 use libcap::FileExt as _;
 use serde::Deserialize;
 use tempfile::NamedTempFile;
@@ -199,7 +198,6 @@ AutoProv: {autoprov}
                 if relpath == Path::new("/") {
                     continue;
                 }
-                #[cfg(libcap)]
                 if let Some(caps) =
                     std::fs::File::open(entry.path()).and_then(|f| f.get_capabilities())?
                 {

--- a/antlir/antlir2/features/install/BUCK
+++ b/antlir/antlir2/features/install/BUCK
@@ -26,13 +26,13 @@ feature_impl(
             ":no-setcap": [],
             "DEFAULT": ["setcap"],
         }),
-        oss = [],
+        oss = ["setcap"],
     ),
     deps = internal_external(
         fb = select({
             ":no-setcap": _base_deps,
             "DEFAULT": _base_deps + ["//antlir/antlir2/libcap:libcap"],
         }),
-        oss = _base_deps,
+        oss = _base_deps + ["//antlir/antlir2/libcap:libcap"],
     ),
 )

--- a/antlir/antlir2/features/install/install.rs
+++ b/antlir/antlir2/features/install/install.rs
@@ -32,15 +32,12 @@ use antlir2_users::GroupId;
 use antlir2_users::Id;
 use antlir2_users::UserId;
 use anyhow::Context;
-#[cfg(feature = "setcap")]
 use libcap::Capabilities;
-#[cfg(feature = "setcap")]
 use libcap::FileExt as _;
 use serde::de::Deserializer;
 use serde::de::Error as _;
 use serde::Deserialize;
 use serde_with::serde_as;
-#[cfg(feature = "setcap")]
 use serde_with::DisplayFromStr;
 use tracing::debug;
 use walkdir::WalkDir;
@@ -58,7 +55,6 @@ pub struct Install {
     pub user: UserName,
     pub binary_info: Option<BinaryInfo>,
     pub xattrs: HashMap<String, XattrValue>,
-    #[cfg(feature = "setcap")]
     #[serde_as(as = "Option<DisplayFromStr>")]
     pub setcap: Option<Capabilities>,
     pub always_use_gnu_debuglink: bool,
@@ -435,7 +431,6 @@ impl antlir2_compile::CompileFeature for Install {
                 for (key, val) in &self.xattrs {
                     dst_file.set_xattr(key, &val.0)?;
                 }
-                #[cfg(feature = "setcap")]
                 if let Some(cap) = self.setcap.as_ref() {
                     // Technically we could just use self.setcap directly, but
                     // then that would still result in a syscall to clear the

--- a/antlir/antlir2/features/install/tests/BUCK
+++ b/antlir/antlir2/features/install/tests/BUCK
@@ -5,7 +5,7 @@ load("//antlir/antlir2/bzl/image:defs.bzl", "image")
 load("//antlir/antlir2/testing:image_diff_test.bzl", "image_diff_test")
 load("//antlir/antlir2/testing:image_test.bzl", "image_python_test", "image_rust_test")
 load("//antlir/antlir2/testing:query_test.bzl", "query_test")
-load("//antlir/bzl:build_defs.bzl", "buck_genrule", "export_file", "internal_external", "python_binary", "rust_binary")
+load("//antlir/bzl:build_defs.bzl", "buck_genrule", "export_file", "python_binary", "rust_binary")
 
 oncall("antlir")
 
@@ -382,10 +382,6 @@ image_diff_test(
         "ovr_config//cpu:x86_64": "setcap.x86_64.toml",
     }),
     diff_type = "file",
-    labels = internal_external(
-        fb = [],
-        oss = ["disabled"],
-    ),
     layer = ":setcap",
 )
 

--- a/antlir/antlir2/features/rpm/tests/BUCK
+++ b/antlir/antlir2/features/rpm/tests/BUCK
@@ -461,20 +461,12 @@ test_binaries_with_file_capabilities_layer = test_rpms(
         "libcap",  # getcap cli
         "antlir2-with-capability",
     ])],
-    labels = internal_external(
-        fb = [],
-        oss = ["disabled"],
-    ),
     parent_layer = simple,
 )
 
 image_python_test(
     name = "test-binaries-with-file-capabilities",
     srcs = ["test_binaries_with_file_capabilities.py"],
-    labels = internal_external(
-        fb = [],
-        oss = ["disabled"],
-    ),
     layer = test_binaries_with_file_capabilities_layer,
 )
 

--- a/antlir/antlir2/libcap/BUCK
+++ b/antlir/antlir2/libcap/BUCK
@@ -1,4 +1,4 @@
-load("//antlir/bzl:build_defs.bzl", "rust_bindgen_library", "rust_library")
+load("//antlir/bzl:build_defs.bzl", "internal_external", "rust_bindgen_library", "rust_library")
 
 oncall("antlir")
 
@@ -8,7 +8,10 @@ rust_bindgen_library(
         "ovr_config//os:linux",
     ],
     cpp_deps = [
-        "third-party//libcap:cap",
+        internal_external(
+            fb = "third-party//libcap:cap",
+            oss = "//third-party/cxx/system:libcap",
+        ),
     ],
     generate = ("types", "functions", "vars"),
     header = "bridge.h",

--- a/third-party/cxx/system/BUCK
+++ b/third-party/cxx/system/BUCK
@@ -1,0 +1,10 @@
+load("@prelude//third-party:pkgconfig.bzl", "external_pkgconfig_library")
+
+# TODO(T181212521) all libraries here *should aim* to be built with buck from
+# source (so that we can use a deterministic, properly hermetic/configured
+# toolchain), but for ease of implementation we still depend on a few libraries
+# installed on the build system using the typical machinery (eg `pkg-config`).
+
+external_pkgconfig_library(
+    name = "libcap",
+)

--- a/third-party/rust/bindgen/BUCK
+++ b/third-party/rust/bindgen/BUCK
@@ -1,0 +1,12 @@
+load("//antlir/bzl:build_defs.bzl", "rust_binary")
+
+rust_binary(
+    name = "bindgen",
+    srcs = ["bindgen.rs"],
+    deps = [
+        "//third-party/rust:anyhow",
+        "//third-party/rust:bindgen",
+        "//third-party/rust:clap",
+        "//third-party/rust:clang-sys",
+    ]
+)

--- a/third-party/rust/bindgen/bindgen.rs
+++ b/third-party/rust/bindgen/bindgen.rs
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::path::PathBuf;
+
+use anyhow::Context;
+use anyhow::Error;
+use anyhow::Result;
+use bindgen::builder;
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+struct Args {
+    #[clap(long)]
+    header: String,
+    #[clap(long)]
+    out: PathBuf,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    clang_sys::load()
+        .map_err(Error::msg)
+        .context("while loading libclang")?;
+
+    let bindings = builder().header(&args.header).generate()?;
+
+    bindings.write_to_file(&args.out)?;
+    Ok(())
+}


### PR DESCRIPTION
Summary:
The previous diff added enough of `rust_bindgen_library` to get this to build
now

Test Plan:
```
❯ buck test antlir//antlir/antlir2/features/install/tests:test-setcap
✓ Pass: antlir//antlir/antlir2/features/install/tests:test-setcap (0.0s)
---- STDOUT ----

---- STDERR ----

Build ID: 45bc2b3a-4fbe-4d47-b5eb-aa10bc29bfa5
Network: Up: 0B  Down: 158MiB
Jobs completed: 21353. Time elapsed: 40.9s.
Cache hits: 0%. Commands: 862 (cached: 0, remote: 0, local: 862)
Tests finished: Pass 1. Fail 0. Fatal 0. Skip 0. Build failure 0
```

Differential Revision: D57733054


