### PR TITLE
[antlir] Bump docs CI Node 18 -> 20 (#295)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: yarn
           cache-dependency-path: 'antlir/antlir2/docs/package.json'
 

--- a/antlir/antlir2/docs/package.json
+++ b/antlir/antlir2/docs/package.json
@@ -38,7 +38,7 @@
     ]
   },
   "engines": {
-    "node": ">=16",
+    "node": ">=20",
     "npm": "use yarn instead",
     "yarn": "^1.5"
   },


### PR DESCRIPTION
Summary:

cheerio@1.2.0 (pulled in transitively via docusaurus/preset-classic)
now requires Node >=20.18.1. The CI was running Node 18, causing yarn
install to fail with an incompatible engine error. Bumping the workflow
to Node 20 and updating the package.json engines field to match.

Test Plan: CI passes on the next docs build.

Differential Revision: D95228702


