### PR TITLE
[antlir][oss] Fix Github CI breakage

### DIFF
--- a/antlir/antlir2/bzl/python_helpers.bzl
+++ b/antlir/antlir2/bzl/python_helpers.bzl
@@ -3,16 +3,17 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-load("@fbsource//tools/build_defs:feature_rollout_utils.bzl", "rollout")
+# @oss-disable
 load("@prelude//python:python.bzl", "PythonLibraryInfo")
+load("//antlir/bzl:oss_shim.bzl", "rollout", read_bool = "ret_false") # @oss-enable
 
 PYTHON_OUTPLACE_PAR_ROLLOUT = rollout.create_feature(
     {
         # "example_opt_in": True,
         "antlir/antlir2/features/install/tests": True,
-        "fblite/devx/fixmydevenv": True,
-        "python/pylot": True,
-        "registry/builder/rpm/bzl/mac_sign/tests": True,
+        # @oss-disable
+        # @oss-disable
+        # @oss-disable
     },
 )
 

--- a/antlir/bzl/oss_shim.bzl
+++ b/antlir/bzl/oss_shim.bzl
@@ -39,4 +39,5 @@ NAMING_ROLLOUT_LABEL = "OSS_NO_OP"
 
 rollout = struct(
     check_base_path = ret_false,
+    create_feature = ret_false,
 )


### PR DESCRIPTION
Summary:
It appears this should be using the open-source shim

https://github.com/facebookincubator/antlir/actions/runs/17576053686/job/49921462561

https://github.com/facebookincubator/antlir/actions/runs/17576053670/job/49921462606

Test Plan:
Sandcastle

Rollback Plan:

Differential Revision: D82056371


