### PR TITLE
[antlir2][isolate_unshare] refactor and add error contexts

### DIFF
--- a/antlir/antlir2/antlir2_isolate/isolate_cfg/BUCK
+++ b/antlir/antlir2/antlir2_isolate/isolate_cfg/BUCK
@@ -8,5 +8,6 @@ rust_library(
     visibility = ["//antlir/antlir2/antlir2_isolate/..."],
     deps = [
         "serde",
+        "serde_with",
     ],
 )

--- a/antlir/antlir2/antlir2_isolate/isolate_cfg/src/lib.rs
+++ b/antlir/antlir2/antlir2_isolate/isolate_cfg/src/lib.rs
@@ -17,20 +17,26 @@ use std::path::PathBuf;
 
 use serde::Deserialize;
 use serde::Serialize;
+use serde_with::serde_as;
 
 /// Everything needed to know how to isolate an image compilation.
+#[serde_as]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IsolationContext<'a> {
     pub layer: Cow<'a, Path>,
     /// See [IsolationContextBuilder::platform]
+    #[serde_as(as = "Vec<(_, _)>")]
     pub platform: BTreeMap<Cow<'a, Path>, Cow<'a, Path>>,
     /// Directory in which to invoke the provided command.
     pub working_directory: Option<Cow<'a, Path>>,
     /// See [IsolationContextBuilder::setenv]
+    #[serde_as(as = "Vec<(_, _)>")]
     pub setenv: BTreeMap<Cow<'a, OsStr>, Cow<'a, OsStr>>,
     /// See [IsolationContextBuilder::inputs]
+    #[serde_as(as = "Vec<(_, _)>")]
     pub inputs: BTreeMap<Cow<'a, Path>, Cow<'a, Path>>,
     /// See [IsolationContextBuilder::outputs]
+    #[serde_as(as = "Vec<(_, _)>")]
     pub outputs: BTreeMap<Cow<'a, Path>, Cow<'a, Path>>,
     /// See [InvocationType]
     pub invocation_type: InvocationType,

--- a/antlir/antlir2/antlir2_isolate/isolate_unshare/BUCK
+++ b/antlir/antlir2/antlir2_isolate/isolate_unshare/BUCK
@@ -21,7 +21,6 @@ rust_library(
         "serde_json",
         "thiserror",
         "//antlir/antlir2/antlir2_isolate/isolate_cfg:isolate_cfg",
-        "//antlir/antlir2/antlir2_isolate/isolate_unshare/isolate_unshare_preexec:isolate_unshare_preexec-lib",
         "//antlir/antlir2/antlir2_users:antlir2_users",
     ],
 )

--- a/antlir/antlir2/antlir2_isolate/isolate_unshare/isolate_unshare_preexec/BUCK
+++ b/antlir/antlir2/antlir2_isolate/isolate_unshare/isolate_unshare_preexec/BUCK
@@ -1,24 +1,6 @@
-load("//antlir/bzl:build_defs.bzl", "rust_binary", "rust_library")
+load("//antlir/bzl:build_defs.bzl", "rust_binary")
 
 oncall("antlir")
