### PR TITLE
[antlir] fix oss CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install \
             cpio jq libcap-dev systemd-container
+      
+      - name: Chown home
+        run: |
+          sudo chown root:root $HOME
+          sudo chmod 777 $HOME
 
       - name: Disable watchman
         run: |
@@ -38,11 +43,11 @@ jobs:
 
       - name: Test target graph
         run: |
-          ./buck2 bxl //ci:test_target_graph.bxl:test_target_graph
+          sudo -E env "PATH=$PATH" ./buck2 bxl //ci:test_target_graph.bxl:test_target_graph
 
       - name: Find tests
         run: |
-          ./buck2 bxl //ci:find_tests.bxl:find_tests -- \
+          sudo -E env "PATH=$PATH" ./buck2 bxl //ci:find_tests.bxl:find_tests -- \
             --disable //antlir/antlir2/antlir2_btrfs/... \
             --disable //antlir/antlir2/antlir2_cas_dir:antlir2_cas_dir-image-test \
             --disable //antlir/antlir2/antlir2_change_stream/... \
@@ -65,8 +70,8 @@ jobs:
 
       - name: Build tests
         run: |
-          ./buck2 build --keep-going @${{ runner.temp }}/tests.txt
+          sudo -E env "PATH=$PATH" ./buck2 build --keep-going @${{ runner.temp }}/tests.txt
 
       - name: Run tests
         run: |
-          ./buck2 test --keep-going @${{ runner.temp }}/tests.txt
+          sudo -E env "PATH=$PATH" ./buck2 test --keep-going @${{ runner.temp }}/tests.txt

--- a/antlir/util/testing/snapshot_test/snapshot_test.bzl
+++ b/antlir/util/testing/snapshot_test/snapshot_test.bzl
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-load("@fbcode_macros//build_defs:fully_qualified_test_name_rollout.bzl", "NAMING_ROLLOUT_LABEL", "fully_qualified_test_name_rollout")
+# @oss-disable
 load("@prelude//:paths.bzl", "paths")
 
 def _dir_snapshot_test_impl(ctx: AnalysisContext) -> list[Provider]:
@@ -52,8 +52,6 @@ _dir_snapshot_test = rule(
 
 def dir_snapshot_test(**kwargs):
     labels = kwargs.get("labels", [])
-    if fully_qualified_test_name_rollout.use_fully_qualified_name():
-        labels = labels + [NAMING_ROLLOUT_LABEL]
 
     return _dir_snapshot_test(
         name = kwargs.get("name"),


### PR DESCRIPTION
Summary:
CVM is going to use opensource antlir more heavily, let's make CI green again
(things keep slipping through the cracks despite actually having some real
internal tests...)

Test Plan: Export to a PR

Differential Revision: D70520233


