### PR TITLE
[antlir2] don't use yarn.lock when building docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,10 +26,10 @@ jobs:
         with:
           node-version: 18
           cache: yarn
-          cache-dependency-path: 'antlir/antlir2/docs/yarn.lock'
+          cache-dependency-path: 'antlir/antlir2/docs/package.json'
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install
 
       - name: Disable watchman
         run: |


### PR DESCRIPTION
Summary:
Dependabot reads this and we get internal tasks that are completely useless.
Just don't use it, so that we can stop shipping it to GitHub

Test Plan: Export to a PR

Differential Revision: D83645080
