### PR TITLE
[oss] fix antlir OSS build (#297)

### DIFF
--- a/antlir/antlir2/antlir2_packager/BUCK
+++ b/antlir/antlir2/antlir2_packager/BUCK
@@ -1,7 +1,8 @@
 load("//antlir/antlir2/bzl/feature:defs.bzl", "feature")
 load("//antlir/antlir2/bzl/image:defs.bzl", "image")
 load("//antlir/antlir2/bzl/package:defs.bzl", "package")
-load("//antlir/antlir2/facebook/images/build_appliance:defs.bzl", "build_appliance_from_dir")
+# @oss-disable[end= ]: load("//antlir/antlir2/facebook/images/build_appliance:defs.bzl", "build_appliance_from_dir")
+load("//antlir/antlir2/build_appliance:defs.bzl", "build_appliance_from_dir") # @oss-enable
 load("//antlir/bzl:build_defs.bzl", "alias", "rust_binary")
 load("//antlir/bzl:internal_external.bzl", "internal_external")
 

--- a/antlir/antlir2/build_appliance/defs.bzl
+++ b/antlir/antlir2/build_appliance/defs.bzl
@@ -1,0 +1,25 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+load("//antlir/antlir2/bzl:platform.bzl", "default_target_platform_kwargs")
+load("//antlir/antlir2/bzl:types.bzl", "BuildApplianceInfo")
+
+def _build_appliance_impl(ctx: AnalysisContext) -> list[Provider]:
+    return [
+        DefaultInfo(),
+        BuildApplianceInfo(
+            dir = ctx.attrs.archive,
+        ),
+    ]
+
+_build_appliance_rule = rule(
+    impl = _build_appliance_impl,
+    attrs = {
+        "archive": attrs.source(),
+    },
+)
+
+def build_appliance_from_dir(*, name: str, dir, **kwargs):
+    _build_appliance_rule(name = name, archive = dir, **(default_target_platform_kwargs() | kwargs))

--- a/antlir/antlir2/features/extract/tests/BUCK
+++ b/antlir/antlir2/features/extract/tests/BUCK
@@ -1,4 +1,5 @@
-load("@fbsource//tools/build_defs:testpilot_defs.bzl", "tpx_labels")
+# @oss-disable[end= ]: load("@fbsource//tools/build_defs:testpilot_defs.bzl", "tpx_labels")
+load("//antlir/bzl:oss_shim.bzl", "tpx_labels") # @oss-enable
 load("//antlir/antlir2/bzl/feature:defs.bzl", "feature")
 load("//antlir/antlir2/bzl/image:defs.bzl", "image")
 load("//antlir/antlir2/testing:image_test.bzl", "image_sh_test")

--- a/antlir/bzl/build_defs_impl.bzl
+++ b/antlir/bzl/build_defs_impl.bzl
@@ -200,6 +200,7 @@ def _cpp_python_extension(name: str, **_kwargs):
 def _rust_unittest(*args, **kwargs):
     kwargs.pop("nodefaultlibs", None)
     kwargs.pop("allocator", None)
+    kwargs.pop("proc_macro", None)
     _wrap_internal(native.rust_test, args, kwargs)
 
 def _rust_binary(*, name: str, **kwargs):

--- a/antlir/bzl/oss_shim.bzl
+++ b/antlir/bzl/oss_shim.bzl
@@ -24,7 +24,7 @@ empty_list = []
 
 none = None
 
-special_tags = struct(
+tpx_labels = struct(
     run_as_bundle = "OSS_NO_OP",
     enable_artifact_reporting = "OSS_NO_OP",
     disabled = "disabled",


### PR DESCRIPTION
Summary:

Several fixes so the OSS target-graph query (`ci/test_target_graph.bxl`, `set(//...) - set(//antlir/distro/...)`) loads cleanly.

1) Rename the OSS shim struct `special_tags` to `tpx_labels` in `antlir/bzl/oss/oss_shim.bzl`. `antlir/antlir2/testing/image_test.bzl` has an `oss-enable` load of `tpx_labels` from `//antlir/bzl:oss_shim.bzl`, but the shim only exported `special_tags`, so loading `image_test.bzl` failed with `Module has no symbol tpx_labels`.

2) Drop `proc_macro` in the OSS `_rust_unittest` shim (`antlir/bzl/oss/build_defs_impl.bzl`). A `rust_library(proc_macro = True)` generates an implicit `-unittest` target whose kwargs are routed into `rust_test`, which has no `proc_macro` parameter. `rust_library` accepts `proc_macro` so the library still builds; only the generated test needed it stripped.

3) Provide `build_appliance_from_dir` to OSS builds. `antlir/antlir2/antlir2_packager/BUCK` loaded it unconditionally from `//antlir/antlir2/facebook/images/build_appliance:defs.bzl`, which is not part of the OSS export, so the query failed with `File not found`. Add an OSS-visible copy at `//antlir/antlir2/build_appliance:defs.bzl` and gate the load with `oss-disable`/`oss-enable`, mirroring `image_test.bzl`.

4) Gate the `tpx_labels` load in `antlir/antlir2/features/extract/tests/BUCK`. It loaded `tpx_labels` unconditionally from `fbsource//tools/build_defs:testpilot_defs.bzl`, which is not in the OSS export, so the query failed with `File not found: none//tools/build_defs/testpilot_defs.bzl`. Tag the load `oss-disable` and add an `oss-enable` load of `tpx_labels` from `//antlir/bzl:oss_shim.bzl`, mirroring `image_test.bzl`.

Test Plan:
- No remaining references to `special_tags` under `antlir/`, so the rename breaks no other call site.
- Every `tpx_labels` field used in the shim build exists in the renamed struct: `disabled`, `test_is_invisible_to_testpilot`, `enable_artifact_reporting`, `run_as_bundle`.
- After dropping `proc_macro`, the kwargs reaching `rust_test` for the implicit `-unittest` are all valid `rust_test` attributes.
- Loading `antlir2_packager/BUCK` resolves `build_appliance_from_dir` via the OSS `//antlir/antlir2/build_appliance:defs.bzl` instead of the missing `facebook` path.
- `antlir2/features/extract/tests/BUCK` resolves `tpx_labels` via the OSS shim `//antlir/bzl:oss_shim.bzl` under `oss-enable`, matching `image_test.bzl`.
- Re-run `buck2 bxl //ci:test_target_graph.bxl`.

Differential Revision: D108942815