-
-rust_library(
-    name = "isolate_unshare_preexec-lib",
-    srcs = glob(["src/**/*.rs"]),
-    compatible_with = [
-        "ovr_config//os:linux",
-    ],
-    crate = "isolate_unshare_preexec",
-    crate_root = "src/main.rs",
-    visibility = ["//antlir/antlir2/antlir2_isolate/isolate_unshare:"],
-    deps = [
-        "anyhow",
-        "clap",
-        "nix",
-        "serde",
-        "//antlir/util/cli/json_arg:json_arg",
-    ],
-)
 
 rust_binary(
     name = "isolate_unshare_preexec",
@@ -29,9 +11,10 @@ rust_binary(
     visibility = ["//antlir/antlir2/antlir2_isolate/isolate_unshare:"],
     deps = [
         "anyhow",
+        "cap-std",
         "clap",
         "nix",
-        "serde",
+        "//antlir/antlir2/antlir2_isolate/isolate_cfg:isolate_cfg",
         "//antlir/util/cli/json_arg:json_arg",
     ],
 )

--- a/antlir/antlir2/antlir2_isolate/isolate_unshare/isolate_unshare_preexec/src/main.rs
+++ b/antlir/antlir2/antlir2_isolate/isolate_unshare/isolate_unshare_preexec/src/main.rs
@@ -8,35 +8,29 @@
 #![feature(io_error_more)]
 
 use std::ffi::OsString;
-use std::fs::create_dir;
 use std::fs::create_dir_all;
-use std::fs::File;
 use std::io::ErrorKind;
 use std::os::fd::AsRawFd;
 use std::os::unix::process::CommandExt;
+use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
+use anyhow::Context;
 use anyhow::Error;
 use anyhow::Result;
+use cap_std::fs::Dir;
 use clap::Parser;
+use isolate_cfg::IsolationContext;
 use json_arg::Json;
-use nix::dir::Dir;
 use nix::errno::Errno;
-use nix::fcntl::OFlag;
 use nix::mount::mount;
 use nix::mount::MsFlags;
 use nix::sched::unshare;
 use nix::sched::CloneFlags;
-use nix::sys::stat::Mode;
-use nix::unistd::mkdir;
-use nix::unistd::symlinkat;
-use serde::Deserialize;
-use serde::Serialize;
-
-static SCRATCH: &str = "/tmp/__antlir2__";
-pub static NEWROOT: &str = "/tmp/__antlir2__/newroot";
-static NEWROOT_PROC: &str = "/tmp/__antlir2__/newroot/proc";
+use nix::unistd::Gid;
+use nix::unistd::Uid;
+use nix::unistd::User;
 
 /// MS_NOSYMFOLLOW (since Linux 5.10)
 /// Do not follow symbolic links when resolving paths.  Symbolic links can still
@@ -44,54 +38,102 @@ static NEWROOT_PROC: &str = "/tmp/__antlir2__/newroot/proc";
 /// still work properly.
 static MS_NOSYMFOLLOW: MsFlags = unsafe { MsFlags::from_bits_unchecked(256) };
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct Args {
-    pub root: PathBuf,
-    pub root_ro: bool,
-    pub dir_binds: Vec<Bind>,
-    pub file_binds: Vec<Bind>,
-    pub tmpfs: Vec<PathBuf>,
-    pub devtmpfs: Vec<PathBuf>,
-    pub tmpfs_overlay: Vec<TmpfsOverlay>,
-    pub working_dir: PathBuf,
-    pub hostname: Option<String>,
-    pub uid: u32,
-    pub gid: u32,
-    pub ephemeral: bool,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct Bind {
-    pub src: PathBuf,
-    pub dst: PathBuf,
-    pub ro: bool,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct TmpfsOverlay {
-    pub dst: PathBuf,
-    pub upper: PathBuf,
-    pub work: PathBuf,
-    pub data: OsString,
-}
-
 #[derive(Debug, Parser)]
 struct CliArgs {
-    args: Json<Args>,
+    isolation: Json<IsolationContext<'static>>,
     program: OsString,
     #[clap(last = true)]
     program_args: Vec<OsString>,
 }
 
-fn main() -> Result<()> {
+fn main() {
+    if let Err(e) = do_main() {
+        let e = format!("{e:#?}");
+        eprintln!("{e}");
+        std::process::exit(1);
+    }
+}
+
+fn do_main() -> Result<()> {
     let args = CliArgs::parse();
-    isolate_unshare_preexec(&args.args)?;
-    let err = Command::new(args.program).args(args.program_args).exec();
+    isolate_unshare_preexec(&args.isolation).context("while setting up in-process isolation")?;
+    let mut cmd = Command::new(args.program);
+    cmd.env_clear();
+    // reasonable default PATH (same as systemd-nspawn uses)
+    cmd.env(
+        "PATH",
+        "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    );
+    cmd.env("container", "antlir2");
+    cmd.env("USER", args.isolation.user.as_ref());
+    if let Some(term) = std::env::var_os("TERM") {
+        cmd.env("TERM", term);
+    }
+    for (key, val) in &args.isolation.setenv {
+        cmd.env(key, val);
+    }
+    let err = cmd.args(args.program_args).exec();
     Err(Error::from(err).context("failed to exec child"))
 }
 
-fn isolate_unshare_preexec(args: &Args) -> std::io::Result<()> {
-    unshare(CloneFlags::CLONE_NEWNS | CloneFlags::CLONE_NEWNET | CloneFlags::CLONE_NEWUTS)?;
+trait DirExt {
+    fn abspath(&self) -> PathBuf;
+}
+
+impl DirExt for Dir {
+    fn abspath(&self) -> PathBuf {
+        std::fs::read_link(format!("/proc/self/fd/{}", self.as_raw_fd()))
+            .expect("failed to read /proc/self/fd to find open path")
+    }
+}
+
+impl DirExt for cap_std::fs::File {
+    fn abspath(&self) -> PathBuf {
+        std::fs::read_link(format!("/proc/self/fd/{}", self.as_raw_fd()))
+            .expect("failed to read /proc/self/fd to find open path")
+    }
+}
+
+trait PathExt {
+    fn strip_abs(&self) -> &Path;
+}
+
+impl PathExt for Path {
+    fn strip_abs(&self) -> &Path {
+        self.strip_prefix("/").unwrap_or(self)
+    }
+}
+
+impl PathExt for PathBuf {
+    fn strip_abs(&self) -> &Path {
+        self.strip_prefix("/").unwrap_or(self)
+    }
+}
+
+#[deny(unused_variables)]
+fn isolate_unshare_preexec(isol: &IsolationContext) -> Result<()> {
+    let IsolationContext {
+        layer,
+        working_directory,
+        setenv: _,
+        platform,
+        inputs,
+        outputs,
+        user,
+        ephemeral,
+        tmpfs,
+        devtmpfs,
+        tmpfs_overlay,
+        hostname,
+        readonly,
+        // isolate_unshare crate already ensures that these are not configured
+        invocation_type: _,
+        register: _,
+        enable_network: _,
+    } = &isol;
+
+    unshare(CloneFlags::CLONE_NEWNS | CloneFlags::CLONE_NEWNET | CloneFlags::CLONE_NEWUTS)
+        .context("while unsharing into new namespaces")?;
     // Remount / as private so that we don't let any changes escape back to the
     // parent mount namespace.
     // This is basically equivalent to `mount --make-rprivate /`
@@ -101,193 +143,309 @@ fn isolate_unshare_preexec(args: &Args) -> std::io::Result<()> {
         None::<&str>,
         MsFlags::MS_REC | MsFlags::MS_PRIVATE,
         None::<&str>,
-    )?;
+    )
+    .context("while making / private")?;
 
-    create_dir_all(SCRATCH)?;
+    let scratch = Path::new("/tmp/__antlir2__");
+    create_dir_all(scratch)
+        .with_context(|| format!("while making scratch dir '{}'", scratch.display()))?;
     mount(
         None::<&str>,
-        SCRATCH,
+        scratch,
         Some("tmpfs"),
         MsFlags::empty(),
         None::<&str>,
-    )?;
-    create_dir_all(NEWROOT)?;
+    )
+    .with_context(|| {
+        format!(
+            "while mounting tmpfs on scratch dir '{}'",
+            scratch.display()
+        )
+    })?;
+    let scratch = Dir::open_ambient_dir(scratch, cap_std::ambient_authority())
+        .with_context(|| format!("while opening scratch dir '{}", scratch.display()))?;
 
-    if args.ephemeral {
-        create_dir("/tmp/__antlir2__/ephemeral_upper")?;
-        create_dir("/tmp/__antlir2__/ephemeral_work")?;
-        create_dir("/tmp/__antlir2__/ephemeral_lower")?;
+    scratch
+        .create_dir("newroot")
+        .context("while making newroot")?;
+    let newroot = scratch
+        .open_dir("newroot")
+        .context("while opening newroot")?;
+
+    if *ephemeral {
+        scratch
+            .create_dir("ephemeral_upper")
+            .context("mkdir ephemeral_upper")?;
+        scratch
+            .create_dir("ephemeral_work")
+            .context("mkdir ephemeral_work")?;
+        scratch
+            .create_dir("ephemeral_lower")
+            .context("mkdir ephemeral_lower")?;
+        let scratch_abspath = scratch.abspath();
         mount(
-            Some(&args.root),
-            "/tmp/__antlir2__/ephemeral_lower",
+            Some(layer.as_ref()),
+            &scratch_abspath.join("ephemeral_lower"),
             None::<&str>,
             MsFlags::MS_BIND | MsFlags::MS_REC | MsFlags::MS_RDONLY,
             None::<&str>,
-        )?;
+        )
+        .context("while mounting root at ephemeral lower")?;
+        let mut mount_opts = OsString::from("lowerdir=");
+        mount_opts.push(scratch_abspath.join("ephemeral_lower").into_os_string());
+        mount_opts.push(",upperdir=");
+        mount_opts.push(scratch_abspath.join("ephemeral_upper").into_os_string());
+        mount_opts.push(",workdir=");
+        mount_opts.push(scratch_abspath.join("ephemeral_work").into_os_string());
         mount(
             Some("overlay"),
-            NEWROOT,
+            &newroot.abspath(),
             Some("overlay"),
             MsFlags::empty(),
-            Some(
-                "lowerdir=/tmp/__antlir2__/ephemeral_lower,upperdir=/tmp/__antlir2__/ephemeral_upper,workdir=/tmp/__antlir2__/ephemeral_work",
-            ),
-        )?;
+            Some(mount_opts.as_os_str()),
+        )
+        .context("while mounting ephemeral overlayfs root")?;
     } else {
         let mut root_flags = MsFlags::MS_BIND | MsFlags::MS_REC;
-        if args.root_ro {
+        if *readonly {
             root_flags |= MsFlags::MS_RDONLY;
         }
 
         mount(
-            Some(&args.root),
-            NEWROOT,
+            Some(layer.as_ref()),
+            &newroot.abspath(),
             None::<&str>,
             root_flags,
             None::<&str>,
-        )?;
+        )
+        .context("while mounting root layer")?;
     }
 
-    for (tmpfs, dev) in args
-        .tmpfs
+    let newroot = scratch
+        .open_dir("newroot")
+        .context("while (re)opening newroot")?;
+
+    for (tmpfs, dev) in tmpfs
         .iter()
         .map(|t| (t, false))
-        .chain(args.devtmpfs.iter().map(|t| (t, true)))
+        .chain(devtmpfs.iter().map(|t| (t, true)))
     {
-        match mkdir(tmpfs, Mode::S_IRWXU) {
+        match newroot.create_dir_all(tmpfs.strip_abs()) {
             Ok(()) => Ok(()),
-            Err(Errno::EEXIST) => Ok(()),
+            Err(e) if e.kind() == ErrorKind::AlreadyExists => Ok(()),
             Err(e) => Err(e),
-        }?;
+        }
+        .with_context(|| format!("while making tmpfs mountpoint at '{}'", tmpfs.display()))?;
         nix::mount::mount(
             None::<&str>,
-            tmpfs,
+            &newroot.abspath().join(tmpfs.strip_abs()),
             Some("tmpfs"),
             MsFlags::empty(),
             if dev { Some("mode=0755") } else { None },
-        )?;
+        )
+        .with_context(|| format!("while mounting tmpfs at '{}'", tmpfs.display()))?;
+        let tmpfs = newroot
+            .open_dir(tmpfs.strip_abs())
+            .with_context(|| format!("while opening tmpfs '{}'", tmpfs.display()))?;
         if dev {
-            let dir = Dir::open(tmpfs, OFlag::O_DIRECTORY, Mode::empty())?;
-            symlinkat("/proc/self/fd", Some(dir.as_raw_fd()), "fd")?;
-        }
-    }
+            tmpfs
+                .symlink_contents("/proc/self/fd", "fd")
+                .context("while creating /dev/fd symlink")?;
 
-    for bind in &args.dir_binds {
-        match create_dir_all(&bind.dst) {
-            Ok(()) => Ok(()),
-            Err(e) => match e.kind() {
-                ErrorKind::AlreadyExists => Ok(()),
-                _ => Err(e),
-            },
-        }?;
-        mount(
-            Some(&bind.src),
-            &bind.dst,
-            None::<&str>,
-            MsFlags::MS_BIND | MsFlags::MS_REC,
-            None::<&str>,
-        )?;
-    }
-    for bind in &args.file_binds {
-        if let Some(parent) = bind.dst.parent() {
-            match create_dir_all(parent) {
-                Ok(()) => Ok(()),
-                Err(e) => match e.kind() {
-                    ErrorKind::AlreadyExists => Ok(()),
-                    _ => Err(e),
-                },
-            }?;
-        }
-
-        match File::options()
-            .create(true)
-            .truncate(false)
-            .write(true)
-            .open(&bind.dst)
-        {
-            Ok(_) => Ok(()),
-            Err(e) => match e.kind() {
-                ErrorKind::AlreadyExists => Ok(()),
-                // The target path could already exist but be a broken symlink
-                // in which case this will return ENOENT, but since we use
-                // MS_NOSYMFOLLOW the mount call might still succeed.
-                ErrorKind::NotFound => Ok(()),
-                // We get ROFS even if the file already exists, so maybe the
-                // following mount still has a chance of working
-                ErrorKind::ReadOnlyFilesystem => Ok(()),
-                _ => Err(e),
-            },
-        }?;
-        mount(
-            Some(&bind.src),
-            &bind.dst,
-            None::<&str>,
-            MsFlags::MS_BIND | MS_NOSYMFOLLOW,
-            None::<&str>,
-        )?;
-    }
-    // MS_BIND ignores MS_RDONLY, so let's go try to make all the readonly binds actually readonly
-    // TODO(T185979228) we should also check for any recursive bind mounts
-    // brought in by the first bind mount (since it necessarily has MS_REC)
-    for bind in args.dir_binds.iter().chain(&args.file_binds) {
-        if bind.ro {
-            if let Err(e) = mount(
-                Some("none"),
-                &bind.dst,
-                None::<&str>,
-                MsFlags::MS_REMOUNT | MsFlags::MS_BIND | MsFlags::MS_REC | MsFlags::MS_RDONLY,
-                None::<&str>,
-            ) {
-                if e != Errno::EPERM {
-                    return Err(e.into());
-                }
-                // If we failed to make it readonly, carry on anyway. We can't
-                // gain any new privileges here accidentally, so it's OK to
-                // ignore the fact that some mounts like /mnt/gvfs cannot be
-                // made readonly for whatever reason
+            for devname in ["null", "random", "urandom"] {
+                let dev = tmpfs
+                    .create(devname)
+                    .with_context(|| format!("while creating device file '{devname}'"))?;
+                nix::mount::mount(
+                    Some(&Path::new("/dev").join(devname)),
+                    &dev.abspath(),
+                    None::<&str>,
+                    MsFlags::MS_BIND | MS_NOSYMFOLLOW,
+                    None::<&str>,
+                )
+                .with_context(|| format!("while mounting device node '{devname}'"))?;
             }
         }
     }
 
-    create_dir("/tmp/__antlir2__/tmpfs_overlay")?;
-    for overlay in &args.tmpfs_overlay {
-        create_dir(&overlay.upper)?;
-        create_dir(&overlay.work)?;
-        mount(
-            Some("overlay"),
-            &overlay.dst,
-            Some("overlay"),
-            MsFlags::empty(),
-            Some(overlay.data.as_os_str()),
-        )?;
+    for (dst, src, ro) in inputs
+        .iter()
+        .map(|(dst, src)| (dst, src, true))
+        .chain(platform.iter().map(|(dst, src)| (dst, src, true)))
+        .chain(outputs.iter().map(|(dst, src)| (dst, src, false)))
+    {
+        let ft = src
+            .metadata()
+            .with_context(|| format!("while statting '{}'", src.display()))?
+            .file_type();
+        let dst = if let Ok(target) = std::fs::read_link(layer.join(dst.strip_abs())) {
+            dst.parent().unwrap_or(dst).join(target)
+        } else {
+            dst.clone().into_owned()
+        };
+        if ft.is_dir() {
+            match newroot.create_dir_all(dst.strip_abs()) {
+                Ok(()) => Ok(()),
+                Err(e) if e.kind() == ErrorKind::AlreadyExists => Ok(()),
+                Err(e) => Err(e),
+            }
+            .with_context(|| format!("while creating mountpoint '{}'", dst.display()))?;
+            let dst = newroot.open_dir(dst.strip_abs())?;
+            mount(
+                Some(src.as_ref()),
+                &dst.abspath(),
+                None::<&str>,
+                MsFlags::MS_BIND | MsFlags::MS_REC,
+                None::<&str>,
+            )
+            .with_context(|| format!("while mounting '{}'", dst.abspath().display()))?;
+        } else {
+            if let Some(parent) = dst.parent() {
+                match newroot.create_dir_all(parent.strip_abs()) {
+                    Ok(()) => Ok(()),
+                    Err(e) if e.kind() == ErrorKind::AlreadyExists => Ok(()),
+                    Err(e) => Err(e),
+                }
+                .with_context(|| format!("while creating parent dir '{}'", parent.display()))?;
+            }
+
+            match newroot.open_with(
+                dst.strip_abs(),
+                cap_std::fs::OpenOptions::new()
+                    .create(true)
+                    .truncate(false)
+                    .write(true),
+            ) {
+                Ok(_) => Ok(()),
+                Err(e) if e.kind() == ErrorKind::AlreadyExists => Ok(()),
+                // The target path could already exist but be a broken symlink
+                // in which case this will return ENOENT, but since we use
+                // MS_NOSYMFOLLOW the mount call might still succeed.
+                Err(e) if e.kind() == ErrorKind::NotFound => Ok(()),
+                // We get ROFS even if the file already exists, so maybe the
+                // following mount still has a chance of working
+                Err(e) if e.kind() == ErrorKind::ReadOnlyFilesystem => Ok(()),
+                Err(e) => Err(e),
+            }
+            .with_context(|| {
+                format!("while creating bind mount dst file for '{}'", dst.display())
+            })?;
+            let dst = newroot.open(dst.strip_abs())?;
+            mount(
+                Some(src.as_ref()),
+                &dst.abspath(),
+                None::<&str>,
+                MsFlags::MS_BIND | MS_NOSYMFOLLOW,
+                None::<&str>,
+            )
+            .with_context(|| {
+                if !src.exists() {
+                    format!(
+                        "bind src '{}' for '{}' does not exist",
+                        src.display(),
+                        dst.abspath().display()
+                    )
+                } else {
+                    format!(
+                        "while mounting {} on {}",
+                        src.display(),
+                        dst.abspath().display()
+                    )
+                }
+            })?;
+        }
+
+        // MS_BIND ignores MS_RDONLY, so let's go try to make all the readonly
+        // binds actually readonly.
+        // TODO(T185979228) we should also check for any
+        // recursive bind mounts brought in by the first bind mount (since it
+        // necessarily has MS_REC)
+        if ro {
+            let dst = newroot.abspath().join(dst.strip_abs());
+            match mount(
+                Some("none"),
+                &dst,
+                None::<&str>,
+                MsFlags::MS_REMOUNT | MsFlags::MS_BIND | MsFlags::MS_REC | MsFlags::MS_RDONLY,
+                None::<&str>,
+            ) {
+                Ok(()) => Ok(()),
+                Err(Errno::EPERM) => {
+                    // If we failed to make it readonly, carry on anyway. We
+                    // can't gain any new privileges here accidentally, so it's
+                    // OK to ignore the fact that some mounts like /mnt/gvfs
+                    // cannot be made readonly for whatever reason
+                    Ok(())
+                }
+                Err(e) => Err(std::io::Error::from(e)),
+            }
+            .with_context(|| format!("while making mount '{}' readonly", dst.display()))?;
+        }
     }
 
-    if let Some(hostname) = &args.hostname {
-        nix::unistd::sethostname(hostname)?;
+    if !tmpfs_overlay.is_empty() {
+        scratch.create_dir("tmpfs_overlay")?;
+        let overlay_root = scratch.open_dir("tmpfs_overlay")?;
+        for (idx, path) in tmpfs_overlay.iter().enumerate() {
+            let dst = newroot.open_dir(path.strip_abs())?;
+            overlay_root.create_dir(format!("upper_{idx}"))?;
+            overlay_root.create_dir(format!("work_{idx}"))?;
+            let upper = overlay_root.open_dir(format!("upper_{idx}"))?;
+            let work = overlay_root.open_dir(format!("work_{idx}"))?;
+            let mut opts = OsString::from("lowerdir=");
+            opts.push(dst.abspath());
+            opts.push(",upperdir=");
+            opts.push(upper.abspath());
+            opts.push(",workdir=");
+            opts.push(work.abspath());
+            mount(
+                Some("overlay"),
+                &dst.abspath(),
+                Some("overlay"),
+                MsFlags::empty(),
+                Some(opts.as_os_str()),
+            )
+            .with_context(|| format!("while mounting tmpfs overlay at '{}'", path.display()))?;
+        }
     }
 
-    match create_dir(NEWROOT_PROC) {
+    if let Some(hostname) = hostname {
+        nix::unistd::sethostname(hostname.as_ref()).context("while setting hostname")?;
+    }
+
+    match newroot.create_dir("proc") {
         Ok(()) => Ok(()),
-        Err(e) => match e.kind() {
-            ErrorKind::AlreadyExists => Ok(()),
-            _ => Err(e),
-        },
+        Err(e) if e.kind() == ErrorKind::AlreadyExists => Ok(()),
+        Err(e) => Err(e),
     }?;
     // TODO: when we support CLONE_NEWPID, this should be a fresh mount of /proc
     // instead of binding it from the parent ns
     nix::mount::mount(
         Some("/proc"),
-        NEWROOT_PROC,
+        &newroot.open_dir("proc")?.abspath(),
         Some("proc"),
         MsFlags::MS_BIND | MsFlags::MS_REC,
         None::<&str>,
-    )?;
+    )
+    .context("while mounting /proc")?;
 
-    nix::unistd::chroot(NEWROOT)?;
-    std::env::set_current_dir(&args.working_dir)?;
+    nix::unistd::chroot(&newroot.abspath())?;
+    if let Some(wd) = working_directory {
+        std::env::set_current_dir(wd)
+            .with_context(|| format!("while changing directory into '{}'", wd.display()))?;
+    }
 
-    nix::unistd::setgid(args.gid.into())?;
-    nix::unistd::setuid(args.uid.into())?;
+    let (uid, gid) = if user == "root" {
+        (Uid::from_raw(0), Gid::from_raw(0))
+    } else {
+        let user = User::from_name(user)
+            .with_context(|| format!("while looking up user '{user}'"))?
+            .with_context(|| format!("no such user '{user}'"))?;
+        (user.uid, user.gid)
+    };
+
+    nix::unistd::setgid(gid)?;
+    nix::unistd::setuid(uid)?;
 
     Ok(())
 }

--- a/antlir/antlir2/antlir2_isolate/isolate_unshare/src/lib.rs
+++ b/antlir/antlir2/antlir2_isolate/isolate_unshare/src/lib.rs
@@ -9,12 +9,8 @@
 compile_error!("only supported on linux");
 
 use std::ffi::OsStr;
-use std::ffi::OsString;
-use std::io::ErrorKind;
-use std::path::Path;
 use std::process::Command;
 
-use antlir2_users::passwd::EtcPasswd;
 use isolate_cfg::InvocationType;
 use isolate_cfg::IsolationContext;
 
@@ -30,6 +26,8 @@ pub enum Error {
     UserDb(#[from] antlir2_users::Error),
     #[error("user '{0}' not found in user database")]
     MissingUser(String),
+    #[error("failed to serialize isolation settings: {0} - {1}")]
+    Serialize(serde_json::Error, String),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -38,177 +36,29 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 pub struct IsolatedContext<'a>(IsolationContext<'a>);
 
 impl<'a> IsolatedContext<'a> {
-    #[deny(unused_variables)]
     pub fn command<S: AsRef<OsStr>>(&self, program: S) -> Result<Command> {
-        let IsolationContext {
-            layer,
-            working_directory,
-            setenv,
-            platform,
-            inputs,
-            outputs,
-            invocation_type,
-            register,
-            user,
-            ephemeral,
-            tmpfs,
-            devtmpfs,
-            tmpfs_overlay,
-            hostname,
-            readonly,
-            enable_network,
-        } = &self.0;
-
         // TODO: remove these settings entirely when we get rid of
         // systemd-nspawn / move the things that require this (like image_test)
         // to *only* use systemd-nspawn
-        if *invocation_type != InvocationType::Pid2Pipe {
+        if self.0.invocation_type != InvocationType::Pid2Pipe {
             return Err(Error::UnsupportedSetting("invocation_type"));
         }
-        if *register {
+        if self.0.register {
             return Err(Error::UnsupportedSetting("register"));
         }
-        if *enable_network {
+        if self.0.enable_network {
             return Err(Error::UnsupportedSetting("enable_network"));
         }
-
-        let mut dir_binds = Vec::new();
-        let mut file_binds = Vec::new();
-        for (dst, src, ro) in inputs
-            .iter()
-            .chain(platform.iter())
-            .map(|(dst, src)| (dst, src, true))
-            .chain(outputs.iter().map(|(dst, src)| (dst, src, false)))
-        {
-            let ft = src.metadata()?.file_type();
-            let dst = if let Ok(target) =
-                std::fs::read_link(layer.join(dst.strip_prefix("/").unwrap_or(dst)))
-            {
-                dst.parent().unwrap_or(dst).join(target)
-            } else {
-                dst.clone().into_owned()
-            };
-            let dst = Path::new(isolate_unshare_preexec::NEWROOT)
-                .join(dst.strip_prefix("/").unwrap_or(&dst));
-            if ft.is_dir() {
-                dir_binds.push(isolate_unshare_preexec::Bind {
-                    src: src.clone().into(),
-                    dst,
-                    ro,
-                });
-            } else {
-                file_binds.push(isolate_unshare_preexec::Bind {
-                    src: src.clone().into(),
-                    dst,
-                    ro,
-                });
-            }
-        }
-        for devtmpfs in devtmpfs {
-            for dev in ["null", "random", "urandom"] {
-                file_binds.push(isolate_unshare_preexec::Bind {
-                    src: Path::new("/dev").join(dev),
-                    dst: Path::new(isolate_unshare_preexec::NEWROOT)
-                        .join(devtmpfs.strip_prefix("/").unwrap_or(devtmpfs))
-                        .join(dev),
-                    ro: false,
-                });
-            }
-        }
-
-        let (uid, gid) = if user == "root" {
-            (0, 0)
-        } else {
-            match std::fs::read_to_string(layer.join("etc/passwd")) {
-                Ok(contents) => {
-                    let user_db = EtcPasswd::parse(&contents).map_err(Error::UserDb)?;
-                    user_db
-                        .get_user_by_name(user)
-                        .ok_or_else(|| Error::MissingUser(user.clone().into()))
-                        .map(|u| (u.uid.into(), u.gid.into()))
-                }
-                Err(e) => match e.kind() {
-                    ErrorKind::NotFound => Err(Error::MissingUser(user.clone().into())),
-                    _ => Err(Error::IO(e)),
-                },
-            }?
-        };
-
-        let args = isolate_unshare_preexec::Args {
-            root: layer.clone().into(),
-            root_ro: *readonly,
-            dir_binds,
-            file_binds,
-            tmpfs: tmpfs
-                .iter()
-                .map(|t| {
-                    Path::new(isolate_unshare_preexec::NEWROOT)
-                        .join(t.strip_prefix("/").unwrap_or(t))
-                        .to_owned()
-                })
-                .collect(),
-            devtmpfs: devtmpfs
-                .iter()
-                .map(|t| {
-                    Path::new(isolate_unshare_preexec::NEWROOT)
-                        .join(t.strip_prefix("/").unwrap_or(t))
-                        .to_owned()
-                })
-                .collect(),
-            tmpfs_overlay: tmpfs_overlay
-                .iter()
-                .enumerate()
-                .map(|(idx, t)| {
-                    let dst = Path::new(isolate_unshare_preexec::NEWROOT)
-                        .join(t.strip_prefix("/").unwrap_or(t))
-                        .to_owned();
-                    let upper =
-                        Path::new("/tmp/__antlir2__/tmpfs_overlay").join(format!("upper_{idx}"));
-                    let work =
-                        Path::new("/tmp/__antlir2__/tmpfs_overlay").join(format!("work_{idx}"));
-                    let mut data: OsString = "lowerdir=".into();
-                    data.push(&dst);
-                    data.push(",upperdir=");
-                    data.push(&upper);
-                    data.push(",workdir=");
-                    data.push(&work);
-                    isolate_unshare_preexec::TmpfsOverlay {
-                        dst,
-                        upper,
-                        work,
-                        data,
-                    }
-                })
-                .collect(),
-            working_dir: working_directory
-                .as_ref()
-                .map(|wd| wd.clone().into())
-                .or_else(|| std::env::current_dir().ok())
-                .expect("no working dir set"),
-            hostname: hostname.clone().map(|h| h.clone().into()),
-            uid,
-            gid,
-            ephemeral: *ephemeral,
-        };
 
         let mut cmd = Command::new(
             buck_resources::get("antlir/antlir2/antlir2_isolate/isolate_unshare/preexec")
                 .expect("isolate_unshare_preexec is always present"),
         );
 
-        cmd.env_clear();
-        // reasonable default PATH (same as systemd-nspawn uses)
-        cmd.env(
-            "PATH",
-            "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        cmd.arg(
+            serde_json::to_string(&self.0)
+                .map_err(|e| Error::Serialize(e, format!("{:#?}", self.0)))?,
         );
-        cmd.env("container", "antlir2");
-        cmd.env("USER", &**user);
-        if let Some(term) = std::env::var_os("TERM") {
-            cmd.env("TERM", term);
-        }
-        cmd.envs(setenv);
-        cmd.arg(serde_json::to_string(&args).expect("args are always serializable"));
         cmd.arg(program);
         cmd.arg("--");
 


### PR DESCRIPTION
Summary:
Move code around and simplify it now that the pre-exec process doesn't have to
be so constrained.

Add context to most error points.

Test Plan:
```
❯ buck2 test fbcode//antlir/antlir2/features/genrule/tests: fbcode//antlir/antlir2/features/rpm/tests:
Buck UI: https://www.internalfb.com/buck2/457bb417-e0d1-4a27-9608-bfb0624dc59c
Test UI: https://www.internalfb.com/intern/testinfra/testrun/16044073717563394
Network: Up: 7.2MiB  Down: 2.2MiB  (reSessionID-6d45b2d5-319d-4493-b136-9abf1e187aca)
Jobs completed: 88279. Time elapsed: 58.1s.
Cache hits: 20%. Commands: 592 (cached: 120, remote: 0, local: 472)
Tests finished: Pass 71. Fail 0. Fatal 0. Skip 0. Build failure 0
```

Differential Revision: D61152830


