### PR TITLE
[third_party][rust] Update futures family to 0.3.32

### DIFF
--- a/antlir/antlir2/sendstream_parser/Cargo.toml
+++ b/antlir/antlir2/sendstream_parser/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 [dependencies]
 bytes = { version = "1.11.1", features = ["serde"] }
 derive_more = { version = "1.0.0", features = ["full"] }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 hex = { version = "0.4.3", features = ["alloc"] }
 nix = { version = "0.30.1", features = ["dir", "event", "hostname", "inotify", "ioctl", "mman", "mount", "net", "poll", "ptrace", "reboot", "resource", "sched", "signal", "term", "time", "user", "zerocopy"] }
 nom = "8"


### PR DESCRIPTION
Summary: Update the futures family of Rust crates from 0.3.30/0.3.31 to 0.3.32: futures, futures-channel, futures-core, and futures-util. This is a minor version bump that includes upstream bug fixes and improvements.

Test Plan: Sandcastle

Reviewed By: dtolnay

Differential Revision: D93684256
