### PR TITLE
[easy][antlir][oss] fix ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
             --disable //antlir/antlir2/test_images/cfg/target_arch/... \
             --disable //antlir/antlir2/test_images/package/... \
             --disable //antlir/antlir2/testing/tests:booted-image-test-that-should-fail \
-            --disable //antlir/antlir2/testing/tests:test-sh-booted-requires-units \
+            --disable //antlir/antlir2/testing/tests:test-sh-boot-requires_units-centos9 \
             --disable //antlir/bzl/shape2/... \
             --disable //antlir/bzl/tests/shapes/... \
             --disable //antlir/rust:gen-modules-bzl-unittest \

--- a/toolchains/BUCK
+++ b/toolchains/BUCK
@@ -5,6 +5,7 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
+load("@prelude//tests:test_toolchain.bzl", "noop_test_toolchain")
 load("@prelude//toolchains:cxx.bzl", "system_cxx_toolchain")
 load("@prelude//toolchains:genrule.bzl", "system_genrule_toolchain")
 load("@prelude//toolchains:python.bzl", "system_python_bootstrap_toolchain", "system_python_toolchain")
@@ -53,5 +54,10 @@ remote_test_execution_toolchain(
 sh_binary(
     name = "objcopy",
     main = "objcopy",
+    visibility = ["PUBLIC"],
+)
+
+noop_test_toolchain(
+    name = "test",
     visibility = ["PUBLIC"],
 )


### PR DESCRIPTION
Summary:
Add a `toolchains//:test` which is now used by things in the prelude
Update the list of disabled tests to reflect the new name

Test Plan: Export to a PR

Differential Revision: D66468904
