### PR TITLE
[antlir][oss] ensure antlir2-out is owned by unprivileged user

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           truncate -s 100G ${{ runner.temp }}/image.btrfs
           mkfs.btrfs ${{ runner.temp }}/image.btrfs
           sudo mount ${{ runner.temp }}/image.btrfs antlir2-out
+          sudo chown -R $(id -u):$(id -g) antlir2-out
       - name: Install deps
         run: |
           sudo apt install \

--- a/antlir/antlir2/test_images/remote_execution/BUCK
+++ b/antlir/antlir2/test_images/remote_execution/BUCK
@@ -1,6 +1,7 @@
 load("//antlir/antlir2/bzl/feature:defs.bzl", "feature")
 load("//antlir/antlir2/bzl/image:defs.bzl", "image")
 load("//antlir/antlir2/testing:image_rpms_test.bzl", "image_test_rpm_names")
+load("//antlir/bzl:build_defs.bzl", "internal_external")
 
 oncall("antlir")
 
@@ -37,6 +38,10 @@ image.layer(
 image_test_rpm_names(
     name = "test-rpms-installed",
     src = "rpms.txt",
+    labels = internal_external(
+        fb = [],
+        oss = ["disabled"],
+    ),
     layer = ":child-that-installs-rpms",
     rootless = True,
 )

--- a/antlir/antlir2/testing/image_rpms_test.bzl
+++ b/antlir/antlir2/testing/image_rpms_test.bzl
@@ -44,6 +44,7 @@ _rpm_names_test = rule(
     impl = _rpm_names_test_impl,
     attrs = {
         "image_rpms_test": attrs.default_only(attrs.exec_dep(default = "//antlir/antlir2/testing/image_rpms_test:image-rpms-test")),
+        "labels": attrs.list(attrs.string(), default = []),
         "layer": attrs.dep(providers = [LayerInfo]),
         "not_installed": attrs.bool(default = False),
         "src": attrs.source(),


### PR DESCRIPTION
Summary:
Now that some rootless builds are enabled on OSS CI, make sure that the
unprivileged build user owns `antlir2-out` so that new subvolumes can be
created, etc

Test Plan: GitHub Actions

Differential Revision: D58876307
