### PR TITLE
[third_party][rust] Update uuid 1.17 to 1.21.0

### DIFF
--- a/antlir/antlir2/sendstream_parser/Cargo.toml
+++ b/antlir/antlir2/sendstream_parser/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 [dependencies]
 bytes = { version = "1.11.1", features = ["serde"] }
 derive_more = { version = "1.0.0", features = ["full"] }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 hex = { version = "0.4.3", features = ["alloc"] }
 nix = { version = "0.30.1", features = ["dir", "event", "hostname", "inotify", "ioctl", "mman", "mount", "net", "poll", "ptrace", "reboot", "resource", "sched", "signal", "term", "time", "user", "zerocopy"] }
 nom = "8"

--- a/antlir/antlir2/sendstream_parser/Cargo.toml
+++ b/antlir/antlir2/sendstream_parser/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1.0.219", features = ["derive", "rc"], optional = true }
 thiserror = "2.0.18"
 tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 tokio-util = { version = "0.7.15", features = ["full"] }
-uuid = { version = "1.17", features = ["rng-getrandom", "serde", "v4", "v5", "v6", "v7", "v8"] }
+uuid = { version = "1.21.0", features = ["rng-getrandom", "serde", "v4", "v5", "v6", "v7", "v8"] }
 
 [dev-dependencies]
 serde = { version = "1.0.219", features = ["derive", "rc"] }


### PR DESCRIPTION
Summary: Update the uuid Rust crate from version 1.17 to 1.21.0. This is a minor version bump that includes upstream bug fixes and improvements.

Test Plan: Sandcastle

Reviewed By: dtolnay

Differential Revision: D93684254
