### PR TITLE
[third-party][rust] upgrading tokio to 1.52.1

### DIFF
--- a/antlir/antlir2/sendstream_parser/Cargo.toml
+++ b/antlir/antlir2/sendstream_parser/Cargo.toml
@@ -24,7 +24,7 @@ nom = "8"
 num_enum = "0.7.6"
 serde = { version = "1.0.219", features = ["derive", "rc"], optional = true }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tokio-util = { version = "0.7.18", features = ["full"] }
 uuid = { version = "1.23.0", features = ["rng-getrandom", "serde", "v4", "v5", "v6", "v7", "v8"] }
 


### PR DESCRIPTION
Summary:
Upgrading `tokio` from `1.50.0` to `1.52.1`.
- All downstream consumers checked with arc rust-check — 0 errors.

Test Plan:
```
buck2 build --materializations=none fbsource//third-party/rust/ci:
fbcode/common/rust/tools/scripts/third-party-check.sh
xbgs third-party/rust:tokio -l | sed 's,^fbsource/,,' | rg -v '^third-party/rust/' | xargs arc rust-check
```

Reviewed By: dtolnay

Differential Revision: D101580193
