### PR TITLE
oss shim: fix target mapping of shorthand target names

### DIFF
--- a/antlir/bzl/build_defs.bzl
+++ b/antlir/bzl/build_defs.bzl
@@ -124,7 +124,9 @@ def _split_rust_kwargs(kwargs):
     return kwargs, test_kwargs
 
 def _normalize_rust_dep(dep):
-    if ":" in dep:
+    # Anything that looks like a target label (including the `//foo/bar`
+    # shorthand for `//foo/bar:bar`) is already fully specified.
+    if ":" in dep or "//" in dep:
         return dep
     return shim.third_party.library(dep, platform = "rust")
 


### PR DESCRIPTION
I was under the impression these never worked in build files inside of fb so I have no idea why or how anyone successfully wrote one. (c.f. https://github.com/facebook/buck2/pull/1004)

Important part: `-> antlir//third-party/rust://antlir/antlir2/libcap (^)`

"wait that makes no sense, that's not a valid target name" -- apparently buck did not reject it as such! dunno why that would be.

```
$ buck uquery -a deps antlir//antlir/antlir2/antlir2_packager:antlir2-packager
{
  "antlir//antlir/antlir2/antlir2_packager:antlir2-packager": {
      <snip>
    "default_deps": "deps",
    "deps": {
      "__type": "concat",
      "items": [
        [
          <snip>
          "antlir//third-party/rust://antlir/util/cli/json_arg"
        ],
        {
          "__type": "selector",
          "entries": {
            "DEFAULT": [],
            "antlir//antlir/antlir2/libcap:available": [
              "antlir//third-party/rust://antlir/antlir2/libcap"
              ^^^^^^^^^^ !!!!!
            ]
          }
        }
      ]
    },
    <snip>
  }
}
```

```
$ buck build //antlir/antlir2/test_images/package/oci
Build ID: e9057320-140f-4a9d-87a8-ccfe470296e2
Network:  up 0B  down 0B
Phase                 Remaining
Loading targets         0/   58
Command build
elapsed 0.1s
Build ID: e9057320-140f-4a9d-87a8-ccfe470296e2
BUILD FAILED
Error running analysis for `antlir//antlir/antlir2/test_images/package/oci:oci (prelude//platform
s:default#5c1b01ec01a662a2)`

Caused by:
    0: Error in configured node dependency, dependency chain follows (-> indicates depends on, ^ 
indicates same configuration as previous):
              antlir//antlir/antlir2/test_images/package/oci:oci (prelude//platforms:default#5c1b
01ec01a662a2)
           -> antlir//antlir/antlir2/test_images/package/oci:oci (prelude//platforms:default#8cd3
90d44fbe0e30)
       
    1: Error checking compatibility of `antlir//antlir/antlir2/antlir2_packager:packager-applianc
e` with `antlir//platforms:host#41047d192dfeeae0`
    2: Error in configured node dependency, dependency chain follows (-> indicates depends on, ^ 
indicates same configuration as previous):
              antlir//antlir/antlir2/antlir2_packager:packager-appliance (antlir//platforms:host#
41047d192dfeeae0)
           -> antlir//antlir/antlir2/antlir2_packager:packager-appliance.impl (^)
           -> antlir//antlir/antlir2/antlir2_packager:packager-appliance.dir (^)
           -> antlir//antlir/antlir2/antlir2_packager:packager-appliance.dir (antlir//platforms:host#c9da970705bbe45e)
       
    3: Error checking compatibility of `antlir//flavor/fedora44:build-appliance` with `antlir//platforms:host#41047d192dfeeae0`
    4: Error in configured node dependency, dependency chain follows (-> indicates depends on, ^ indicates same configuration as previous):
              antlir//flavor/fedora44:build-appliance (antlir//platforms:host#41047d192dfeeae0)
           -> antlir//flavor/fedora44:build-appliance.dir (^)
           -> antlir//flavor/fedora44:build-appliance.dir (antlir//platforms:host#c9da970705bbe45
e)
       
    5: Error checking compatibility of `antlir//antlir/antlir2/antlir2_packager:antlir2-packager`
 with `antlir//platforms:host#41047d192dfeeae0`
    6: Error in configured node dependency, dependency chain follows (-> indicates depends on, ^ 
indicates same configuration as previous):
              antlir//antlir/antlir2/antlir2_packager:antlir2-packager (antlir//platforms:host#41
047d192dfeeae0)
           -> antlir//third-party/rust://antlir/antlir2/libcap (^)
       
    7: looking up unconfigured target node `antlir//third-party/rust://antlir/antlir2/libcap`
    8: Unknown target `//antlir/antlir2/libcap` from package `antlir//third-party/rust`.
       Did you mean one of the 2366 targets in antlir//third-party/rust:BUCK?
       
       Available targets (showing 25 of 2366):
         antlir//third-party/rust:addr2line
         antlir//third-party/rust:alloc-no-stdlib-2
         antlir//third-party/rust:alloc-stdlib-0.2
         antlir//third-party/rust:allocative
         antlir//third-party/rust:allocative-0.3
         antlir//third-party/rust:allocator-api2
         antlir//third-party/rust:allocator-api2-0.2
         antlir//third-party/rust:ansi_term
         antlir//third-party/rust:ansi_term-0.12
         antlir//third-party/rust:anstream
         antlir//third-party/rust:darling-0.20
         antlir//third-party/rust:fastrand
         antlir//third-party/rust:fastrand-2
         antlir//third-party/rust:fastrand-2.3.0.crate
         antlir//third-party/rust:generic-array
         antlir//third-party/rust:handlebars
         antlir//third-party/rust:handlebars-5
         antlir//third-party/rust:lalrpop
         antlir//third-party/rust:lazy_static
         antlir//third-party/rust:lazy_static-1
         antlir//third-party/rust:num-rational
         antlir//third-party/rust:num-rational-0.2
         antlir//third-party/rust:num-rational-0.4
         antlir//third-party/rust:static_assertions
         antlir//third-party/rust:thread_local
       
       To see all 2366 targets, run:
         buck2 uquery --reuse-current-config antlir//third-party/rust:
```