### PR TITLE
[antlir][oss] keep running as much as possible on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,9 @@ defaults:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        shard: [1/3, 2/3, 3/3]
+    runs-on:
+      # this runner comes with 150GB of disk space
+      labels: 4-core-ubuntu
     steps:
       - uses: actions/checkout@v4
         with:
@@ -43,7 +42,6 @@ jobs:
       - name: Find tests
         run: |
           ./buck2 bxl //ci:find_tests.bxl:find_tests -- \
-            --shard=${{ matrix.shard }} \
             --disable //antlir/antlir2/antlir2_btrfs/... \
             --disable //antlir/antlir2/antlir2_cas_dir:antlir2_cas_dir-image-test \
             --disable //antlir/antlir2/antlir2_overlayfs/... \
@@ -64,8 +62,8 @@ jobs:
 
       - name: Build tests
         run: |
-          ./buck2 build @${{ runner.temp }}/tests.txt
+          ./buck2 build --keep-going @${{ runner.temp }}/tests.txt
 
       - name: Run tests
         run: |
-          ./buck2 test @${{ runner.temp }}/tests.txt
+          ./buck2 test --keep-going @${{ runner.temp }}/tests.txt


### PR DESCRIPTION
Summary:
Don't cancel concurrent workflow shards if one fails.
Ask buck2 to keep building things even on failure.

The end result will still be a failure / red signal, but it'll let us catch as
many issues as possible and minimize how much we have to play whack-a-mole.

Test Plan: Export to a PR

Differential Revision: D61812747
