### PR TITLE
[antlir][oss] use external cell instead of submodule for generated

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -3,7 +3,6 @@
     prelude = prelude
     toolchains = toolchains
     none = none
-    generated = generated
 
 [cell_aliases]
     config = prelude
@@ -24,3 +23,5 @@
 
 [buck2]
     file_watcher = watchman
+
+<file:.buckconfig.generated>

--- a/.buckconfig.generated
+++ b/.buckconfig.generated
@@ -1,0 +1,9 @@
+[cells]
+    generated = generated
+
+[external_cells]
+    generated = git
+
+[external_cell_generated]
+    git_origin = https://github.com/facebookincubator/antlir
+    commit_hash = f129d8dc5c62359ace195445e0ca8a3ec852bc4b

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           truncate -s 100G ${{ runner.temp }}/image.btrfs
           mkfs.btrfs ${{ runner.temp }}/image.btrfs
           sudo mount ${{ runner.temp }}/image.btrfs antlir2-out
+          sudo chown -R $(id -u):$(id -g) antlir2-out
       - name: Install deps
         run: |
           sudo apt install \

--- a/antlir/antlir2/test_images/remote_execution/BUCK
+++ b/antlir/antlir2/test_images/remote_execution/BUCK
@@ -1,6 +1,7 @@
 load("//antlir/antlir2/bzl/feature:defs.bzl", "feature")
 load("//antlir/antlir2/bzl/image:defs.bzl", "image")
 load("//antlir/antlir2/testing:image_rpms_test.bzl", "image_test_rpm_names")
+load("//antlir/bzl:build_defs.bzl", "internal_external")
 
 oncall("antlir")
 
@@ -37,6 +38,10 @@ image.layer(
 image_test_rpm_names(
     name = "test-rpms-installed",
     src = "rpms.txt",
+    labels = internal_external(
+        fb = [],
+        oss = ["disabled"],
+    ),
     layer = ":child-that-installs-rpms",
     rootless = True,
 )

--- a/antlir/antlir2/testing/image_rpms_test.bzl
+++ b/antlir/antlir2/testing/image_rpms_test.bzl
@@ -44,6 +44,7 @@ _rpm_names_test = rule(
     impl = _rpm_names_test_impl,
     attrs = {
         "image_rpms_test": attrs.default_only(attrs.exec_dep(default = "//antlir/antlir2/testing/image_rpms_test:image-rpms-test")),
+        "labels": attrs.list(attrs.string(), default = []),
         "layer": attrs.dep(providers = [LayerInfo]),
         "not_installed": attrs.bool(default = False),
         "src": attrs.source(),


### PR DESCRIPTION
Summary:
Use the new [external
cells](https://buck2.build/docs/users/advanced/external_cells/) feature of
buck2 instead of a git submodule

Test Plan: Export to a PR

Differential Revision: D58885465
